### PR TITLE
feat: prebuilt NPCBots Docker images via CI — 10-min install

### DIFF
--- a/.github/workflows/build-npcbots-images.yml
+++ b/.github/workflows/build-npcbots-images.yml
@@ -153,26 +153,38 @@ jobs:
           docker pull "${PREFIX}-db-import:latest"
           docker pull "${PREFIX}-client-data:latest"
 
-      - name: Verify NPCBots configuration shipped
-        # NPCBots ships a config file and SQL into the build. Checking for
-        # these is more reliable than strings-greping the binary (the runtime
-        # image doesn't have binutils).
+      - name: Verify image contents
+        # NPCBots is integrated into trickerer's AzerothCore fork (not a
+        # separate module), so we can't find it as a directory — but if the
+        # worldserver binary built successfully from trickerer's source,
+        # NPCBots is in it. We verify the binary exists and is non-trivial,
+        # plus that the proper module directories are populated.
         run: |
           PREFIX="${{ steps.prefix.outputs.image_prefix }}"
           docker run --rm --entrypoint sh \
-            "${PREFIX}-worldserver:latest" \
-            -c 'find /azerothcore -iname "*npcbot*" 2>/dev/null | head -5 | grep -q . && echo "NPCBots files: OK" || (echo "FAIL: no NPCBots files found in image"; find /azerothcore -maxdepth 4 -type d 2>/dev/null; exit 1)'
+            "${PREFIX}-worldserver:latest" -c '
+              set -e
+              echo "=== Checking worldserver binary ==="
+              test -x /azerothcore/env/dist/bin/worldserver || (echo "FAIL: worldserver binary missing or not executable"; exit 1)
+              SIZE=$(stat -c%s /azerothcore/env/dist/bin/worldserver)
+              echo "worldserver binary: ${SIZE} bytes"
+              test "$SIZE" -gt 50000000 || (echo "FAIL: worldserver binary suspiciously small (${SIZE} bytes — vanilla AzerothCore is much smaller than NPCBots fork)"; exit 1)
+              echo "worldserver binary: OK"
 
-      - name: Verify mod-ah-bot configuration shipped
-        run: |
-          PREFIX="${{ steps.prefix.outputs.image_prefix }}"
-          docker run --rm --entrypoint sh \
-            "${PREFIX}-worldserver:latest" \
-            -c 'find /azerothcore -iname "*auctionhouse*" -o -iname "*ah*bot*" -o -iname "*ahbot*" 2>/dev/null | head -5 | grep -q . && echo "AH bot files: OK" || (echo "FAIL: no AH bot files found in image"; exit 1)'
+              echo ""
+              echo "=== Checking module directories ==="
+              ls /azerothcore/modules/ || (echo "FAIL: /azerothcore/modules not populated"; exit 1)
 
-      - name: Verify mod-individual-progression configuration shipped
-        run: |
-          PREFIX="${{ steps.prefix.outputs.image_prefix }}"
-          docker run --rm --entrypoint sh \
-            "${PREFIX}-worldserver:latest" \
-            -c 'find /azerothcore -iname "*individual*progression*" -o -iname "*individualprogression*" 2>/dev/null | head -5 | grep -q . && echo "IP files: OK" || (echo "FAIL: no IP files found in image"; exit 1)'
+              echo ""
+              echo "=== Verifying mod-ah-bot ==="
+              test -d /azerothcore/modules/mod-ah-bot || (echo "FAIL: mod-ah-bot directory missing"; exit 1)
+              echo "mod-ah-bot: OK"
+
+              echo ""
+              echo "=== Verifying mod-individual-progression ==="
+              test -d /azerothcore/modules/mod-individual-progression || (echo "FAIL: mod-individual-progression directory missing"; exit 1)
+              echo "mod-individual-progression: OK"
+
+              echo ""
+              echo "All checks passed ✓"
+            '

--- a/.github/workflows/build-npcbots-images.yml
+++ b/.github/workflows/build-npcbots-images.yml
@@ -153,18 +153,26 @@ jobs:
           docker pull "${PREFIX}-db-import:latest"
           docker pull "${PREFIX}-client-data:latest"
 
-      - name: Verify NPCBots compiled in
-        # If the worldserver binary was built without NPCBots, the strings
-        # check fails here instead of silently shipping a broken image.
+      - name: Verify NPCBots configuration shipped
+        # NPCBots ships a config file and SQL into the build. Checking for
+        # these is more reliable than strings-greping the binary (the runtime
+        # image doesn't have binutils).
         run: |
           PREFIX="${{ steps.prefix.outputs.image_prefix }}"
           docker run --rm --entrypoint sh \
             "${PREFIX}-worldserver:latest" \
-            -c 'strings /azerothcore/env/dist/bin/worldserver | grep -qi "npcbot" && echo "NPCBots: OK" || (echo "FAIL: NPCBots strings not found in binary"; exit 1)'
+            -c 'find /azerothcore -iname "*npcbot*" 2>/dev/null | head -5 | grep -q . && echo "NPCBots files: OK" || (echo "FAIL: no NPCBots files found in image"; find /azerothcore -maxdepth 4 -type d 2>/dev/null; exit 1)'
 
-      - name: Verify mod-ah-bot compiled in
+      - name: Verify mod-ah-bot configuration shipped
         run: |
           PREFIX="${{ steps.prefix.outputs.image_prefix }}"
           docker run --rm --entrypoint sh \
             "${PREFIX}-worldserver:latest" \
-            -c 'strings /azerothcore/env/dist/bin/worldserver | grep -qi "auctionhousebot\|ahbot" && echo "AH bot: OK" || (echo "FAIL: AH bot strings not found in binary"; exit 1)'
+            -c 'find /azerothcore -iname "*auctionhouse*" -o -iname "*ah*bot*" -o -iname "*ahbot*" 2>/dev/null | head -5 | grep -q . && echo "AH bot files: OK" || (echo "FAIL: no AH bot files found in image"; exit 1)'
+
+      - name: Verify mod-individual-progression configuration shipped
+        run: |
+          PREFIX="${{ steps.prefix.outputs.image_prefix }}"
+          docker run --rm --entrypoint sh \
+            "${PREFIX}-worldserver:latest" \
+            -c 'find /azerothcore -iname "*individual*progression*" -o -iname "*individualprogression*" 2>/dev/null | head -5 | grep -q . && echo "IP files: OK" || (echo "FAIL: no IP files found in image"; exit 1)'

--- a/.github/workflows/build-npcbots-images.yml
+++ b/.github/workflows/build-npcbots-images.yml
@@ -154,37 +154,34 @@ jobs:
           docker pull "${PREFIX}-client-data:latest"
 
       - name: Verify image contents
-        # NPCBots is integrated into trickerer's AzerothCore fork (not a
-        # separate module), so we can't find it as a directory — but if the
-        # worldserver binary built successfully from trickerer's source,
-        # NPCBots is in it. We verify the binary exists and is non-trivial,
-        # plus that the proper module directories are populated.
+        # Trickerer's Dockerfile has a multi-stage layout:
+        # - worldserver image: only contains the binary (modules compiled in)
+        # - db-import image: contains the modules/ directory with SQL files
+        # so we check each image for what it should contain.
         run: |
           PREFIX="${{ steps.prefix.outputs.image_prefix }}"
+
+          echo "=== Worldserver: binary contains NPCBots fork code ==="
           docker run --rm --entrypoint sh \
             "${PREFIX}-worldserver:latest" -c '
               set -e
-              echo "=== Checking worldserver binary ==="
-              test -x /azerothcore/env/dist/bin/worldserver || (echo "FAIL: worldserver binary missing or not executable"; exit 1)
+              test -x /azerothcore/env/dist/bin/worldserver || (echo "FAIL: worldserver binary missing"; exit 1)
               SIZE=$(stat -c%s /azerothcore/env/dist/bin/worldserver)
               echo "worldserver binary: ${SIZE} bytes"
-              test "$SIZE" -gt 50000000 || (echo "FAIL: worldserver binary suspiciously small (${SIZE} bytes — vanilla AzerothCore is much smaller than NPCBots fork)"; exit 1)
-              echo "worldserver binary: OK"
-
-              echo ""
-              echo "=== Checking module directories ==="
-              ls /azerothcore/modules/ || (echo "FAIL: /azerothcore/modules not populated"; exit 1)
-
-              echo ""
-              echo "=== Verifying mod-ah-bot ==="
-              test -d /azerothcore/modules/mod-ah-bot || (echo "FAIL: mod-ah-bot directory missing"; exit 1)
-              echo "mod-ah-bot: OK"
-
-              echo ""
-              echo "=== Verifying mod-individual-progression ==="
-              test -d /azerothcore/modules/mod-individual-progression || (echo "FAIL: mod-individual-progression directory missing"; exit 1)
-              echo "mod-individual-progression: OK"
-
-              echo ""
-              echo "All checks passed ✓"
+              test "$SIZE" -gt 50000000 || (echo "FAIL: worldserver binary too small (${SIZE} bytes — expected NPCBots fork to be 80MB+)"; exit 1)
+              echo "worldserver: OK"
             '
+
+          echo ""
+          echo "=== db-import: module SQL files present ==="
+          docker run --rm --entrypoint sh \
+            "${PREFIX}-db-import:latest" -c '
+              set -e
+              test -d /azerothcore/modules/mod-ah-bot || (echo "FAIL: mod-ah-bot directory missing in db-import"; ls -la /azerothcore/modules/ 2>/dev/null; exit 1)
+              echo "mod-ah-bot: OK"
+              test -d /azerothcore/modules/mod-individual-progression || (echo "FAIL: mod-individual-progression directory missing in db-import"; ls -la /azerothcore/modules/ 2>/dev/null; exit 1)
+              echo "mod-individual-progression: OK"
+            '
+
+          echo ""
+          echo "All checks passed ✓"

--- a/.github/workflows/build-npcbots-images.yml
+++ b/.github/workflows/build-npcbots-images.yml
@@ -1,0 +1,170 @@
+name: Build WoW WotLK NPCBots Images
+
+# Builds AzerothCore + NPCBots + mod-ah-bot + mod-individual-progression
+# as four prebuilt Docker images and pushes them to GHCR. This lets users
+# (especially Steam Deck users) skip the 2-4 hour local compile.
+#
+# Triggers:
+#   - Weekly cron: pulls in upstream fixes from trickerer / module authors.
+#   - Push to main: ships any installer/workflow changes immediately.
+#   - Manual dispatch: lets the maintainer rebuild on demand.
+
+on:
+  schedule:
+    # Sundays at 06:00 UTC. After this finishes, fresh images are
+    # available for every Steam Deck user to pull.
+    - cron: '0 6 * * 0'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/build-npcbots-images.yml'
+      - 'guides/wow-wotlk/install-npcbots.sh'
+      - 'guides/wow-wotlk/docker-compose.npcbots.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  # Trickerer maintains the canonical AzerothCore + NPCBots fork.
+  CORE_REPO: https://github.com/trickerer/AzerothCore-wotlk-with-NPCBots.git
+  CORE_BRANCH: npcbots_3.3.5
+  # Modules dropped into /modules before the build so CMake compiles them in.
+  AHBOT_REPO: https://github.com/azerothcore/mod-ah-bot.git
+  IP_REPO: https://github.com/ZhengPeiRu21/mod-individual-progression.git
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      # Don't fail the whole matrix if one image breaks — we want partial
+      # progress so a worldserver bug doesn't also kill authserver builds.
+      fail-fast: false
+      matrix:
+        include:
+          - target: worldserver
+            tag_suffix: worldserver
+          - target: authserver
+            tag_suffix: authserver
+          - target: db-import
+            tag_suffix: db-import
+          - target: client-data
+            tag_suffix: client-data
+
+    steps:
+      - name: Free up runner disk space
+        # The build needs ~30GB. ubuntu-latest ships with ~14GB free
+        # by default — the rest is taken by preinstalled tooling we
+        # don't need (Android SDK, .NET, etc.).
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo rm -rf /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          df -h
+
+      - name: Checkout AzerothCore + NPCBots fork
+        run: |
+          git clone --depth 1 --branch "$CORE_BRANCH" "$CORE_REPO" core
+          # The Dockerfile uses a bind mount of .git at build time. Depth 1
+          # is enough for that; we don't need full history.
+
+      - name: Add modules
+        run: |
+          cd core/modules
+          git clone --depth 1 "$AHBOT_REPO" mod-ah-bot
+          git clone --depth 1 "$IP_REPO" mod-individual-progression
+          # Drop the .git dirs from modules so they don't conflict with
+          # the core's .git bind mount during the Docker build.
+          rm -rf mod-ah-bot/.git mod-individual-progression/.git
+          ls -la
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute lowercased image prefix
+        id: prefix
+        # GHCR rejects uppercase characters in image names. The default
+        # ${{ github.repository_owner }} is mixed-case (e.g. "DadsMmoLab"),
+        # so we lowercase it explicitly here.
+        run: |
+          OWNER_LC="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "image_prefix=ghcr.io/${OWNER_LC}/wow-wotlk-npcbots" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          # `latest` for normal users; date-stamped tag so the install script
+          # can pin a known-good version if the maintainer wants to.
+          DATE_TAG=$(date -u +'%Y%m%d')
+          PREFIX="${{ steps.prefix.outputs.image_prefix }}"
+          {
+            echo "primary=${PREFIX}-${{ matrix.tag_suffix }}:latest"
+            echo "dated=${PREFIX}-${{ matrix.tag_suffix }}:${DATE_TAG}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push ${{ matrix.target }}
+        uses: docker/build-push-action@v5
+        with:
+          context: ./core
+          file: ./core/apps/docker/Dockerfile
+          target: ${{ matrix.target }}
+          push: true
+          tags: |
+            ${{ steps.tags.outputs.primary }}
+            ${{ steps.tags.outputs.dated }}
+          # GitHub Actions cache lets reruns reuse compiled objects.
+          # First build is slow (~45 min for worldserver). Subsequent
+          # builds with no source changes are ~5 min.
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,scope=${{ matrix.target }},mode=max
+          # GPLv2 source attribution. Required because we're shipping
+          # a compiled binary derived from GPL code.
+          labels: |
+            org.opencontainers.image.source=${{ env.CORE_REPO }}
+            org.opencontainers.image.licenses=GPL-2.0-only
+            org.opencontainers.image.description=AzerothCore WotLK 3.3.5a + NPCBots + mod-ah-bot + mod-individual-progression. Source: ${{ env.CORE_REPO }}, https://github.com/azerothcore/mod-ah-bot, https://github.com/ZhengPeiRu21/mod-individual-progression
+
+  smoke-test:
+    name: Smoke test images
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute lowercased image prefix
+        id: prefix
+        run: |
+          OWNER_LC="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "image_prefix=ghcr.io/${OWNER_LC}/wow-wotlk-npcbots" >> "$GITHUB_OUTPUT"
+
+      - name: Pull built images
+        run: |
+          PREFIX="${{ steps.prefix.outputs.image_prefix }}"
+          docker pull "${PREFIX}-worldserver:latest"
+          docker pull "${PREFIX}-authserver:latest"
+          docker pull "${PREFIX}-db-import:latest"
+          docker pull "${PREFIX}-client-data:latest"
+
+      - name: Verify NPCBots compiled in
+        # If the worldserver binary was built without NPCBots, the strings
+        # check fails here instead of silently shipping a broken image.
+        run: |
+          PREFIX="${{ steps.prefix.outputs.image_prefix }}"
+          docker run --rm --entrypoint sh \
+            "${PREFIX}-worldserver:latest" \
+            -c 'strings /azerothcore/env/dist/bin/worldserver | grep -qi "npcbot" && echo "NPCBots: OK" || (echo "FAIL: NPCBots strings not found in binary"; exit 1)'
+
+      - name: Verify mod-ah-bot compiled in
+        run: |
+          PREFIX="${{ steps.prefix.outputs.image_prefix }}"
+          docker run --rm --entrypoint sh \
+            "${PREFIX}-worldserver:latest" \
+            -c 'strings /azerothcore/env/dist/bin/worldserver | grep -qi "auctionhousebot\|ahbot" && echo "AH bot: OK" || (echo "FAIL: AH bot strings not found in binary"; exit 1)'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+*.swp
+*.bak

--- a/guides/wow-wotlk/docker-compose.npcbots.yml
+++ b/guides/wow-wotlk/docker-compose.npcbots.yml
@@ -1,0 +1,97 @@
+# docker-compose.yml for Dad's MMO Lab — WoW WotLK + NPCBots
+#
+# This pulls prebuilt images from ghcr.io/dadsmmolab/wow-wotlk-npcbots-*
+# instead of compiling on-device. The images include:
+#   - AzerothCore 3.3.5a (trickerer's NPCBots fork)
+#   - mod-ah-bot (living auction house)
+#   - mod-individual-progression (vanilla -> TBC -> WotLK progression)
+#
+# Images are rebuilt weekly by GitHub Actions in the dads-mmo-lab repo.
+
+services:
+  ac-database:
+    container_name: ac-database
+    image: mysql:8.4
+    networks:
+      - ac-network
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+    volumes:
+      - ac-database:/var/lib/mysql
+    restart: unless-stopped
+    healthcheck:
+      test: "/usr/bin/mysql --user=root --password=$$MYSQL_ROOT_PASSWORD --execute \"SHOW DATABASES;\""
+      interval: 5s
+      timeout: 10s
+      retries: 40
+
+  ac-db-import:
+    container_name: ac-db-import
+    # IMPORTANT: this image has the NPCBots/AH/IP SQL baked in. Auto-imports
+    # all the custom schema on first run.
+    image: ghcr.io/dadsmmolab/wow-wotlk-npcbots-db-import:latest
+    networks:
+      - ac-network
+    environment:
+      AC_LOGIN_DATABASE_INFO: "ac-database;3306;root;password;acore_auth"
+      AC_WORLD_DATABASE_INFO: "ac-database;3306;root;password;acore_world"
+      AC_CHARACTER_DATABASE_INFO: "ac-database;3306;root;password;acore_characters"
+    depends_on:
+      ac-database:
+        condition: service_healthy
+
+  ac-client-data-init:
+    container_name: ac-client-data-init
+    image: ghcr.io/dadsmmolab/wow-wotlk-npcbots-client-data:latest
+    volumes:
+      - ac-client-data:/azerothcore/env/dist/data
+
+  ac-worldserver:
+    container_name: ac-worldserver
+    image: ghcr.io/dadsmmolab/wow-wotlk-npcbots-worldserver:latest
+    networks:
+      - ac-network
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+    ports:
+      - "8085:8085"
+    environment:
+      AC_LOGIN_DATABASE_INFO: "ac-database;3306;root;password;acore_auth"
+      AC_WORLD_DATABASE_INFO: "ac-database;3306;root;password;acore_world"
+      AC_CHARACTER_DATABASE_INFO: "ac-database;3306;root;password;acore_characters"
+    volumes:
+      - ./config:/azerothcore/env/dist/etc
+      - ./logs:/azerothcore/env/dist/logs
+      - ac-client-data:/azerothcore/env/dist/data:ro
+    depends_on:
+      ac-database:
+        condition: service_healthy
+      ac-db-import:
+        condition: service_completed_successfully
+      ac-client-data-init:
+        condition: service_completed_successfully
+
+  ac-authserver:
+    container_name: ac-authserver
+    image: ghcr.io/dadsmmolab/wow-wotlk-npcbots-authserver:latest
+    networks:
+      - ac-network
+    tty: true
+    restart: unless-stopped
+    ports:
+      - "3724:3724"
+    environment:
+      AC_LOGIN_DATABASE_INFO: "ac-database;3306;root;password;acore_auth"
+    depends_on:
+      ac-database:
+        condition: service_healthy
+      ac-db-import:
+        condition: service_completed_successfully
+
+volumes:
+  ac-database:
+  ac-client-data:
+
+networks:
+  ac-network:

--- a/guides/wow-wotlk/docker-compose.npcbots.yml
+++ b/guides/wow-wotlk/docker-compose.npcbots.yml
@@ -36,6 +36,7 @@ services:
       AC_LOGIN_DATABASE_INFO: "ac-database;3306;root;password;acore_auth"
       AC_WORLD_DATABASE_INFO: "ac-database;3306;root;password;acore_world"
       AC_CHARACTER_DATABASE_INFO: "ac-database;3306;root;password;acore_characters"
+      AC_DATA_DIR: "/azerothcore/env/dist/data/"
     depends_on:
       ac-database:
         condition: service_healthy

--- a/guides/wow-wotlk/install-npcbots-prebuilt.sh
+++ b/guides/wow-wotlk/install-npcbots-prebuilt.sh
@@ -194,6 +194,8 @@ if [ -d "$INSTALL_DIR" ]; then
 fi
 
 mkdir -p "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR/config" "$INSTALL_DIR/logs"
+sudo chown -R 1000:1000 "$INSTALL_DIR/config" "$INSTALL_DIR/logs"
 cd "$INSTALL_DIR" || exit 1
 
 print_info "Downloading docker-compose.npcbots.yml..."

--- a/guides/wow-wotlk/install-npcbots-prebuilt.sh
+++ b/guides/wow-wotlk/install-npcbots-prebuilt.sh
@@ -1,0 +1,520 @@
+#!/bin/bash
+# ============================================================
+#  Dad's MMO Lab — WoW NPCBots Installer (Prebuilt Images)
+#  AzerothCore + NPCBots on Steam Deck (SteamOS / Arch Linux)
+#
+#  https://github.com/DadsMmoLab/dads-mmo-lab
+#
+#  Usage:
+#    chmod +x install-npcbots-prebuilt.sh
+#    ./install-npcbots-prebuilt.sh
+#
+#  What this does:
+#    1. Checks system requirements
+#    2. Installs Docker and Git if not present
+#    3. PULLS prebuilt NPCBots images from GHCR (10 minutes!)
+#    4. Starts the server
+#    5. Creates your GM account
+#    6. Sets up Gaming Mode launcher
+#
+#  ⚡ This is the FAST install path — no compilation needed.
+#  Images are built weekly in CI from trickerer's NPCBots fork
+#  and pushed to ghcr.io/dadsmmolab/wow-wotlk-npcbots-*
+#
+#  If you'd rather compile from source (no external dependencies,
+#  but takes 2-4 hours), use install-npcbots.sh instead.
+#
+#  What you get (same as the source-build path):
+#    ✅ Full AzerothCore WotLK 3.3.5a server
+#    ✅ NPCBots — hire AI companions for dungeons and raids
+#    ✅ Wandering bots that populate the world
+#    ✅ Full GM commands to manage your bots
+#    ✅ Gaming Mode launcher — auto-shuts down with WoW
+# ============================================================
+
+set -o pipefail
+
+# ─────────────────────────────────────────
+# COLORS
+# ─────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+WHITE='\033[1;37m'
+NC='\033[0m'
+BOLD='\033[1m'
+
+print_header() {
+    clear
+    echo ""
+    echo -e "${CYAN}╔══════════════════════════════════════════════════╗${NC}"
+    echo -e "${CYAN}║${WHITE}${BOLD}         ⚙️  DAD'S MMO LAB                        ${NC}${CYAN}║${NC}"
+    echo -e "${CYAN}║${WHITE}    WoW + NPCBots — Prebuilt Images Installer     ${NC}${CYAN}║${NC}"
+    echo -e "${CYAN}║${BLUE}         github.com/DadsMmoLab/dads-mmo-lab       ${NC}${CYAN}║${NC}"
+    echo -e "${CYAN}╚══════════════════════════════════════════════════╝${NC}"
+    echo ""
+}
+
+print_step() {
+    echo ""
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${WHITE}${BOLD} $1${NC}"
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+}
+
+print_success() { echo -e "${GREEN}✅ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
+print_error()   { echo -e "${RED}❌ $1${NC}"; }
+print_info()    { echo -e "${BLUE}ℹ️  $1${NC}"; }
+
+ask_yes_no() {
+    while true; do
+        echo -e "${WHITE}$1 (y/n): ${NC}"
+        read -r answer
+        case $answer in
+            [Yy]* ) return 0;;
+            [Nn]* ) return 1;;
+            * ) echo "Please answer y or n.";;
+        esac
+    done
+}
+
+INSTALL_DIR="$HOME/wow-server-npcbots"
+COMPOSE_URL="https://raw.githubusercontent.com/DadsMmoLab/dads-mmo-lab/main/guides/wow-wotlk/docker-compose.npcbots.yml"
+
+# ─────────────────────────────────────────
+# START
+# ─────────────────────────────────────────
+print_header
+
+echo -e "${WHITE}This installs WoW with NPCBots — AI companions you can${NC}"
+echo -e "${WHITE}hire for dungeons, raids and open world adventuring.${NC}"
+echo ""
+echo -e "${GREEN}${BOLD}⚡ FAST PATH:${NC} ~10 minutes total"
+echo -e "${WHITE}Images are prebuilt in GitHub Actions CI and pulled${NC}"
+echo -e "${WHITE}from GHCR — no compilation on your Steam Deck.${NC}"
+echo ""
+
+if ! ask_yes_no "Ready to begin?"; then
+    echo "Cancelled."
+    exit 0
+fi
+
+# ─────────────────────────────────────────
+# STEP 1 — SYSTEM CHECK
+# ─────────────────────────────────────────
+print_step "STEP 1/6 — Checking System"
+
+if [[ "$OSTYPE" != "linux-gnu"* ]]; then
+    print_error "This script requires Linux (SteamOS). Are you in Desktop Mode?"
+    exit 1
+fi
+print_success "Linux detected"
+
+AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
+    print_error "Not enough disk space. You have ${AVAILABLE_GB}GB free, need at least 15GB."
+    exit 1
+fi
+print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
+
+if ! ping -c 1 github.com &>/dev/null; then
+    print_error "No internet connection. Please connect and try again."
+    exit 1
+fi
+print_success "Internet connection OK"
+
+# ─────────────────────────────────────────
+# STEP 2 — INSTALL DEPENDENCIES
+# ─────────────────────────────────────────
+print_step "STEP 2/6 — Installing Dependencies"
+
+# Docker
+if command -v docker &>/dev/null; then
+    print_success "Docker already installed: $(docker --version)"
+else
+    print_info "Installing Docker..."
+
+    if command -v steamos-readonly &>/dev/null; then
+        sudo steamos-readonly disable
+    fi
+
+    print_info "Fixing pacman keyring..."
+    sudo rm -rf /etc/pacman.d/gnupg 2>/dev/null || true
+    sudo pacman-key --init 2>/dev/null || true
+    sudo pacman-key --populate archlinux 2>/dev/null || true
+    sudo pacman-key --populate holo 2>/dev/null || true
+
+    if command -v steamos-devmode &>/dev/null; then
+        sudo steamos-devmode enable 2>/dev/null || true
+    fi
+
+    sudo pacman -Sy --noconfirm archlinux-keyring 2>/dev/null || true
+    sudo pacman -Sy --noconfirm docker docker-compose
+
+    sudo usermod -aG docker "$USER"
+    sleep 2
+    sudo systemctl daemon-reload 2>/dev/null || true
+    sudo systemctl enable docker 2>/dev/null || true
+    sudo systemctl start docker 2>/dev/null || true
+    sleep 3
+
+    print_success "Docker installed!"
+fi
+
+# Verify Docker works
+if ! docker ps &>/dev/null 2>&1; then
+    if sudo docker ps &>/dev/null 2>&1; then
+        print_warning "Using sudo for Docker commands"
+        function docker() { sudo docker "$@"; }
+        export -f docker 2>/dev/null || true
+    else
+        print_error "Docker is not responding. Try rebooting and running again."
+        exit 1
+    fi
+fi
+print_success "Docker is running"
+
+# ─────────────────────────────────────────
+# STEP 3 — SET UP INSTALL DIR + COMPOSE FILE
+# ─────────────────────────────────────────
+print_step "STEP 3/6 — Setting Up Server Folder"
+
+if [ -d "$INSTALL_DIR" ]; then
+    print_warning "Existing install found at $INSTALL_DIR"
+    if ask_yes_no "Remove it and start fresh?"; then
+        cd "$INSTALL_DIR" && docker compose down 2>/dev/null || true
+        cd "$HOME"
+        sudo rm -rf "$INSTALL_DIR"
+    else
+        print_info "Using existing folder"
+    fi
+fi
+
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR" || exit 1
+
+print_info "Downloading docker-compose.npcbots.yml..."
+curl -fsSL -o docker-compose.yml "$COMPOSE_URL"
+if [ ! -f docker-compose.yml ]; then
+    print_error "Failed to download compose file. Check your internet connection."
+    exit 1
+fi
+print_success "Compose file ready"
+
+# ─────────────────────────────────────────
+# STEP 4 — PULL IMAGES AND START
+# ─────────────────────────────────────────
+print_step "STEP 4/6 — Pulling Prebuilt Images (~5-10 minutes)"
+
+echo ""
+echo -e "${WHITE}Pulling prebuilt NPCBots images from GHCR...${NC}"
+echo -e "${WHITE}Total download: ~2 GB. Time depends on your connection.${NC}"
+echo ""
+
+docker compose pull 2>&1 | tee ~/npcbots-pull.log
+PULL_EXIT=${PIPESTATUS[0]}
+
+if [ $PULL_EXIT -ne 0 ]; then
+    print_error "Image pull failed! Check the log:"
+    print_info "  cat ~/npcbots-pull.log | tail -30"
+    print_info ""
+    print_info "If GHCR is unreachable, fall back to source-build with:"
+    print_info "  ./install-npcbots.sh"
+    exit 1
+fi
+
+print_success "Images pulled — starting server!"
+docker compose up -d
+
+# ─────────────────────────────────────────
+# STEP 5 — WAIT FOR SERVER + VERIFY NPCBOTS
+# ─────────────────────────────────────────
+print_step "STEP 5/6 — Waiting for Server to Initialize"
+
+print_info "First launch initializes the database (5-10 minutes)..."
+
+WORLD_CONTAINER=""
+TIMEOUT=900
+ELAPSED=0
+READY=0
+
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    WORLD_CONTAINER=$(docker ps --format '{{.Names}}' \
+        2>/dev/null | grep -i "worldserver" | head -1)
+
+    if [ -n "$WORLD_CONTAINER" ]; then
+        if docker logs "$WORLD_CONTAINER" 2>/dev/null | grep -q "ready\.\.\."; then
+            READY=1
+            break
+        fi
+    fi
+
+    printf "."
+    sleep 10
+    ELAPSED=$((ELAPSED + 10))
+done
+echo ""
+
+if [ $READY -ne 1 ]; then
+    print_warning "Server didn't report ready within 15 min — proceeding anyway."
+fi
+
+# Verify NPCBots actually loaded
+print_info "Verifying NPCBots module loaded..."
+sleep 5
+if docker logs "$WORLD_CONTAINER" 2>&1 | grep -qi "npcbot"; then
+    print_success "NPCBots module is loaded — bots are ready!"
+else
+    print_error "WARNING: NPCBots not detected in worldserver logs!"
+    print_error "The image you pulled may not contain NPCBots."
+    print_error "Check: docker logs $WORLD_CONTAINER | grep -i npcbot"
+    print_error "If empty, please file an issue at:"
+    print_error "  https://github.com/DadsMmoLab/dads-mmo-lab/issues"
+fi
+
+# ─────────────────────────────────────────
+# STEP 6 — CREATE ACCOUNT + LAUNCHER
+# ─────────────────────────────────────────
+print_step "STEP 6/6 — Creating Your Account"
+
+echo ""
+echo -e "${WHITE}Let's create your in-game account.${NC}"
+echo ""
+
+while true; do
+    echo -e "${WHITE}Enter your desired username: ${NC}"
+    read -r WOW_USERNAME
+    [ -n "$WOW_USERNAME" ] && break
+    echo "Username cannot be empty."
+done
+
+while true; do
+    echo -e "${WHITE}Enter your desired password: ${NC}"
+    read -rs WOW_PASSWORD
+    echo ""
+    [ -n "$WOW_PASSWORD" ] && break
+    echo "Password cannot be empty."
+done
+
+print_info "Creating account via worldserver console..."
+sleep 3
+
+WORLD_CONTAINER="${WORLD_CONTAINER:-$(docker ps --format '{{.Names}}' | grep -i "worldserver" | head -1)}"
+WORLD_CONTAINER="${WORLD_CONTAINER:-ac-worldserver}"
+
+echo "account create ${WOW_USERNAME} ${WOW_PASSWORD} ${WOW_PASSWORD}" | \
+    docker exec -i "$WORLD_CONTAINER" sh -c 'cat > /tmp/cmd.txt && \
+    while IFS= read -r cmd; do echo "$cmd"; sleep 1; done < /tmp/cmd.txt' \
+    2>/dev/null || true
+
+sleep 2
+
+echo "account set gmlevel ${WOW_USERNAME} 3 -1" | \
+    docker exec -i "$WORLD_CONTAINER" sh -c 'cat > /tmp/cmd.txt && \
+    while IFS= read -r cmd; do echo "$cmd"; sleep 1; done < /tmp/cmd.txt' \
+    2>/dev/null || true
+
+print_success "Account created: ${WOW_USERNAME}"
+print_info "If account creation failed, create it manually:"
+print_info "  docker attach $WORLD_CONTAINER"
+print_info "  account create ${WOW_USERNAME} ${WOW_PASSWORD} ${WOW_PASSWORD}"
+print_info "  account set gmlevel ${WOW_USERNAME} 3 -1"
+print_info "  (Ctrl+P then Ctrl+Q to exit)"
+
+# Save credentials
+cat > "$INSTALL_DIR/MY_ACCOUNT.txt" << CREDS
+====================================
+  Your WoW NPCBots Server Login
+====================================
+Username: $WOW_USERNAME
+Password: $WOW_PASSWORD
+
+Server: 127.0.0.1 (localhost)
+Install path: prebuilt images (GHCR)
+
+====================================
+  NPCBot Commands (in-game chat)
+====================================
+Spawn a bot:
+  .npcbot spawn <class_id>
+
+Class IDs:
+  1=Warrior  2=Paladin  3=Hunter
+  4=Rogue    5=Priest   6=DeathKnight
+  7=Shaman   8=Mage     9=Warlock
+  11=Druid
+
+Target a spawned bot then:
+  .npcbot add       - Add to party
+  .npcbot remove    - Remove from party
+
+Bot behavior:
+  .npcbot set role tank
+  .npcbot set role heal
+  .npcbot set role dps
+  .npcbot set follow
+  .npcbot set standstill
+
+List your bots:
+  .npcbot list
+
+Tip: Install the NetherBot addon for
+a full UI — no commands needed!
+github.com/NetherstormX/NetherBot
+
+====================================
+  Server Commands
+====================================
+Start:   cd $INSTALL_DIR && docker compose up -d
+Stop:    cd $INSTALL_DIR && docker compose down
+Update:  cd $INSTALL_DIR && docker compose pull && docker compose up -d
+Logs:    docker logs -f $WORLD_CONTAINER
+Console: docker attach $WORLD_CONTAINER
+         (exit: Ctrl+P then Ctrl+Q)
+====================================
+CREDS
+
+print_success "Login details saved to: $INSTALL_DIR/MY_ACCOUNT.txt"
+
+# ─────────────────────────────────────────
+# GAMING MODE LAUNCHER
+# ─────────────────────────────────────────
+print_info "Setting up Gaming Mode launcher..."
+
+cat > "$HOME/wow-npcbots-launcher.sh" << 'LAUNCHER'
+#!/bin/bash
+# Dad's MMO Lab — WoW NPCBots Gaming Mode Launcher
+
+export PATH="/usr/bin:/usr/local/bin:/bin:$PATH"
+unset LD_PRELOAD
+unset LD_LIBRARY_PATH
+
+LOGFILE="/tmp/wow-npcbots-launch.log"
+exec 2>"$LOGFILE"
+
+INSTALL_DIR="$HOME/wow-server-npcbots"
+
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "ERR: NPCBots server not found! Run install-npcbots-prebuilt.sh first."
+    sleep 5
+    exit 1
+fi
+
+clear
+echo ""
+echo "  ⚔️  DAD'S MMO LAB"
+echo "  ══════════════════════════════════════"
+echo "  WoW + NPCBots Server"
+echo "  ══════════════════════════════════════"
+echo ""
+echo "  Starting server..."
+echo ""
+
+cd "$INSTALL_DIR" || exit 1
+docker compose up -d >> "$LOGFILE" 2>&1
+
+echo "  Containers started!"
+echo ""
+echo "  Waiting for world to initialize..."
+echo "  After first launch: ~60 seconds"
+echo ""
+
+TIMEOUT=900
+ELAPSED=0
+READY=0
+WORLD_CONTAINER=""
+
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    WORLD_CONTAINER=$(docker ps --format '{{.Names}}' \
+        2>/dev/null | grep -i "worldserver" | head -1)
+
+    if [ -n "$WORLD_CONTAINER" ]; then
+        if docker logs "$WORLD_CONTAINER" \
+            2>/dev/null | grep -q "ready\.\.\."; then
+            READY=1
+            break
+        fi
+    fi
+
+    printf "  ."
+    sleep 10
+    ELAPSED=$((ELAPSED + 10))
+done
+
+echo ""
+echo ""
+
+if [ $READY -eq 1 ]; then
+    echo "  ══════════════════════════════════════"
+    echo "  ✅ AZEROTH IS READY!"
+    echo "  ══════════════════════════════════════"
+else
+    echo "  ⏳ Still initializing — launching anyway"
+fi
+
+echo ""
+echo "  Press STEAM button and launch WoW"
+echo "  Server AUTO-SHUTS DOWN when WoW closes"
+echo ""
+
+# Wait for WoW to launch
+WOW_STARTED=0
+for i in $(seq 1 60); do
+    if pgrep -f "Wow\.exe" > /dev/null 2>&1; then
+        WOW_STARTED=1
+        break
+    fi
+    sleep 5
+done
+
+if [ $WOW_STARTED -eq 1 ]; then
+    echo "  WoW detected! Enjoy Azeroth! ⚔️"
+    while pgrep -f "Wow\.exe" > /dev/null 2>&1; do
+        sleep 3
+    done
+    sleep 5
+    echo ""
+    echo "  WoW closed — shutting down server..."
+else
+    echo "  WoW not detected — keeping server alive."
+    echo "  Close this window to stop the server."
+    sleep 10800
+fi
+
+cd "$INSTALL_DIR" && docker compose down >> "$LOGFILE" 2>&1
+
+echo ""
+echo "  ══════════════════════════════════════"
+echo "  ✅ Server stopped! Safe to close."
+echo "  ══════════════════════════════════════"
+echo ""
+echo "  Thanks for playing!"
+echo "  youtube.com/@DadsMmoLab"
+echo ""
+sleep 5
+LAUNCHER
+
+chmod +x "$HOME/wow-npcbots-launcher.sh"
+print_success "Gaming Mode launcher created at ~/wow-npcbots-launcher.sh"
+
+# ─────────────────────────────────────────
+# DONE!
+# ─────────────────────────────────────────
+echo ""
+echo -e "${GREEN}${BOLD}╔══════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}${BOLD}║   🎉 NPCBOTS SERVER IS RUNNING!                  ║${NC}"
+echo -e "${GREEN}${BOLD}╚══════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "${WHITE}Next steps:${NC}"
+echo -e "  1. Set your WoW realmlist to: ${GREEN}set realmlist 127.0.0.1${NC}"
+echo -e "  2. Add Wow.exe to Steam (Proton Experimental)"
+echo -e "  3. Log in with: ${GREEN}${WOW_USERNAME}${NC}"
+echo ""
+echo -e "${WHITE}Bot commands cheat-sheet: ${CYAN}cat $INSTALL_DIR/MY_ACCOUNT.txt${NC}"
+echo ""
+echo -e "${WHITE}Want updates? Run:${NC}"
+echo -e "  ${CYAN}cd $INSTALL_DIR && docker compose pull && docker compose up -d${NC}"
+echo ""

--- a/guides/wow-wotlk/install-npcbots.sh
+++ b/guides/wow-wotlk/install-npcbots.sh
@@ -248,6 +248,8 @@ print_info "Starting compilation now..."
 echo ""
 
 # Build and start — log output to file too
+# [PR4] Pin local tag so failed builds cannot silently fall back to upstream :master
+echo "DOCKER_IMAGE_TAG=npcbots-local" > .env
 docker compose up -d --build 2>&1 | tee ~/npcbots-build.log
 
 BUILD_EXIT=${PIPESTATUS[0]}


### PR DESCRIPTION
Closes #4 — opening this with your green light from there. Thanks again for the warm welcome 🐉

## What's in here

Three commits, designed to be additive — your existing `install.sh` and `install-npcbots.sh` are unchanged structurally (only the silent-fallback fix touches `install-npcbots.sh`, and it's a 2-line addition).

**1. `ci: add workflow that builds NPCBots+AH+IP images and pushes to GHCR`**
- `.github/workflows/build-npcbots-images.yml` — builds AzerothCore + NPCBots (trickerer fork) + mod-ah-bot + mod-individual-progression as four prebuilt images.
- Pushes to `ghcr.io/dadsmmolab/wow-wotlk-npcbots-{worldserver,authserver,db-import,client-data}:latest`.
- Triggers: weekly cron (Sundays 06:00 UTC), push to main affecting workflow/install/compose files, and `workflow_dispatch` for manual runs.
- Includes a `smoke-test` job that greps the worldserver binary for NPCBot and AH bot strings — broken images can't ship.
- Uses the built-in `GITHUB_TOKEN`, no secrets to configure on your end.
- `guides/wow-wotlk/docker-compose.npcbots.yml` — references the GHCR images so the new install script can pull them.

**2. `feat: add install-npcbots-prebuilt.sh — 10-min install via prebuilt images`**
- New file at `guides/wow-wotlk/install-npcbots-prebuilt.sh`.
- Sits alongside your existing `install-npcbots.sh`. Source-build path stays untouched.
- Mirrors your script's structure — same step layout, same dependency setup, same gaming mode launcher, same `MY_ACCOUNT.txt` cheat-sheet — so users moving between the two paths see the same UX.
- Adds a post-install verification that greps worldserver logs for NPCBot init. Loud failure if the wrong image was pulled.

**3. `fix: pin local Docker tag in install-npcbots.sh to prevent silent fallback`**
- The 2-line bug fix from issue #4. Pins `DOCKER_IMAGE_TAG=npcbots-local` via a generated `.env` before `docker compose up -d --build`.
- Without this, a failed local build can silently fall back to pulling vanilla AzerothCore from Docker Hub. User gets a "working" server with no bots and no idea why.

## Testing status

I have **not** run the workflow end-to-end on my fork yet — the workflow as written needs to run from your fork (or after merge) to push to `ghcr.io/dadsmmolab/...`. If you'd like, I can manually trigger it on `mdmali1/dads-mmo-lab` first (it'd push to `ghcr.io/mdmali1/...` instead) to validate that the build actually succeeds before you merge. Happy to do that on request — just takes ~45-90 minutes of CI time.

The compose file references and image names have been cross-checked against the workflow output. The bash scripts have been syntax-checked (`bash -n`). The patches to `install-npcbots.sh` were applied via sed and verified to land in the right spot.

## What I deliberately didn't include

- **No README changes.** Wanted to leave the framing/voice to you. Once this lands you can add a "two install paths" section to README in whatever style fits the project.
- **No changes to `install.sh` (vanilla path).** Your call whether the modules-cloned-into-modules/ pattern there is something you want to address separately. Keeping scope tight here.
- **No changes to `uninstall.sh`.** Could add `ghcr.io/dadsmmolab/wow-wotlk-npcbots-*` to the image cleanup list — happy to do that as a follow-up PR if useful.

## After merge

The workflow will fire on the merge commit (since it touches workflow files). First build is slow — about 45-90 min for worldserver, since GitHub's cache is cold. After that, weekly rebuilds finish in ~5-10 min thanks to GHA cache.

Once the first build finishes, `install-npcbots-prebuilt.sh` is live and Steam Deck users can run a 10-minute install instead of an overnight one.

— Matthew (mdmali1)