### PR TITLE
WoW-Manager: Complete Rewrite of Module Manager, ALE Scripts, SQL Mods, Terminal UX, and Better Steam Deck support for Wotlk Manager

### DIFF
--- a/guides/wow-wotlk/manage-wow-modules.sh
+++ b/guides/wow-wotlk/manage-wow-modules.sh
@@ -1501,6 +1501,15 @@ configure_ale_paragon() {
     echo -e "${DIM}The addon communicates with the server via the ParagonAnniversary protocol.${RST}"
 }
 
+# Return 0 if $1 is already in the remaining args; used for dedup in
+# configure_ale_bmah without associative arrays (Bash 3 / macOS compatible).
+_bmah_in_list() {
+    local needle="$1"; shift
+    local item
+    for item in "$@"; do [ "$item" = "$needle" ] && return 0; done
+    return 1
+}
+
 configure_ale_bmah() {
     local clone_dir
     clone_dir=$(ale_script_clone_dir "bmah")
@@ -1519,14 +1528,6 @@ configure_ale_bmah() {
                           "Baron Vardus"
                           "Count Remo" )
 
-    # Return 0 if $1 is already in the remaining args; used for dedup without
-    # associative arrays so this stays Bash 3 / macOS compatible.
-    _bmah_in_list() {
-        local needle="$1"; shift
-        local item
-        for item in "$@"; do [ "$item" = "$needle" ] && return 0; done
-        return 1
-    }
 
     print_step "Black Market AH — NPC Vendor Configuration"
     echo ""
@@ -1554,7 +1555,7 @@ configure_ale_bmah() {
     # ── Show current IDs extracted from the file ──────────────
     local current_ids
     current_ids=$(awk '
-        /local BMAH_VENDOR_NPCs[[:space:]]*=/ { found=1 }
+        /^[[:space:]]*local BMAH_VENDOR_NPCs[[:space:]]*=/ { found=1 }
         found {
             tmp = $0
             gsub(/--[^\n]*/, "", tmp)   # strip line comments
@@ -1600,7 +1601,9 @@ configure_ale_bmah() {
     local -a sel_ids=()
     local -a sel_names=()
 
-    if [[ "${_bsel,,}" == "all" ]]; then
+    local _bsel_lower
+    _bsel_lower=$(printf '%s' "$_bsel" | tr '[:upper:]' '[:lower:]')
+    if [ "$_bsel_lower" = "all" ]; then
         sel_ids=("${BNPC_IDS[@]}")
         sel_names=("${BNPC_NAMES[@]}")
     elif [ -n "$_bsel" ]; then
@@ -1633,7 +1636,7 @@ configure_ale_bmah() {
         echo ""
         printf "${WHITE}Apply as: [a] Add to existing list  [r] Replace list entirely [a]: ${RST}"
         read -r _bmode_raw
-        [ "${_bmode_raw,,}" = "r" ] && _bmode="replace"
+        case "$_bmode_raw" in [Rr]) _bmode="replace" ;; esac
     fi
 
     # ── Build final deduped ID list ───────────────────────────
@@ -1664,8 +1667,15 @@ configure_ale_bmah() {
         # Write one NPC entry per line to a temp file; awk reads it with
         # getline so embedded newlines never hit the -v variable limit.
         local ids_file tmpfile j label
-        ids_file=$(mktemp "${TMPDIR:-/tmp}/bmah_ids_XXXXXX")
-        tmpfile=$(mktemp "${TMPDIR:-/tmp}/bmah_server_XXXXXX.lua")
+        ids_file=$(mktemp "${TMPDIR:-/tmp}/bmah_ids_XXXXXX") || {
+            print_error "Could not create temp file — aborting NPC patch."
+            return 1
+        }
+        tmpfile=$(mktemp "${TMPDIR:-/tmp}/bmah_server_XXXXXX.lua") || {
+            rm -f "$ids_file"
+            print_error "Could not create temp file — aborting NPC patch."
+            return 1
+        }
         for id in "${final_ids[@]}"; do
             label=""
             for (( j=0; j<${#BNPC_IDS[@]}; j++ )); do
@@ -1675,10 +1685,11 @@ configure_ale_bmah() {
         done
 
         # awk replaces the BMAH_VENDOR_NPCs block — handles both inline and
-        # multiline forms.  Exits 1 if the pattern was never matched so we
-        # detect a failed patch before overwriting the live file.
+        # multiline forms.  Anchored to line-start so a commented-out example
+        # line cannot trigger the replacement.  Exits 1 if the pattern was
+        # never matched so we detect a failed patch before overwriting the file.
         awk -v ids_file="$ids_file" '
-            /local BMAH_VENDOR_NPCs[[:space:]]*=/ {
+            /^[[:space:]]*local BMAH_VENDOR_NPCs[[:space:]]*=/ {
                 print "local BMAH_VENDOR_NPCs = {"
                 while ((getline line < ids_file) > 0) { print line }
                 close(ids_file)
@@ -1698,16 +1709,20 @@ configure_ale_bmah() {
         rm -f "$ids_file"
 
         if [ $awk_rc -eq 0 ] && [ -s "$tmpfile" ]; then
-            mv "$tmpfile" "$deployed_file"
-            echo ""
-            print_success "BMAH_VENDOR_NPCs updated with ${#final_ids[@]} NPC(s):"
-            for id in "${final_ids[@]}"; do
-                label=""
-                for (( j=0; j<${#BNPC_IDS[@]}; j++ )); do
-                    [ "${BNPC_IDS[$j]}" = "$id" ] && label=" — ${BNPC_NAMES[$j]}" && break
+            if mv "$tmpfile" "$deployed_file"; then
+                echo ""
+                print_success "BMAH_VENDOR_NPCs updated with ${#final_ids[@]} NPC(s):"
+                for id in "${final_ids[@]}"; do
+                    label=""
+                    for (( j=0; j<${#BNPC_IDS[@]}; j++ )); do
+                        [ "${BNPC_IDS[$j]}" = "$id" ] && label=" — ${BNPC_NAMES[$j]}" && break
+                    done
+                    print_info "  • ${id}${label}"
                 done
-                print_info "  • ${id}${label}"
-            done
+            else
+                rm -f "$tmpfile"
+                print_error "Could not write updated file — check permissions on: $deployed_file"
+            fi
         else
             rm -f "$tmpfile"
             print_error "Could not locate BMAH_VENDOR_NPCs block in bmah_server.lua."
@@ -1755,16 +1770,26 @@ configure_ale_bmah() {
 # Patch one ENABLE flag from false → true in a deployed Lua file.
 # Usage: _aw_enable <file> <FLAG_NAME>
 # Returns 1 and prints a warning if the patch cannot be verified.
+# Uses a temp-file rewrite instead of sed -i so it works on both
+# macOS (BSD sed) and Linux (GNU sed) without a backup-suffix dance.
 _aw_enable() {
     local file="$1" flag="$2"
     if [ ! -f "$file" ]; then
         print_warning "  File not found: $(basename "$file") — skipping."
         return 1
     fi
-    sed -i "s/\(local ${flag}\)[[:space:]]*=[[:space:]]*false/\1 = true/" "$file"
-    if grep -q "local ${flag} = true" "$file"; then
+    local _aw_tmp
+    _aw_tmp=$(mktemp "${TMPDIR:-/tmp}/aw_enable_XXXXXX") || {
+        print_warning "  mktemp failed; cannot patch ${flag}."
+        return 1
+    }
+    # Anchor to line-start so commented-out lines (-- local FLAG = false) are skipped.
+    sed "s/^\([[:space:]]*local ${flag}\)[[:space:]]*=[[:space:]]*false/\1 = true/" "$file" > "$_aw_tmp"
+    if grep -q "^[[:space:]]*local ${flag} = true" "$_aw_tmp"; then
+        mv "$_aw_tmp" "$file"
         return 0
     fi
+    rm -f "$_aw_tmp"
     print_warning "  Could not patch ${flag} in $(basename "$file") — edit manually."
     return 1
 }
@@ -1819,14 +1844,16 @@ configure_ale_accountwide() {
     if [ -f "$f_mon" ]; then
         echo -e "${GOLD}Money${RST}"
         if ask_yes_no "Enable Accountwide Money (shared gold pool across all characters)?"; then
-            _aw_enable "$f_mon" "ENABLE_ACCOUNTWIDE_MONEY" && \
+            if _aw_enable "$f_mon" "ENABLE_ACCOUNTWIDE_MONEY"; then
                 print_success "  Money enabled."
-            if ask_yes_no "  Enable real-time gold tick (syncs gold every ~5 s while online)?"; then
-                _aw_enable "$f_mon" "ENABLE_REALTIME_TICK" && \
-                    print_success "  Realtime tick enabled."
-                if ask_yes_no "  Also enable realtime tick for Altbots?"; then
-                    _aw_enable "$f_mon" "ENABLE_ALTBOT_REALTIME_TICK" && \
-                        print_success "  Altbot realtime tick enabled."
+                if ask_yes_no "  Enable real-time gold tick (syncs gold every ~5 s while online)?"; then
+                    if _aw_enable "$f_mon" "ENABLE_REALTIME_TICK"; then
+                        print_success "  Realtime tick enabled."
+                        if ask_yes_no "  Also enable realtime tick for Altbots?"; then
+                            _aw_enable "$f_mon" "ENABLE_ALTBOT_REALTIME_TICK" && \
+                                print_success "  Altbot realtime tick enabled."
+                        fi
+                    fi
                 fi
             fi
         fi
@@ -1895,12 +1922,20 @@ configure_ale_accountwide() {
         read -r _rep_choice
         if [ "$_rep_choice" = "2" ]; then
             f_rep_target="$f_rep_other"
-            rm -f "$f_rep_default"
-            print_success "  Removed default variant, keeping: $(basename "$f_rep_other")"
+            if rm -f "$f_rep_default" && [ ! -f "$f_rep_default" ]; then
+                print_success "  Removed default variant, keeping: $(basename "$f_rep_other")"
+            else
+                print_warning "  Could not remove default variant — both files may load. Remove manually:"
+                print_info "    $f_rep_default"
+            fi
         else
             f_rep_target="$f_rep_default"
-            rm -f "$f_rep_other"
-            print_success "  Removed custom variant, keeping: $(basename "$f_rep_default")"
+            if rm -f "$f_rep_other" && [ ! -f "$f_rep_other" ]; then
+                print_success "  Removed custom variant, keeping: $(basename "$f_rep_default")"
+            else
+                print_warning "  Could not remove custom variant — both files may load. Remove manually:"
+                print_info "    $f_rep_other"
+            fi
         fi
     elif [ -n "$f_rep_default" ]; then
         f_rep_target="$f_rep_default"

--- a/guides/wow-wotlk/manage-wow-modules.sh
+++ b/guides/wow-wotlk/manage-wow-modules.sh
@@ -1559,6 +1559,213 @@ configure_ale_bmah() {
     echo -e "${WHITE}After copying, run ${CYAN}/reload${WHITE} or restart the WoW client.${RST}"
 }
 
+# ─────────────────────────────────────────────────────────────
+# ACCOUNTWIDE CONFIGURATION
+# ─────────────────────────────────────────────────────────────
+# Patches ENABLE_* flags in the deployed Accountwide Lua scripts.
+# Each system is opt-in — all flags default to false upstream.
+# Handles the dual reputation variant by prompting which to keep
+# and removing the other so both aren't loaded simultaneously.
+#
+# Tolerant sed pattern:  s/\(local FLAG\)[[:space:]]*=[[:space:]]*false/\1 = true/
+# Verifies each patch landed; warns if the file was not changed.
+
+# Patch one ENABLE flag from false → true in a deployed Lua file.
+# Usage: _aw_enable <file> <FLAG_NAME>
+# Returns 1 and prints a warning if the patch cannot be verified.
+_aw_enable() {
+    local file="$1" flag="$2"
+    if [ ! -f "$file" ]; then
+        print_warning "  File not found: $(basename "$file") — skipping."
+        return 1
+    fi
+    sed -i "s/\(local ${flag}\)[[:space:]]*=[[:space:]]*false/\1 = true/" "$file"
+    if grep -q "local ${flag} = true" "$file"; then
+        return 0
+    fi
+    print_warning "  Could not patch ${flag} in $(basename "$file") — edit manually."
+    return 1
+}
+
+configure_ale_accountwide() {
+    local lua_dir
+    lua_dir=$(ale_lua_scripts_dir)
+    local aw_dir="$lua_dir/accountwide"
+
+    print_step "Configuring Accountwide Systems"
+
+    if [ ! -d "$aw_dir" ]; then
+        print_error "Accountwide scripts not found at: $aw_dir"
+        print_info "Install the script first from the ALE Scripts menu."
+        return 1
+    fi
+
+    echo ""
+    echo -e "${WHITE}Each system is enabled independently — answer Y to activate each one.${RST}"
+    echo -e "${WHITE}All systems are disabled by default; only enable what you want.${RST}"
+    echo -e "${DIM}The characters DB tables must be applied before starting the server.${RST}"
+    echo ""
+
+    # ── Achievements ──────────────────────────────────────────
+    local f_ach="$aw_dir/AccountAchievements.lua"
+    if [ -f "$f_ach" ]; then
+        echo -e "${GOLD}Achievements${RST}"
+        if ask_yes_no "Enable Accountwide Completed Achievements (sync earned achievements across alts)?"; then
+            _aw_enable "$f_ach" "ENABLE_ACCOUNTWIDE_COMPLETED_ACHIEVEMENTS" && \
+                print_success "  Completed Achievements enabled."
+        fi
+        if ask_yes_no "Enable Accountwide Achievement Criteria Progress (sync partial criteria)?"; then
+            _aw_enable "$f_ach" "ENABLE_ACCOUNTWIDE_CRITERIA_PROGRESS" && \
+                print_success "  Criteria Progress enabled."
+        fi
+        echo ""
+    fi
+
+    # ── Currency ─────────────────────────────────────────────
+    local f_cur="$aw_dir/AccountCurrency.lua"
+    if [ -f "$f_cur" ]; then
+        echo -e "${GOLD}Currency${RST}"
+        if ask_yes_no "Enable Accountwide Currency (shared badge/token counts across all characters)?"; then
+            _aw_enable "$f_cur" "ENABLE_ACCOUNTWIDE_CURRENCY" && \
+                print_success "  Currency enabled."
+        fi
+        echo ""
+    fi
+
+    # ── Money ────────────────────────────────────────────────
+    local f_mon="$aw_dir/AccountMoney.lua"
+    if [ -f "$f_mon" ]; then
+        echo -e "${GOLD}Money${RST}"
+        if ask_yes_no "Enable Accountwide Money (shared gold pool across all characters)?"; then
+            _aw_enable "$f_mon" "ENABLE_ACCOUNTWIDE_MONEY" && \
+                print_success "  Money enabled."
+            if ask_yes_no "  Enable real-time gold tick (syncs gold every ~5 s while online)?"; then
+                _aw_enable "$f_mon" "ENABLE_REALTIME_TICK" && \
+                    print_success "  Realtime tick enabled."
+                if ask_yes_no "  Also enable realtime tick for Altbots?"; then
+                    _aw_enable "$f_mon" "ENABLE_ALTBOT_REALTIME_TICK" && \
+                        print_success "  Altbot realtime tick enabled."
+                fi
+            fi
+        fi
+        echo ""
+    fi
+
+    # ── Mounts ───────────────────────────────────────────────
+    local f_mnt="$aw_dir/AccountMounts.lua"
+    if [ -f "$f_mnt" ]; then
+        echo -e "${GOLD}Mounts${RST}"
+        if ask_yes_no "Enable Accountwide Mounts (shared learned mounts across all characters)?"; then
+            _aw_enable "$f_mnt" "ENABLE_ACCOUNTWIDE_MOUNTS" && \
+                print_success "  Mounts enabled."
+        fi
+        echo ""
+    fi
+
+    # ── Pets ─────────────────────────────────────────────────
+    local f_pet="$aw_dir/AccountPets.lua"
+    if [ -f "$f_pet" ]; then
+        echo -e "${GOLD}Pets${RST}"
+        if ask_yes_no "Enable Accountwide Pets (shared companion pets across all characters)?"; then
+            _aw_enable "$f_pet" "ENABLE_ACCOUNTWIDE_PETS" && \
+                print_success "  Pets enabled."
+        fi
+        echo ""
+    fi
+
+    # ── Playtime ─────────────────────────────────────────────
+    local f_play="$aw_dir/AccountPlaytime.lua"
+    if [ -f "$f_play" ]; then
+        echo -e "${GOLD}Playtime${RST}"
+        if ask_yes_no "Enable Accountwide Playtime (.playtime command for total account play time)?"; then
+            _aw_enable "$f_play" "ENABLE_ACCOUNTWIDE_PLAYTIME" && \
+                print_success "  Playtime enabled."
+        fi
+        echo ""
+    fi
+
+    # ── PvP Rank ─────────────────────────────────────────────
+    local f_pvp="$aw_dir/AccountPvPRank.lua"
+    if [ -f "$f_pvp" ]; then
+        echo -e "${GOLD}PvP Rank${RST}"
+        print_info "  RUN_INIT_SEED_ON_STARTUP is true by default — this seeds existing PvP"
+        print_info "  data on first server start. Set it to false in AccountPvPRank.lua after."
+        if ask_yes_no "Enable Accountwide PvP Rank (sync honor kills, honor/arena points)?"; then
+            _aw_enable "$f_pvp" "ENABLE_ACCOUNTWIDE_PVP_RANK" && \
+                print_success "  PvP Rank enabled."
+        fi
+        echo ""
+    fi
+
+    # ── Reputation ───────────────────────────────────────────
+    # Two variants ship in the repo. Both get copied by the deploy step.
+    # Only one should be loaded — the other must be removed.
+    local f_rep_default f_rep_other f_rep_target
+    f_rep_default=$(find "$aw_dir" -name "AccountReputation*default*" 2>/dev/null | head -1)
+    f_rep_other=$(find "$aw_dir" -name "AccountReputation*.lua" ! -name "*default*" 2>/dev/null | head -1)
+
+    echo -e "${GOLD}Reputation${RST}"
+    if [ -n "$f_rep_default" ] && [ -n "$f_rep_other" ]; then
+        print_info "  Two reputation variants are deployed — only one can be active:"
+        print_info "  1) Default AC-WotLK  (standard AzerothCore factions)"
+        print_info "  2) $(basename "$f_rep_other" .lua)  (custom server modifications)"
+        printf "${WHITE}  Choose variant [1/2, default=1]: ${RST}"
+        read -r _rep_choice
+        if [ "$_rep_choice" = "2" ]; then
+            f_rep_target="$f_rep_other"
+            rm -f "$f_rep_default"
+            print_success "  Removed default variant, keeping: $(basename "$f_rep_other")"
+        else
+            f_rep_target="$f_rep_default"
+            rm -f "$f_rep_other"
+            print_success "  Removed custom variant, keeping: $(basename "$f_rep_default")"
+        fi
+    elif [ -n "$f_rep_default" ]; then
+        f_rep_target="$f_rep_default"
+    elif [ -n "$f_rep_other" ]; then
+        f_rep_target="$f_rep_other"
+    fi
+
+    if [ -n "$f_rep_target" ]; then
+        if ask_yes_no "Enable Accountwide Reputation (shared faction rep, faction-gated by Horde/Alliance)?"; then
+            _aw_enable "$f_rep_target" "ENABLE_ACCOUNTWIDE_REPUTATION" && \
+                print_success "  Reputation enabled ($(basename "$f_rep_target"))."
+        fi
+    else
+        print_warning "  No AccountReputation*.lua found in $aw_dir — skipping."
+    fi
+    echo ""
+
+    # ── Taxi Paths ───────────────────────────────────────────
+    local f_taxi="$aw_dir/AccountTaxiPaths.lua"
+    if [ -f "$f_taxi" ]; then
+        echo -e "${GOLD}Taxi Paths${RST}"
+        print_info "  Requires Aldori15's custom mod-ale fork with updated C++ bindings."
+        print_info "  Skip this unless you're running that specific fork."
+        if ask_yes_no "Enable Accountwide Taxi Paths (shared flight paths per faction)?"; then
+            _aw_enable "$f_taxi" "ENABLE_ACCOUNTWIDE_TAXI_PATHS" && \
+                print_success "  Taxi Paths enabled."
+        fi
+        echo ""
+    fi
+
+    # ── Titles ───────────────────────────────────────────────
+    local f_ttl="$aw_dir/AccountTitles.lua"
+    if [ -f "$f_ttl" ]; then
+        echo -e "${GOLD}Titles${RST}"
+        if ask_yes_no "Enable Accountwide Titles (share earned titles across all characters)?"; then
+            _aw_enable "$f_ttl" "ENABLE_ACCOUNTWIDE_TITLES" && \
+                print_success "  Titles enabled."
+        fi
+        echo ""
+    fi
+
+    echo ""
+    print_info "Accountwide configuration complete."
+    print_info "Ensure create_accountwide_tables.sql has been applied to acore_characters."
+    print_info "Restart the worldserver or run ${CYAN}.reload ale${RST} in-game to activate changes."
+}
+
 # ── Lua file deployment (per-script copy strategy) ───────────
 # Each script has its own repo layout; this handles the mapping.
 ale_deploy_lua_files() {
@@ -1723,6 +1930,12 @@ ale_script_install() {
                 fi
             else
                 print_info "Apply manually: mysql acore_characters < $clone_dir/sql/create_accountwide_tables.sql"
+            fi
+            echo ""
+            if ask_yes_no "Configure Accountwide systems (enable individual scripts) now?"; then
+                configure_ale_accountwide
+            else
+                print_info "Reconfigure anytime from the ALE Scripts menu → c on Accountwide."
             fi
             ;;
         exchangenpc)
@@ -1985,6 +2198,7 @@ menu_ale_scripts() {
                 fi
                 IFS='|' read -r key name url <<< "${available_entries[$((cnum - 1))]}"
                 case "$key" in
+                    accountwide) configure_ale_accountwide ;;
                     battlepass) configure_ale_battlepass ;;
                     paragon)    configure_ale_paragon ;;
                     bmah)       configure_ale_bmah ;;
@@ -2330,7 +2544,7 @@ main_menu() {
         printf "\n  ${GOLD}${BOLD}Server Modifications${RST}\n"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
         printf "  ${WHITE}1)${RST} Manage Modules\n"
-        printf "  ${WHITE}2)${RST} Manage ALE Lua\n"
+        printf "  ${WHITE}2)${RST} Manage ALE Lua Mods\n"
         printf "  ${WHITE}3)${RST} Configure AH Bot\n"
         printf "  ${WHITE}4)${RST} Configure ALE\n"
         printf "  ${WHITE}5)${RST} Rebuild worldserver\n"

--- a/guides/wow-wotlk/manage-wow-modules.sh
+++ b/guides/wow-wotlk/manage-wow-modules.sh
@@ -698,6 +698,8 @@ declare -a ALE_SCRIPT_REGISTRY=(
     "bmah|Black Market Auction House (MoP-style BMAH + client addon)|https://github.com/Youpeoples/Black-Market-Auction-House.git"
     "lootpet|Loot Pet (vanity pet auto-loots nearby corpses)|https://github.com/Brytenwally/Lootpet.git"
     "sod|Season of Discovery Buffs (phased leveling XP rate bonus)|https://github.com/notepadguyOfficial/acore_sod.git"
+    "sitmeanrest|Sit Means Rest (regen buff on /sit; strips on movement)|https://github.com/Brytenwally/SitMeansRest.git"
+    "unlimitedammo|Unlimited Ammo (auto-refills Hunter arrows/bullets)|https://github.com/Day36512/Acore_Lua_Unlimited_Ammo.git"
 )
 
 # Discover the actual SQL filenames in a module's sql dir.
@@ -1341,6 +1343,8 @@ ale_lua_is_deployed() {
         sod)           ls "$lua_dir"/sod*.lua &>/dev/null 2>&1 || \
                        ls "$lua_dir"/SoD*.lua &>/dev/null 2>&1 || \
                        ls "$lua_dir"/season*.lua &>/dev/null 2>&1 ;;
+        sitmeanrest)   [ -f "$lua_dir/SitMeansRest.lua" ] ;;
+        unlimitedammo) [ -f "$lua_dir/UnlimitedAmmo.lua" ] ;;
         *)             false ;;
     esac
 }
@@ -1499,6 +1503,145 @@ configure_ale_paragon() {
     echo -e "  ${CYAN}Destination:${RST} <WoW_Client>/Interface/AddOns/ParagonAnniversary/"
     echo ""
     echo -e "${DIM}The addon communicates with the server via the ParagonAnniversary protocol.${RST}"
+}
+
+# ─────────────────────────────────────────────────────────────
+# SIT MEANS REST CONFIGURATION
+# ─────────────────────────────────────────────────────────────
+
+# Generic single-expression sed patcher using a temp-file rewrite.
+# Portable across macOS (BSD sed) and Linux (GNU sed).
+# Usage: _sed_patch_config <file> <sed_expression> <description>
+_sed_patch_config() {
+    local file="$1" expr="$2" desc="${3:-config value}"
+    local _spc_tmp
+    _spc_tmp=$(mktemp "${TMPDIR:-/tmp}/ale_cfg_XXXXXX") || {
+        print_warning "  mktemp failed; cannot patch ${desc}."
+        return 1
+    }
+    if sed "$expr" "$file" > "$_spc_tmp" && [ -s "$_spc_tmp" ]; then
+        mv "$_spc_tmp" "$file"
+        return 0
+    fi
+    rm -f "$_spc_tmp"
+    print_warning "  Could not patch ${desc} in $(basename "$file") — edit manually."
+    return 1
+}
+
+configure_ale_sitmeanrest() {
+    local lua_dir
+    lua_dir=$(ale_lua_scripts_dir)
+    local deployed="$lua_dir/SitMeansRest.lua"
+
+    print_step "Sit Means Rest — Configuration"
+
+    if [ ! -f "$deployed" ]; then
+        print_error "SitMeansRest.lua not found at: $deployed"
+        print_info "Install first from the ALE Scripts menu."
+        return 1
+    fi
+
+    echo ""
+    echo -e "${WHITE}Players type ${CYAN}/sit${WHITE} out of combat to receive a regen buff.${RST}"
+    echo -e "${WHITE}Moving or standing up removes the buff immediately.${RST}"
+    echo ""
+
+    echo -e "${DIM}Current CONFIG values in SitMeansRest.lua:${RST}"
+    grep -E "DURATION|REGEN_AURA" "$deployed" | grep -v "^[[:space:]]*--" | sed 's/^/  /'
+    echo ""
+
+    # DURATION
+    printf "${WHITE}Rest duration in seconds [default 20, ENTER to keep]: ${RST}"
+    read -r _smr_dur
+    if [[ "$_smr_dur" =~ ^[0-9]+$ ]] && [ "$_smr_dur" -gt 0 ]; then
+        _sed_patch_config "$deployed" \
+            "s/\(DURATION[[:space:]]*=[[:space:]]*\)[0-9]*/\1${_smr_dur}/" \
+            "DURATION" && print_success "  DURATION → ${_smr_dur}s"
+    elif [ -n "$_smr_dur" ]; then
+        print_warning "  '${_smr_dur}' is not a valid positive integer — keeping current."
+    fi
+
+    # REGEN_AURA
+    echo ""
+    echo -e "${WHITE}Regen aura spell ID applied while resting.${RST}"
+    echo -e "${DIM}Default 25990 = Graccu's Fruitcake (restores health + mana for all levels).${RST}"
+    printf "${WHITE}Spell ID [ENTER to keep current]: ${RST}"
+    read -r _smr_aura
+    if [[ "$_smr_aura" =~ ^[0-9]+$ ]] && [ "$_smr_aura" -gt 0 ]; then
+        _sed_patch_config "$deployed" \
+            "s/\(REGEN_AURA[[:space:]]*=[[:space:]]*\)[0-9]*/\1${_smr_aura}/" \
+            "REGEN_AURA" && print_success "  REGEN_AURA → ${_smr_aura}"
+    elif [ -n "$_smr_aura" ]; then
+        print_warning "  '${_smr_aura}' is not a valid spell ID — keeping current."
+    fi
+
+    echo ""
+    print_info "No SQL required — drop-in script."
+    print_info "Reload with ${CYAN}.reload ale${RST} in-game or restart the worldserver."
+}
+
+# ─────────────────────────────────────────────────────────────
+# UNLIMITED AMMO CONFIGURATION
+# ─────────────────────────────────────────────────────────────
+
+configure_ale_unlimitedammo() {
+    local lua_dir
+    lua_dir=$(ale_lua_scripts_dir)
+    local deployed="$lua_dir/UnlimitedAmmo.lua"
+
+    print_step "Unlimited Ammo — Configuration"
+
+    if [ ! -f "$deployed" ]; then
+        print_error "UnlimitedAmmo.lua not found at: $deployed"
+        print_info "Install first from the ALE Scripts menu."
+        return 1
+    fi
+
+    echo ""
+    echo -e "${WHITE}Auto-refills arrows/bullets for Hunters when ammo drops below the threshold.${RST}"
+    echo -e "${WHITE}Supports all ammo types for bows, guns, and crossbows.${RST}"
+    echo -e "${GOLD}The script ships with ENABLED = false — it must be enabled to function.${RST}"
+    echo ""
+
+    echo -e "${DIM}Current configuration in UnlimitedAmmo.lua:${RST}"
+    grep -E "^UnlimitedAmmoNamespace\.(ENABLED|MAX_AMMO|MIN_AMMO)" "$deployed" | sed 's/^/  /'
+    echo ""
+
+    # ENABLED
+    if ask_yes_no "Enable Unlimited Ammo by default (set ENABLED = true in the file)?"; then
+        _sed_patch_config "$deployed" \
+            "s/\(UnlimitedAmmoNamespace\.ENABLED[[:space:]]*=[[:space:]]*\)false/\1true/" \
+            "ENABLED" && print_success "  ENABLED → true"
+    fi
+
+    # MAX_AMMO
+    echo ""
+    printf "${WHITE}Maximum ammo to maintain [default 1000, ENTER to keep]: ${RST}"
+    read -r _ua_max
+    if [[ "$_ua_max" =~ ^[0-9]+$ ]] && [ "$_ua_max" -gt 0 ]; then
+        _sed_patch_config "$deployed" \
+            "s/\(UnlimitedAmmoNamespace\.MAX_AMMO[[:space:]]*=[[:space:]]*\)[0-9]*/\1${_ua_max}/" \
+            "MAX_AMMO" && print_success "  MAX_AMMO → ${_ua_max}"
+    elif [ -n "$_ua_max" ]; then
+        print_warning "  '${_ua_max}' is not a valid positive integer — keeping current."
+    fi
+
+    # MIN_AMMO_THRESHOLD
+    echo ""
+    printf "${WHITE}Refill threshold — top up when ammo drops below this [default 52, ENTER to keep]: ${RST}"
+    read -r _ua_min
+    if [[ "$_ua_min" =~ ^[0-9]+$ ]] && [ "$_ua_min" -gt 0 ]; then
+        _sed_patch_config "$deployed" \
+            "s/\(UnlimitedAmmoNamespace\.MIN_AMMO_THRESHOLD[[:space:]]*=[[:space:]]*\)[0-9]*/\1${_ua_min}/" \
+            "MIN_AMMO_THRESHOLD" && print_success "  MIN_AMMO_THRESHOLD → ${_ua_min}"
+    elif [ -n "$_ua_min" ]; then
+        print_warning "  '${_ua_min}' is not a valid positive integer — keeping current."
+    fi
+
+    echo ""
+    print_info "GM command ${CYAN}.ua${RST} enables the script at runtime (resets to file default on restart)."
+    print_info "No SQL required — drop-in script."
+    print_info "Reload with ${CYAN}.reload ale${RST} in-game or restart the worldserver."
 }
 
 # Return 0 if $1 is already in the remaining args; used for dedup in
@@ -2087,6 +2230,24 @@ ale_deploy_lua_files() {
                 print_warning "No .lua files found in clone root — check $clone_dir"
             fi
             ;;
+        sitmeanrest)
+            if [ -f "$clone_dir/SitMeansRest.lua" ]; then
+                cp "$clone_dir/SitMeansRest.lua" "$lua_dir/" && \
+                    print_success "Deployed SitMeansRest.lua → lua_scripts/" || \
+                    print_warning "Copy failed"
+            else
+                print_warning "SitMeansRest.lua not found in $clone_dir"
+            fi
+            ;;
+        unlimitedammo)
+            if [ -f "$clone_dir/UnlimitedAmmo.lua" ]; then
+                cp "$clone_dir/UnlimitedAmmo.lua" "$lua_dir/" && \
+                    print_success "Deployed UnlimitedAmmo.lua → lua_scripts/" || \
+                    print_warning "Copy failed"
+            else
+                print_warning "UnlimitedAmmo.lua not found in $clone_dir"
+            fi
+            ;;
         *)
             if cp "$clone_dir"/*.lua "$lua_dir/" 2>/dev/null; then
                 print_success "Deployed → lua_scripts/ (generic copy)"
@@ -2201,6 +2362,24 @@ ale_script_install() {
                 configure_ale_bmah
             fi
             ;;
+        sitmeanrest)
+            echo ""
+            if ask_yes_no "Configure Sit Means Rest (duration, regen spell) now?"; then
+                configure_ale_sitmeanrest
+            else
+                print_info "Reconfigure anytime from the ALE Scripts menu → c on Sit Means Rest."
+            fi
+            ;;
+        unlimitedammo)
+            echo ""
+            print_warning "The script ships with ENABLED = false — configure to activate it."
+            if ask_yes_no "Configure Unlimited Ammo (enable + ammo thresholds) now?"; then
+                configure_ale_unlimitedammo
+            else
+                print_info "Reconfigure anytime from the ALE Scripts menu → c on Unlimited Ammo."
+                print_info "Or use the in-game GM command ${CYAN}.ua${RST} to enable at runtime."
+            fi
+            ;;
     esac
 
     echo ""
@@ -2247,6 +2426,8 @@ ale_script_remove() {
         paragon)     deployed_hint="$lua_dir/paragon/" ;;
         bmah)        deployed_hint="$lua_dir/bmah_server.lua" ;;
         lootpet)     deployed_hint="$lua_dir/LootPet.lua" ;;
+        sitmeanrest)  deployed_hint="$lua_dir/SitMeansRest.lua" ;;
+        unlimitedammo) deployed_hint="$lua_dir/UnlimitedAmmo.lua" ;;
         *)           deployed_hint="$lua_dir/ (search for files from this script)" ;;
     esac
 
@@ -2260,6 +2441,8 @@ ale_script_remove() {
             paragon)     rm -rf "$lua_dir/paragon" ;;
             bmah)        rm -f  "$lua_dir/bmah_server.lua" ;;
             lootpet)     rm -f  "$lua_dir/LootPet.lua" ;;
+            sitmeanrest)   rm -f "$lua_dir/SitMeansRest.lua" ;;
+            unlimitedammo) rm -f "$lua_dir/UnlimitedAmmo.lua" ;;
             levelupreward|exchangenpc|sod)
                 local f
                 for f in "${generic_deployed_files[@]}"; do
@@ -2419,6 +2602,8 @@ menu_ale_scripts() {
                     battlepass) configure_ale_battlepass ;;
                     paragon)    configure_ale_paragon ;;
                     bmah)       configure_ale_bmah ;;
+                    sitmeanrest)   configure_ale_sitmeanrest ;;
+                    unlimitedammo) configure_ale_unlimitedammo ;;
                     *) print_info "No dedicated reconfigure for $name." ;;
                 esac
                 press_enter

--- a/guides/wow-wotlk/manage-wow-modules.sh
+++ b/guides/wow-wotlk/manage-wow-modules.sh
@@ -1508,46 +1508,228 @@ configure_ale_bmah() {
     lua_dir=$(ale_lua_scripts_dir)
     local deployed_file="$lua_dir/bmah_server.lua"
 
-    print_step "Black Market AH — NPC Configuration"
+    # Parallel arrays — index-aligned (Bash 3 compatible; no associative arrays).
+    local -a BNPC_IDS=(   45281   2496  11183   8921   3162  14740  11504  10834)
+    local -a BNPC_NAMES=( "Slytter"
+                          "Krazek"
+                          "Dirge Quikcleave"
+                          "Ravenholdt Guards"
+                          "Slyres Notrash"
+                          "Stonard Smuggler"
+                          "Baron Vardus"
+                          "Count Remo" )
+
+    # Return 0 if $1 is already in the remaining args; used for dedup without
+    # associative arrays so this stays Bash 3 / macOS compatible.
+    _bmah_in_list() {
+        local needle="$1"; shift
+        local item
+        for item in "$@"; do [ "$item" = "$needle" ] && return 0; done
+        return 1
+    }
+
+    print_step "Black Market AH — NPC Vendor Configuration"
     echo ""
-    echo -e "${WHITE}The BMAH needs a gossip-enabled NPC in-world to act as the vendor.${RST}"
-    echo -e "${WHITE}Its entry ID(s) must be added to the ${CYAN}BMAH_VENDOR_NPCs${WHITE} list in bmah_server.lua.${RST}"
-    echo -e "${DIM}The list format is: local BMAH_VENDOR_NPCs = { 2069430, 90001, ... }${RST}"
+    echo -e "${WHITE}The BMAH opens when a player interacts with any gossip-enabled NPC whose${RST}"
+    echo -e "${WHITE}entry ID is listed in ${CYAN}BMAH_VENDOR_NPCs${WHITE} inside bmah_server.lua.${RST}"
     echo ""
 
-    if [ -f "$deployed_file" ]; then
-        printf "${WHITE}Enter your gossip NPC entry ID to add [90001]: ${RST}"
-        read -r npc_id
-        npc_id=${npc_id:-90001}
-        if [[ "$npc_id" =~ ^[0-9]+$ ]]; then
-            # Append the new ID into the existing brace-enclosed list
-            if sed -i "s/local BMAH_VENDOR_NPCs = {/local BMAH_VENDOR_NPCs = { $npc_id,/" \
-                "$deployed_file" 2>/dev/null && \
-               grep -q "$npc_id" "$deployed_file"; then
-                print_success "Added NPC $npc_id to BMAH_VENDOR_NPCs list."
-            else
-                print_warning "Auto-patch failed or NPC already present. Edit manually:"
-                print_info "  File: $deployed_file"
-                print_info "  Add ${CYAN}$npc_id${RST} to: local BMAH_VENDOR_NPCs = { ... }"
-            fi
-        else
-            print_warning "Invalid entry ID — edit $deployed_file manually."
-        fi
-    else
-        print_warning "bmah_server.lua not found at expected path:"
+    # ── Missing file guard ────────────────────────────────────
+    if [ ! -f "$deployed_file" ]; then
+        print_warning "bmah_server.lua not found at:"
         print_info "  $deployed_file"
-        print_info "Deploy the script first, then edit BMAH_VENDOR_NPCs at the top of the file."
+        print_info "Deploy the script first (install from the ALE Scripts menu), then reconfigure."
+        echo ""
+        print_step "Black Market AH — Client Addon Required"
+        echo -e "${WHITE}BMAH includes a WoW addon that recreates the Mists of Pandaria BMAH UI.${RST}"
+        echo ""
+        echo -e "${WHITE}${BOLD}Copy this folder to your WoW client's AddOns directory:${RST}"
+        echo -e "  ${CYAN}Source:${RST}      $clone_dir/BlackMarketUI/"
+        echo -e "  ${CYAN}Destination:${RST} <WoW_Client>/Interface/AddOns/BlackMarketUI/"
+        echo ""
+        echo -e "${WHITE}After copying, run ${CYAN}/reload${WHITE} or restart the WoW client.${RST}"
+        return 1
     fi
 
+    # ── Show current IDs extracted from the file ──────────────
+    local current_ids
+    current_ids=$(awk '
+        /local BMAH_VENDOR_NPCs[[:space:]]*=/ { found=1 }
+        found {
+            tmp = $0
+            gsub(/--[^\n]*/, "", tmp)   # strip line comments
+            while (match(tmp, /[0-9]+/)) {
+                print substr(tmp, RSTART, RLENGTH)
+                tmp = substr(tmp, RSTART + RLENGTH)
+            }
+        }
+        found && /\}/ { exit }
+    ' "$deployed_file" | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+
+    if [ -n "$current_ids" ]; then
+        echo -e "${WHITE}Currently configured NPC IDs:${RST} ${CYAN}${current_ids}${RST}"
+        echo ""
+    fi
+
+    # ── NPC selection menu ────────────────────────────────────
+    echo -e "  ${GOLD}──  Suggested Vendor NPCs  ──────────────────────────────────────────────${RST}"
     echo ""
-    echo -e "${WHITE}Additional config (in bmah_server.lua):${RST}"
-    printf "  ${CYAN}%-22s${RST} ${WHITE}%s${RST}\n" "common_price"    "Starting bid for common items"
-    printf "  ${CYAN}%-22s${RST} ${WHITE}%s${RST}\n" "rare_price"      "Starting bid for rare items"
-    printf "  ${CYAN}%-22s${RST} ${WHITE}%s${RST}\n" "ultra_rare_price" "Starting bid for ultra-rare items"
+    echo -e "  ${DIM}Shady / Neutral Factions${RST}"
+    printf "  ${WHITE}%2s)${RST} %-20s ${CYAN}(%5s)${RST}  %s\n" \
+        1 "Slytter"          45281 "Goblin rogue in Booty Bay; coastal smuggler theme" \
+        2 "Krazek"            2496 "Booty Bay goblin with shady business connections" \
+        3 "Dirge Quikcleave" 11183 "Gadgetzan butcher; deals in rare exotic goods"
+    echo ""
+    echo -e "  ${DIM}Criminal Underworld / Rogue Themes${RST}"
+    printf "  ${WHITE}%2s)${RST} %-20s ${CYAN}(%5s)${RST}  %s\n" \
+        4 "Ravenholdt Guards"  8921 "Ravenholdt Manor; gate BMAH behind rogue faction" \
+        5 "Slyres Notrash"     3162 "Dalaran Underbelly; illicit underground zone" \
+        6 "Stonard Smuggler"  14740 "Out-of-the-way NPC; hidden underground trade network"
+    echo ""
+    echo -e "  ${DIM}High Society / Wealthy Elites${RST}"
+    printf "  ${WHITE}%2s)${RST} %-20s ${CYAN}(%5s)${RST}  %s\n" \
+        7 "Baron Vardus"      11504 "Corrupt noble; wealthy elites buying illegal artifacts" \
+        8 "Count Remo"        10834 "High-standing noble; hidden high-end auction ring"
+    echo ""
+    echo -e "  ${GOLD}────────────────────────────────────────────────────────────────────────${RST}"
+    echo ""
+    printf "${WHITE}Select NPCs by number (e.g. 1 3 7), or \"all\". Leave blank to keep current IDs: ${RST}"
+    read -r _bsel
+
+    # ── Parse numbered selection ──────────────────────────────
+    local -a sel_ids=()
+    local -a sel_names=()
+
+    if [[ "${_bsel,,}" == "all" ]]; then
+        sel_ids=("${BNPC_IDS[@]}")
+        sel_names=("${BNPC_NAMES[@]}")
+    elif [ -n "$_bsel" ]; then
+        local tok
+        for tok in $_bsel; do
+            if [[ "$tok" =~ ^[0-9]+$ ]] && \
+               [ "$tok" -ge 1 ] && [ "$tok" -le "${#BNPC_IDS[@]}" ]; then
+                sel_ids+=("${BNPC_IDS[$((tok - 1))]}")
+                sel_names+=("${BNPC_NAMES[$((tok - 1))]}")
+            else
+                print_warning "  Skipping invalid selection: $tok (valid range: 1-${#BNPC_IDS[@]})"
+            fi
+        done
+    fi
+
+    # ── Optional extra custom NPC ID ─────────────────────────
+    echo ""
+    printf "${WHITE}Add a custom NPC entry ID? (leave blank to skip): ${RST}"
+    read -r _bcustom
+    if [[ "$_bcustom" =~ ^[0-9]+$ ]]; then
+        sel_ids+=("$_bcustom")
+        sel_names+=("Custom NPC")
+    elif [ -n "$_bcustom" ]; then
+        print_warning "  '$_bcustom' is not a valid numeric entry ID — skipping."
+    fi
+
+    # ── Decide add vs replace ─────────────────────────────────
+    local _bmode="add"
+    if [ "${#sel_ids[@]}" -gt 0 ] && [ -n "$current_ids" ]; then
+        echo ""
+        printf "${WHITE}Apply as: [a] Add to existing list  [r] Replace list entirely [a]: ${RST}"
+        read -r _bmode_raw
+        [ "${_bmode_raw,,}" = "r" ] && _bmode="replace"
+    fi
+
+    # ── Build final deduped ID list ───────────────────────────
+    local -a final_ids=()
+
+    if [ "$_bmode" = "add" ] && [ -n "$current_ids" ]; then
+        local id
+        for id in $current_ids; do
+            [[ "$id" =~ ^[0-9]+$ ]] && final_ids+=("$id")
+        done
+    fi
+
+    local i
+    for (( i=0; i<${#sel_ids[@]}; i++ )); do
+        local sid="${sel_ids[$i]}"
+        if ! _bmah_in_list "$sid" "${final_ids[@]}"; then
+            final_ids+=("$sid")
+        fi
+    done
+
+    # ── Patch the file (or skip if nothing to change) ─────────
+    if [ "${#final_ids[@]}" -eq 0 ] && [ -z "$_bsel" ] && [ -z "$_bcustom" ]; then
+        print_info "No changes to NPC list."
+    elif [ "${#final_ids[@]}" -eq 0 ]; then
+        print_warning "Resulting NPC list is empty — skipping file patch."
+        print_info "Add at least one NPC ID, or edit ${deployed_file} manually."
+    else
+        # Write one NPC entry per line to a temp file; awk reads it with
+        # getline so embedded newlines never hit the -v variable limit.
+        local ids_file tmpfile j label
+        ids_file=$(mktemp "${TMPDIR:-/tmp}/bmah_ids_XXXXXX")
+        tmpfile=$(mktemp "${TMPDIR:-/tmp}/bmah_server_XXXXXX.lua")
+        for id in "${final_ids[@]}"; do
+            label=""
+            for (( j=0; j<${#BNPC_IDS[@]}; j++ )); do
+                [ "${BNPC_IDS[$j]}" = "$id" ] && label=" --${BNPC_NAMES[$j]}" && break
+            done
+            printf "  %s,%s\n" "$id" "$label" >> "$ids_file"
+        done
+
+        # awk replaces the BMAH_VENDOR_NPCs block — handles both inline and
+        # multiline forms.  Exits 1 if the pattern was never matched so we
+        # detect a failed patch before overwriting the live file.
+        awk -v ids_file="$ids_file" '
+            /local BMAH_VENDOR_NPCs[[:space:]]*=/ {
+                print "local BMAH_VENDOR_NPCs = {"
+                while ((getline line < ids_file) > 0) { print line }
+                close(ids_file)
+                replaced++
+                if (/\}/) { print "}"; next }   # inline closing brace on same line
+                skip = 1
+                next
+            }
+            skip {
+                if (/^[[:space:]]*\}/) { print "}"; skip = 0 }
+                next
+            }
+            { print }
+            END { if (replaced == 0) exit 1 }
+        ' "$deployed_file" > "$tmpfile"
+        local awk_rc=$?
+        rm -f "$ids_file"
+
+        if [ $awk_rc -eq 0 ] && [ -s "$tmpfile" ]; then
+            mv "$tmpfile" "$deployed_file"
+            echo ""
+            print_success "BMAH_VENDOR_NPCs updated with ${#final_ids[@]} NPC(s):"
+            for id in "${final_ids[@]}"; do
+                label=""
+                for (( j=0; j<${#BNPC_IDS[@]}; j++ )); do
+                    [ "${BNPC_IDS[$j]}" = "$id" ] && label=" — ${BNPC_NAMES[$j]}" && break
+                done
+                print_info "  • ${id}${label}"
+            done
+        else
+            rm -f "$tmpfile"
+            print_error "Could not locate BMAH_VENDOR_NPCs block in bmah_server.lua."
+            print_info "Edit manually: $deployed_file"
+            print_info "Look for: local BMAH_VENDOR_NPCs = { ... } and add your IDs."
+        fi
+    fi
+
+    # ── Pricing & timing reference ────────────────────────────
+    echo ""
+    echo -e "${WHITE}Other configurable values (edit directly in bmah_server.lua):${RST}"
+    echo ""
+    printf "  ${CYAN}%-32s${RST} ${WHITE}%s${RST}\n" \
+        "common/rare/ultraRare_*_price"  "Starting bids per item category and tier" \
+        "FillRateCommon / Rare / Ultra"  "Rarity probabilities (default: 85%% / 10%% / 5%%)" \
+        "MinBidIncrementG"               "Minimum gold increment per bid (default: 10g)" \
+        "AutoFillChance"                 "Chance to restock when empty (default: 0.50)" \
+        "PotentialDurations"             "Auction lengths in minutes (default: 720, 1440)"
     echo ""
     echo -e "${WHITE}GM commands: ${CYAN}/bmah flush${WHITE} (expire all) | ${CYAN}/bmah fill${WHITE} (refill immediately)${RST}"
 
-    # Client addon
+    # ── Client addon ─────────────────────────────────────────
     echo ""
     print_step "Black Market AH — Client Addon Required"
     echo -e "${WHITE}BMAH includes a WoW addon that recreates the Mists of Pandaria BMAH UI.${RST}"
@@ -1708,7 +1890,7 @@ configure_ale_accountwide() {
     if [ -n "$f_rep_default" ] && [ -n "$f_rep_other" ]; then
         print_info "  Two reputation variants are deployed — only one can be active:"
         print_info "  1) Default AC-WotLK  (standard AzerothCore factions)"
-        print_info "  2) $(basename "$f_rep_other" .lua)  (custom server modifications)"
+        print_info "  2) $(basename "$f_rep_other" .lua)  (custom server modifications, Offline doesn't use this.)"
         printf "${WHITE}  Choose variant [1/2, default=1]: ${RST}"
         read -r _rep_choice
         if [ "$_rep_choice" = "2" ]; then

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -52,6 +52,9 @@ GOLD='\033[38;5;220m'; DIM='\033[2m'
 #   Row  15+  : menu content
 MENU_START_ROW=15
 MENU_INPUT_ROW=24
+_TERM_LINES=24
+_TERM_COLS=80
+_RESIZE_NEEDED=false
 ANIM_PID=""
 _IN_ALT_SCREEN=false
 
@@ -107,15 +110,35 @@ stop_logo_animation() {
     fi
 }
 
+_get_term_size() {
+    _TERM_LINES=$(tput lines 2>/dev/null || echo 24)
+    _TERM_COLS=$(tput cols  2>/dev/null || echo 80)
+}
+
+# Lightweight SIGWINCH handler — keeps the trap body minimal to avoid
+# interleaved output while other code may be printing.
+# Full logo/header redraw is deferred to the next menu loop iteration.
+_handle_resize() {
+    _RESIZE_NEEDED=true
+    _get_term_size
+    if [ "${_TERM_COLS:-80}" -ge 80 ]; then
+        MENU_START_ROW=15
+    else
+        MENU_START_ROW=6
+    fi
+    # Update scroll region immediately so new output stays below the header.
+    printf '\033[%d;%dr' "$MENU_START_ROW" "$_TERM_LINES" 2>/dev/null || true
+}
+
 # Read a menu choice into global _MENU_INPUT.
 # Positions the cursor at the given row; backspace/delete work via the terminal's line editing.
 _MENU_INPUT=""
 _read_menu_input() {
-    local _input_row=${1:-$MENU_INPUT_ROW}
+    local _input_row=${1:-$(( ${_TERM_LINES:-24} - 1 ))}
     _MENU_INPUT=""
     printf '\033[%d;3H\033[K' "$_input_row"
     printf "${WHITE}Choice: ${RST}"
-    read -r _MENU_INPUT
+    read -r _MENU_INPUT || { [ -z "$_MENU_INPUT" ] && return 2; }
 }
 
 _screen_int_handler() {
@@ -129,20 +152,31 @@ _screen_int_handler() {
 # Draw the logo + subtitle bar statically (full clear + redraw).
 _draw_logo_static() {
     printf '\033[1;1H\033[J'
-    printf '\n'
-    printf '\033[2m%s\033[K\033[0m\n'       "$_LOGO_L0"
-    printf '\033[38;5;220m%s\033[K\033[0m\n' "$_LOGO_L1"
-    printf '\033[38;5;220m%s\033[K\033[0m\n' "$_LOGO_L2"
-    printf '\033[38;5;214m%s\033[K\033[0m\n' "$_LOGO_L3"
-    printf '\033[38;5;214m%s\033[K\033[0m\n' "$_LOGO_L4"
-    printf '\033[38;5;208m%s\033[K\033[0m\n' "$_LOGO_L5"
-    printf '\033[38;5;202m%s\033[K\033[0m\n' "$_LOGO_L6"
-    printf '\033[38;5;196m%s\033[K\033[0m\n' "$_LOGO_L7"
-    printf '\n'
-    printf '\033[38;5;220m ══════════════════════════════════════════════════════════════════════════════════\033[K\033[0m\n'
-    printf '   \033[2m⚔︎ WotLK Mod and Server Manager\033[0m  ✦  \033[2mv%s\033[0m\033[K\n' "$MANAGER_VERSION"
-    printf '\033[38;5;220m ══════════════════════════════════════════════════════════════════════════════════\033[K\033[0m\n'
-    printf '\n'
+    tput rmam 2>/dev/null || true  # disable line wrap — logo/bars truncate cleanly on narrow terminals
+    if [ "${_TERM_COLS:-80}" -ge 80 ]; then
+        printf '\n'
+        printf '\033[2m%s\033[K\033[0m\n'       "$_LOGO_L0"
+        printf '\033[38;5;220m%s\033[K\033[0m\n' "$_LOGO_L1"
+        printf '\033[38;5;220m%s\033[K\033[0m\n' "$_LOGO_L2"
+        printf '\033[38;5;214m%s\033[K\033[0m\n' "$_LOGO_L3"
+        printf '\033[38;5;214m%s\033[K\033[0m\n' "$_LOGO_L4"
+        printf '\033[38;5;208m%s\033[K\033[0m\n' "$_LOGO_L5"
+        printf '\033[38;5;202m%s\033[K\033[0m\n' "$_LOGO_L6"
+        printf '\033[38;5;196m%s\033[K\033[0m\n' "$_LOGO_L7"
+        printf '\n'
+        printf '\033[38;5;220m ══════════════════════════════════════════════════════════════════════════════════\033[K\033[0m\n'
+        printf '   \033[2m⚔︎ WotLK Mod and Server Manager\033[0m  ✦  \033[2mv%s\033[0m\033[K\n' "$MANAGER_VERSION"
+        printf '\033[38;5;220m ══════════════════════════════════════════════════════════════════════════════════\033[K\033[0m\n'
+        printf '\n'
+    else
+        # Compact header for narrow terminals (< 80 cols) — fits in 5 rows (MENU_START_ROW=6).
+        printf '\n'
+        printf '\033[38;5;220m ══ Dad'"'"'s MMO Lab ══\033[K\033[0m\n'
+        printf '   \033[2m⚔︎ WoW Mgr\033[0m  v%s\033[K\n' "$MANAGER_VERSION"
+        printf '\033[38;5;220m ═══════════════════\033[K\033[0m\n'
+        printf '\n'
+    fi
+    tput smam 2>/dev/null || true  # re-enable line wrap
 }
 
 # Enter alt screen buffer, set scroll region, draw static logo.
@@ -152,9 +186,13 @@ _setup_screen() {
         printf '\033[?1049h'
         _IN_ALT_SCREEN=true
     fi
-    local tlines
-    tlines=$(tput lines 2>/dev/null || echo 25)
-    printf '\033[%d;%dr' "$MENU_START_ROW" "$tlines"
+    _get_term_size
+    if [ "${_TERM_COLS:-80}" -ge 80 ]; then
+        MENU_START_ROW=15
+    else
+        MENU_START_ROW=6
+    fi
+    printf '\033[%d;%dr' "$MENU_START_ROW" "$_TERM_LINES"
     printf '\033[?25l'
     _draw_logo_static
     printf '\033[?25h'
@@ -164,8 +202,9 @@ _setup_screen() {
 # then freezes the logo statically for the rest of the session.
 start_logo_animation() {
     _setup_screen
-    trap 'printf "\033[r\033[?1049l\033[?25h"' EXIT
+    trap 'tput smam 2>/dev/null || true; printf "\033[r\033[?1049l\033[?25h"' EXIT
     trap '_screen_int_handler' INT TERM
+    trap '_handle_resize' WINCH
 
     # Start animation subprocess
     _logo_anim_loop \
@@ -192,7 +231,9 @@ start_logo_animation() {
 with_full_screen() {
     printf '\033[r\033[H\033[2J\033[?25h'
     _ALLOW_INT_EXIT=false
+    trap '' WINCH  # suppress resize redraws while a full-screen child is running
     "$@"
+    trap '_handle_resize' WINCH
     _ALLOW_INT_EXIT=true
     _setup_screen
     printf '\033[%d;1H\033[J' "$MENU_START_ROW"
@@ -4294,7 +4335,11 @@ show_about() {
 menu_ale_scripts() {
     local page_start=0
     while true; do
-        local tlines; tlines=$(tput lines 2>/dev/null || echo 24)
+        if [ "$_RESIZE_NEEDED" = true ]; then
+            _RESIZE_NEEDED=false
+            _setup_screen
+        fi
+        local tlines; tlines=$_TERM_LINES
 
         # Clear menu area
         printf '\033[%d;1H\033[J' "$MENU_START_ROW"
@@ -4364,9 +4409,11 @@ menu_ale_scripts() {
             [ "$current_page" -lt "$total_pages" ]  && nav+="   ${WHITE}> next${RST}"
             printf "%b\n" "$nav"
         fi
-        printf "  ${WHITE}i<nums>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}?<num>${RST} About   ${WHITE}ENTER${RST} Back\n"
+        local page_hint=""
+        [ "$total_pages" -gt 1 ] && page_hint="   ${WHITE}< >${RST} Page"
+        printf "  ${WHITE}i<nums>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}?<num>${RST} About${page_hint}   ${WHITE}ENTER${RST} Back\n"
 
-        _read_menu_input "$(( tlines - 1 ))"
+        _read_menu_input "$(( tlines - 1 ))" || continue
         local raw_choice="$_MENU_INPUT"
 
         [ -z "$raw_choice" ] && return
@@ -4471,7 +4518,11 @@ menu_ale_scripts() {
 menu_modules() {
     local page_start=0
     while true; do
-        local tlines; tlines=$(tput lines 2>/dev/null || echo 24)
+        if [ "$_RESIZE_NEEDED" = true ]; then
+            _RESIZE_NEEDED=false
+            _setup_screen
+        fi
+        local tlines; tlines=$_TERM_LINES
 
         # Build full registry list (always done fresh for current status)
         local -a available_entries=()
@@ -4566,9 +4617,11 @@ menu_modules() {
             [ "$current_page" -lt "$total_pages" ]  && nav+="   ${WHITE}> next${RST}"
             printf "%b\n" "$nav"
         fi
-        printf "  ${WHITE}i <nums>${RST} Install   ${WHITE}r <num>${RST} Remove   ${WHITE}c <num>${RST} Config   ${WHITE}?<num>${RST} About   ${WHITE}ENTER${RST} Back\n"
+        local page_hint=""
+        [ "$total_pages" -gt 1 ] && page_hint="   ${WHITE}< >${RST} Page"
+        printf "  ${WHITE}i <nums>${RST} Install   ${WHITE}r <num>${RST} Remove   ${WHITE}c <num>${RST} Config   ${WHITE}?<num>${RST} About${page_hint}   ${WHITE}ENTER${RST} Back\n"
 
-        _read_menu_input "$(( tlines - 1 ))"
+        _read_menu_input "$(( tlines - 1 ))" || continue
         local raw_choice="$_MENU_INPUT"
 
         [ -z "$raw_choice" ] && return
@@ -4950,7 +5003,11 @@ _module_conf_hints() {
 menu_module_management() {
     local page_start=0
     while true; do
-        local tlines; tlines=$(tput lines 2>/dev/null || echo 24)
+        if [ "$_RESIZE_NEEDED" = true ]; then
+            _RESIZE_NEEDED=false
+            _setup_screen
+        fi
+        local tlines; tlines=$_TERM_LINES
         printf '\033[%d;1H\033[J' "$MENU_START_ROW"
 
         local -a available_entries=()
@@ -4990,9 +5047,11 @@ menu_module_management() {
             [ "$current_page" -lt "$total_pages" ] && nav+="   ${WHITE}> next${RST}"
             printf "%b\n" "$nav"
         fi
-        printf "  ${WHITE}a<num>${RST} Activate conf   ${WHITE}e<num>${RST} Edit conf   ${WHITE}r<num>${RST} Reset defaults   ${WHITE}?<num>${RST} Help   ${WHITE}ENTER${RST} Back\n"
+        local page_hint=""
+        [ "$total_pages" -gt 1 ] && page_hint="   ${WHITE}< >${RST} Page"
+        printf "  ${WHITE}a<num>${RST} Activate conf   ${WHITE}e<num>${RST} Edit conf   ${WHITE}r<num>${RST} Reset defaults   ${WHITE}?<num>${RST} Help${page_hint}   ${WHITE}ENTER${RST} Back\n"
 
-        _read_menu_input "$(( tlines - 1 ))"
+        _read_menu_input "$(( tlines - 1 ))" || continue
         local raw_choice="$_MENU_INPUT"
         [ -z "$raw_choice" ] && return
 
@@ -5239,7 +5298,11 @@ menu_sql_mods() {
     sqlmod_init
     local page_start=0
     while true; do
-        local tlines; tlines=$(tput lines 2>/dev/null || echo 24)
+        if [ "$_RESIZE_NEEDED" = true ]; then
+            _RESIZE_NEEDED=false
+            _setup_screen
+        fi
+        local tlines; tlines=$_TERM_LINES
         printf '\033[%d;1H\033[J' "$MENU_START_ROW"
 
         local -a available_entries=()
@@ -5289,9 +5352,11 @@ menu_sql_mods() {
             [ "$current_page" -lt "$total_pages" ]  && nav+="   ${WHITE}> next${RST}"
             printf "%b\n" "$nav"
         fi
-        printf "  ${WHITE}i<num>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}?<num>${RST} About   ${WHITE}ENTER${RST} Back\n"
+        local page_hint=""
+        [ "$total_pages" -gt 1 ] && page_hint="   ${WHITE}< >${RST} Page"
+        printf "  ${WHITE}i<num>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}?<num>${RST} About${page_hint}   ${WHITE}ENTER${RST} Back\n"
 
-        _read_menu_input "$(( tlines - 1 ))"
+        _read_menu_input "$(( tlines - 1 ))" || continue
         local raw_choice="$_MENU_INPUT"
         [ -z "$raw_choice" ] && return
 
@@ -5364,6 +5429,10 @@ menu_sql_mods() {
 # ── Server Maintenance submenu ───────────────────────────────
 menu_server_maintenance() {
     while true; do
+        if [ "$_RESIZE_NEEDED" = true ]; then
+            _RESIZE_NEEDED=false
+            _setup_screen
+        fi
         printf '\033[%d;1H\033[J' "$MENU_START_ROW"
         printf "  ${GOLD}${BOLD}Server Maintenance${RST}\n"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
@@ -5373,8 +5442,8 @@ menu_server_maintenance() {
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
         printf "  ${DIM}  [ENTER] Back${RST}\n"
 
-        local _tlines; _tlines=$(tput lines 2>/dev/null || echo 24)
-        _read_menu_input "$(( _tlines - 1 ))"
+        local _tlines; _tlines=$_TERM_LINES
+        _read_menu_input "$(( _tlines - 1 ))" || continue
         local choice="${_MENU_INPUT,,}"
 
         case "$choice" in
@@ -5515,6 +5584,10 @@ _maintenance_import() {
 
 main_menu() {
     while true; do
+        if [ "$_RESIZE_NEEDED" = true ]; then
+            _RESIZE_NEEDED=false
+            _setup_screen
+        fi
         refresh_container_names
         local state_str build_str
         if container_running "$WORLD_CONTAINER"; then
@@ -5556,9 +5629,9 @@ main_menu() {
         printf "  ${GOLD} Q)${RST} Quit\n"
 
         # Input at second-to-last terminal row so it's always visible
-        local _tlines; _tlines=$(tput lines 2>/dev/null || echo 24)
+        local _tlines; _tlines=$_TERM_LINES
         local _irow=$(( _tlines - 1 ))
-        _read_menu_input "$_irow"
+        _read_menu_input "$_irow" || continue
         local choice="${_MENU_INPUT,,}"
 
         case "$choice" in
@@ -5581,10 +5654,6 @@ main_menu() {
         esac
     done
 }
-
-# ─────────────────────────────────────────────────────────────
-# ENTRYPOINT
-# ─────────────────────────────────────────────────────────────
 
 # Scan all three mod registries and silently populate ingame-commands.txt
 # for any mods already installed. Handles upgrades from older manager versions
@@ -5621,6 +5690,11 @@ sync_ingame_commands_for_installed() {
     [ "$count" -gt 0 ] && \
         print_info "📋 In-game commands reference synced for $count installed mod(s): $INGAME_COMMANDS_FILE"
 }
+
+# ─────────────────────────────────────────────────────────────
+# ENTRYPOINT
+# ─────────────────────────────────────────────────────────────
+
 
 start_logo_animation
 detect_install

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -236,7 +236,7 @@ press_enter() {
 #   Shows GM commands (in-game and console forms) to spawn an NPC
 #   in Stormwind and Orgrimmar.  Uses per-entry deterministic offsets
 #   so repeated calls never stack NPCs on the same coordinates.
-#   Optionally appends commands to $SERVER_DIR/npc_spawn_commands.txt.
+#   NPC spawn commands are recorded to ingame-commands.txt on mod install.
 #   timing_note: extra line shown before coordinates (e.g. "run after rebuild")
 # ─────────────────────────────────────────────────────────────
 _offer_npc_in_capitals() {
@@ -251,6 +251,8 @@ _offer_npc_in_capitals() {
         999991)  slot=1 ;;
         601026)  slot=2 ;;
         1116001) slot=3 ;;
+        90100)   slot=4 ;;
+        2069430) slot=5 ;;
         *)       slot="${_NPC_SPAWN_IDX:-0}" ;;
     esac
     _NPC_SPAWN_IDX=$((_NPC_SPAWN_IDX + 1))
@@ -278,19 +280,458 @@ _offer_npc_in_capitals() {
     print_info "If the NPC lands in a bad spot, use .npc delete (in-game) or"
     print_info "npc delete (console) then re-place with your own coordinates."
     echo ""
+}
 
-    if ask_yes_no "Save these spawn commands to a reference file?"; then
-        local outfile="$SERVER_DIR/npc_spawn_commands.txt"
-        {
-            printf '# %s (entry %s) — %s\n' "$npc_name" "$npc_entry" "$(date '+%Y-%m-%d %H:%M')"
-            printf '# Stormwind (Alliance, map 0)\n'
-            printf 'npc add %s 0 %s %s 94.1 3.7\n' "$npc_entry" "$sw_x" "$sw_y"
-            printf '# Orgrimmar (Horde, map 1)\n'
-            printf 'npc add %s 1 %s %s 17.5 4.5\n' "$npc_entry" "$og_x" "$og_y"
-            printf '\n'
-        } >> "$outfile"
-        print_success "Commands saved to: $outfile"
+# ─────────────────────────────────────────────────────────────
+# IN-GAME COMMANDS FILE HELPERS
+#   _cmd_block_for KEY      — print static command data block for a mod key
+#   upsert_mod_commands KEY — write/replace === key === section in ingame-commands.txt
+#   remove_mod_commands KEY — remove === key === section from ingame-commands.txt
+#   show_ingame_commands    — display ingame-commands.txt with colour formatting
+# ─────────────────────────────────────────────────────────────
+
+_cmd_block_for() {
+    local key="$1"
+    case "$key" in
+        mod-1v1-arena)
+            printf '%s\n' \
+                '1v1 Arena' \
+                'Private one-on-one arena duels. Players can queue from anywhere, challenge others, and track wins/losses. Fully automatic — requires no GM setup beyond placing the Battlemaster NPC.' \
+                '' \
+                'Commands:' \
+                '.q1v1 rated              — Queue for a rated 1v1 arena match' \
+                '.q1v1 unrated            — Queue for an unrated 1v1 arena match' \
+                '.q1v1 stats              — View your personal 1v1 win/loss statistics' \
+                '' \
+                'NPC Spawn Commands (worldserver console; prefix with . for in-game GM):' \
+                'npc add 999991 0 -8828.3 630.2 94.1 3.7   — Stormwind Arena Battlemaster (Alliance)' \
+                'npc add 999991 1 1600.2 -4413.7 17.5 4.5  — Orgrimmar Arena Battlemaster (Horde)'
+            ;;
+        mod-ah-bot)
+            printf '%s\n' \
+                'Auction House Bot' \
+                'Populates the Auction House with NPC-driven listings so players always have items to buy and sell. Configurable pricing, quantity, and categories. Requires a dedicated bot character.' \
+                '' \
+                'Commands (GM Rank 3+ only):' \
+                '[GM] .ahbotoptions minprice <n>     — Set minimum item price' \
+                '[GM] .ahbotoptions maxprice <n>     — Set maximum item price' \
+                '[GM] .ahbotoptions mintime <n>      — Set minimum auction duration (hours)' \
+                '[GM] .ahbotoptions maxtime <n>      — Set maximum auction duration (hours)' \
+                '[GM] .ahbotoptions minbidprice <n>  — Minimum bid price multiplier' \
+                '[GM] .ahbotoptions maxbidprice <n>  — Maximum bid price multiplier' \
+                '[GM] .ahbotoptions maxstack <n>     — Max stack size per listing' \
+                '[GM] .ahbotoptions minitem <n>      — Minimum different items in AH' \
+                '[GM] .ahbotoptions maxitem <n>      — Maximum different items in AH' \
+                '[GM] .ahbotoptions buyprice <n>     — Buyout price multiplier' \
+                '[GM] .ahbotoptions seller <n>       — Enable/disable bot as seller (1/0)' \
+                '[GM] .ahbotoptions buyer <n>        — Enable/disable bot as buyer (1/0)' \
+                '[GM] .ahbotoptions allfaction <n>   — Apply to all factions (1/0)' \
+                '[GM] .ahbotoptions alliance <n>     — Configure Alliance AH separately' \
+                '[GM] .ahbotoptions horde <n>        — Configure Horde AH separately'
+            ;;
+        mod-autobalance)
+            printf '%s\n' \
+                'AutoBalance' \
+                'Dynamically scales dungeon and raid difficulty based on player count, so solo or small-group play is viable. Supports per-dungeon overrides and level scaling.' \
+                '' \
+                'Commands (GM only):' \
+                '[GM] .autobalance getoffset     — Get difficulty offset for current map' \
+                '[GM] .autobalance setoffset <n> — Set difficulty offset for current map' \
+                '[GM] .autobalance mapstat       — Show AutoBalance stats for current map' \
+                '[GM] .autobalance creaturestat  — Show AutoBalance stats for target creature' \
+                '' \
+                'Aliases: .ab getoffset / .ab setoffset / .ab mapstat / .ab creaturestat'
+            ;;
+        mod-challenge-modes)
+            printf '%s\n' \
+                'Challenge Modes' \
+                'Adds optional self-imposed difficulty rules — Hardcore (death = permadeath), Semi-Hardcore, Ironman, and more. Players opt-in via an NPC (Shrine of Challenge) or the game settings menu. Requires EnablePlayerSettings = 1 in worldserver.conf.' \
+                '' \
+                'Commands: (none — all functionality is accessed through the Shrine of Challenge NPC or in-game Settings menu)' \
+                '' \
+                'Configuration: edit mod_challenge_modes.conf after a worldserver rebuild.'
+            ;;
+        mod-solocraft)
+            printf '%s\n' \
+                'SoloCraft' \
+                'Automatically buffs solo players in group content (dungeons, raids) to make progression viable. Scales stats dynamically — fully automatic, no player commands needed.' \
+                '' \
+                'Commands: (none — fully automatic)'
+            ;;
+        mod-transmog)
+            printf '%s\n' \
+                'Transmogrification' \
+                'Lets players change the visual appearance of gear without changing stats. Requires a Transmogrifier NPC placed in the world (entry 190010). Optionally portable and/or toggleable via commands.' \
+                '' \
+                'Commands:' \
+                '.transmog                — Show current transmog status' \
+                '.transmog sync           — Sync transmog visuals' \
+                '.transmog portable       — Toggle portable transmog (interact from anywhere)' \
+                '.transmog interface      — Open transmog UI without the NPC' \
+                '.transmog disclaimer     — Show transmog usage disclaimer' \
+                '[GM] .transmog add <id>  — Add item to transmog collection by item ID' \
+                '[GM] .transmog check     — Check transmog database integrity' \
+                '[GM] .transmog reload    — Reload transmog script' \
+                '' \
+                'NPC Spawn Commands (worldserver console; prefix with . for in-game GM):' \
+                'npc add 190010 0 -8831.3 628.2 94.1 3.7   — Transmogrifier NPC, Stormwind (Alliance)' \
+                'npc add 190010 1 1597.2 -4415.7 17.5 4.5  — Transmogrifier NPC, Orgrimmar (Horde)'
+            ;;
+        mod-individual-progression)
+            printf '%s\n' \
+                'Individual Progression' \
+                'NOTICE: This module repository could not be verified on GitHub — installation may fail.' \
+                'Tracks each player'"'"'s individual content progression, unlocking new tiers as they complete content.' \
+                '' \
+                'Commands: (check module conf after install if the module is available)'
+            ;;
+        mod-player-bot-level-brackets)
+            printf '%s\n' \
+                'Player Bot Level Brackets' \
+                'Restricts AI PlayerBots to operate within configured level brackets, preventing high-level bots from trivialising lower-level content. Requires the Playerbots module.' \
+                '' \
+                'Commands:' \
+                '[ADMIN] .reload          — Reload server scripts (applies bracket config changes without restart)'
+            ;;
+        mod-npc-beastmaster)
+            printf '%s\n' \
+                'NPC Beastmaster' \
+                'Adds a Beastmaster NPC that allows Hunters to tame any pet, including exotic and normally-untameable creatures. Can be summoned anywhere via .beastmaster or placed permanently in capitals (entry 601026).' \
+                '' \
+                'Commands:' \
+                '.beastmaster             — Summon the Beastmaster NPC to your current location' \
+                '.petname rename <name>   — Rename your current pet' \
+                '.petname cancel          — Cancel a pending pet rename' \
+                '' \
+                'NPC Spawn Commands (worldserver console; prefix with . for in-game GM):' \
+                'npc add 601026 0 -8825.3 632.2 94.1 3.7   — White Fang (Beastmaster), Stormwind (Alliance)' \
+                'npc add 601026 1 1603.2 -4411.7 17.5 4.5  — White Fang (Beastmaster), Orgrimmar (Horde)'
+            ;;
+        mod-aoe-loot)
+            printf '%s\n' \
+                'AoE Loot' \
+                'Allows players to loot all nearby corpses simultaneously with a single loot action. Toggleable per-player. Significantly speeds up grinding and farming. No GM configuration needed.' \
+                '' \
+                'Commands:' \
+                '.aoeloot on              — Enable AoE looting for yourself' \
+                '.aoeloot off             — Disable AoE looting for yourself'
+            ;;
+        mod-learn-spells)
+            printf '%s\n' \
+                'Learn Spells on Level Up' \
+                'Automatically teaches players all class spells when they level up, eliminating the need to visit trainers. Configurable to include/exclude specific spell types.' \
+                '' \
+                'Commands: (none — fully automatic on level-up)'
+            ;;
+        mod-junk-to-gold)
+            printf '%s\n' \
+                'Junk to Gold' \
+                'Automatically sells all grey (junk) items in a player'"'"'s bags when they interact with any vendor. Saves time and removes inventory clutter without manual selling.' \
+                '' \
+                'Commands: (none — automatic when visiting any vendor)'
+            ;;
+        battlepass)
+            printf '%s\n' \
+                'Battle Pass (ALE)' \
+                'A seasonal challenge/reward system. Players complete tasks to earn points and claim rewards. Admins manage seasons and reward pools. Requires the Battle Pass Ticker NPC (entry 90100) placed in the world.' \
+                '' \
+                'Commands:' \
+                '.bp status               — View your current Battle Pass progress' \
+                '.bp rewards              — List available rewards this season' \
+                '.bp claim <n>            — Claim reward number n' \
+                '.bp claimall             — Claim all currently available rewards' \
+                '.bp preview              — Preview upcoming rewards' \
+                '.bp help                 — Show Battle Pass command help' \
+                '[GM] .bpadmin season start  — Start a new Battle Pass season' \
+                '[GM] .bpadmin season end    — End the current season' \
+                '[GM] .bpadmin season list   — List all seasons' \
+                '[GM] .bpadmin reward add    — Add a reward to the current season' \
+                '[GM] .bpadmin reward list   — List rewards for the current season' \
+                '[GM] .bpadmin player list   — List player progress for the current season' \
+                '[GM] .bpadmin help          — Show admin command help' \
+                '' \
+                'NPC Spawn Commands (worldserver console; prefix with . for in-game GM):' \
+                'npc add 90100 0 -8819.3 636.2 94.1 3.7   — Battle Pass Ticker, Stormwind (Alliance)' \
+                'npc add 90100 1 1609.2 -4407.7 17.5 4.5  — Battle Pass Ticker, Orgrimmar (Horde)'
+            ;;
+        paragon)
+            printf '%s\n' \
+                'Paragon Anniversary (ALE)' \
+                'A Paragon reputation and anniversary reward system. Players earn paragon points via reputation grinds and receive bonus rewards on server anniversary dates.' \
+                '' \
+                'Commands:' \
+                '.test                    — Debug command (WARNING: no GM guard — any player can use this; appears to be a debug leftover in source code; monitor for abuse)'
+            ;;
+        bmah)
+            printf '%s\n' \
+                'Black Market Auction House (ALE)' \
+                'Adds a Black Market Auction House NPC that lists rare and exclusive items at auction. Requires a companion client addon (AzerothCore-wotlk-client-modifications). NPC entry: 2069430.' \
+                '' \
+                'Commands: (none — all interaction is through the NPC gossip menu)' \
+                '' \
+                'NPC Spawn Commands (worldserver console; prefix with . for in-game GM):' \
+                'npc add 2069430 0 -8816.3 638.2 94.1 3.7   — Black Market AH Auctioneer, Stormwind (Alliance)' \
+                'npc add 2069430 1 1612.2 -4405.7 17.5 4.5  — Black Market AH Auctioneer, Orgrimmar (Horde)'
+            ;;
+        lootpet)
+            printf '%s\n' \
+                'Loot Pet (ALE)' \
+                'Summons a companion pet that automatically picks up nearby loot. Combines well with AoE Loot. Fully automatic once the Lua script is deployed. Uses creature entry 34587 internally.' \
+                '' \
+                'Commands: (none — the pet is summoned and loots automatically)'
+            ;;
+        accountwide)
+            printf '%s\n' \
+                'Account Wide (ALE)' \
+                'Synchronises playtime, reputation, achievements, currencies, and other data across all characters on the same account. Requires a characters DB schema. Individual systems are enabled per-config.' \
+                '' \
+                'Commands:' \
+                '.playtime                — Show total account-wide play time' \
+                '.played                  — Show account-wide played time' \
+                '.awplaytime              — Show account-wide play time (primary alias)' \
+                '.accountplaytime         — Show account-wide play time (alternate alias)' \
+                '.awplayed                — Show account-wide played time (alternate alias)'
+            ;;
+        exchangenpc)
+            printf '%s\n' \
+                'Exchange NPC (ALE)' \
+                'Adds Roboto (entry 1116001), an NPC that lets players exchange currencies, items, and resources. Requires a world SQL file. NPC must be placed in the world after install.' \
+                '' \
+                'Commands: (none — all interaction is through Roboto NPC gossip menu)' \
+                '' \
+                'NPC Spawn Commands (worldserver console; prefix with . for in-game GM):' \
+                'npc add 1116001 0 -8822.3 634.2 94.1 3.7   — Roboto (Exchange NPC), Stormwind (Alliance)' \
+                'npc add 1116001 1 1606.2 -4409.7 17.5 4.5  — Roboto (Exchange NPC), Orgrimmar (Horde)'
+            ;;
+        activechat)
+            printf '%s\n' \
+                'Active Chat (ALE)' \
+                'Broadcasts a configurable activity reminder to all online players at a set interval. Useful for prompting idle players. Fully automatic — no player interaction needed.' \
+                '' \
+                'Commands: (none — message is broadcast on a server timer)'
+            ;;
+        levelupreward)
+            printf '%s\n' \
+                'Level Up Reward (ALE)' \
+                'Automatically grants players an item or currency reward each time they level up. Reward type and quantity are configurable in the Lua script.' \
+                '' \
+                'Commands: (none — reward is granted automatically on level-up)'
+            ;;
+        sod)
+            printf '%s\n' \
+                'Season of Discovery Buff (ALE)' \
+                'Applies a configurable stat buff to all players on login, similar to WoW'"'"'s Season of Discovery rune bonuses. Useful for custom server balancing and boosting new players.' \
+                '' \
+                'Commands: (none — buff is applied automatically on login)'
+            ;;
+        sitmeanrest)
+            printf '%s\n' \
+                'Sit Means Rest (ALE)' \
+                'Automatically applies the Rested XP bonus whenever a player sits down, mimicking inn-style resting anywhere. Duration and regen spell are configurable.' \
+                '' \
+                'Commands: (none — triggered automatically by the /sit emote or sitting action)'
+            ;;
+        unlimitedammo)
+            printf '%s\n' \
+                'Unlimited Ammo (ALE)' \
+                'Allows Hunters and other ranged classes to shoot without consuming ammo. Toggle is per-session. Ships with ENABLED = false and must be configured to activate.' \
+                '' \
+                'Commands:' \
+                '.ua                      — Enable unlimited ammo for yourself (current session only; no .ua off)'
+            ;;
+        portals-capitals)
+            printf '%s\n' \
+                'Portals in All Capitals (SQL Mod)' \
+                'Adds portal game objects to every faction capital city, allowing quick travel between Stormwind, Orgrimmar, and other capitals without a Mage.' \
+                '' \
+                'Commands: (none — portals are world objects; interact with them directly in game)'
+            ;;
+        hearthstone-cd)
+            printf '%s\n' \
+                'Hearthstone Cooldown (SQL Mod)' \
+                'Reduces the Hearthstone cooldown from the WotLK default of 30 minutes. Options: 1 second, 1 minute, 5 minutes, 15 minutes, or 30 minutes (WotLK default).' \
+                '' \
+                'Commands: (none — takes effect after a server restart or .reload spells in-game)'
+            ;;
+        rare-drops)
+            printf '%s\n' \
+                'Rare Drops (SQL Mod)' \
+                'Increases the drop rates of rare-quality items from mobs and bosses, making gear progression feel more rewarding for private servers.' \
+                '' \
+                'Commands: (none — passive database modification, no restart needed)'
+            ;;
+        lvl1-mounts)
+            printf '%s\n' \
+                'Level 1 Mounts (SQL Mod)' \
+                'Lowers the level requirement on all mounts to level 1, so players can ride from the very start of the game. No restart needed.' \
+                '' \
+                'Commands: (none — passive database change, effective immediately)'
+            ;;
+        all-stackables)
+            printf '%s\n' \
+                'All Stackables (SQL Mod)' \
+                'Increases the maximum stack size on all stackable items (potions, reagents, trade goods, etc.) to a configurable amount (default 200).' \
+                '' \
+                'Commands: (none — passive database change, takes effect after server restart)'
+            ;;
+        buff-mobs)
+            printf '%s\n' \
+                'Buff Mobs (SQL Mod)' \
+                'Increases all creature HP, damage, armor, and attack speed (HP×2, DMG×1.5, ARM×1.5) for a more challenging experience. Mutually exclusive with Nerf Mobs, XBuff Mobs, and Baby Mobs.' \
+                '' \
+                'Commands: (none — database multipliers applied to creature_template)'
+            ;;
+        xbuff-mobs)
+            printf '%s\n' \
+                'XBuff Mobs — Extreme Difficulty (SQL Mod)' \
+                'Significantly increases all creature stats (HP×4, DMG×2, ARM×2). The hardest mob difficulty option. Mutually exclusive with all other mob tweak SQL mods.' \
+                '' \
+                'Commands: (none — database multipliers applied to creature_template)'
+            ;;
+        nerf-mobs)
+            printf '%s\n' \
+                'Nerf Mobs (SQL Mod)' \
+                'Reduces all creature stats (HP×0.5, DMG×0.75, ARM×0.75) for an easier experience. Mutually exclusive with Buff Mobs, XBuff Mobs, and Baby Mobs.' \
+                '' \
+                'Commands: (none — database multipliers applied to creature_template)'
+            ;;
+        baby-mobs)
+            printf '%s\n' \
+                'Baby Mobs — Trivial Difficulty (SQL Mod)' \
+                'Drastically reduces all creature stats (HP×0.25, DMG×0.25, ARM×0.25). Best for testing or casual play. Mutually exclusive with all other mob tweak SQL mods.' \
+                '' \
+                'Commands: (none — database multipliers applied to creature_template)'
+            ;;
+        npc-teleporter)
+            printf '%s\n' \
+                'NPC Teleporter (SQL Mod)' \
+                'Adds a teleporter NPC to capital cities and/or starting zones, allowing players to fast-travel to major locations including raids and dungeons. ONY_LEVEL controls Onyxia level requirement.' \
+                '' \
+                'Commands: (none — all interaction through the NPC gossip teleport menu)'
+            ;;
+        xp-rates)
+            printf '%s\n' \
+                'XP Rates (SQL Mod)' \
+                'Adjusts kill, quest, and exploration XP multipliers in worldserver.conf. Requires a reload config or server restart to apply changes.' \
+                '' \
+                'Commands: (none — edits worldserver.conf; use .reload config in-game to apply without a full restart)'
+            ;;
+        custom-login)
+            printf '%s\n' \
+                'Custom Login (SQL Mod / Module)' \
+                'Gives new characters starter items, spells, or buffs on first login. Configurable via mod_customlogin.conf.' \
+                '' \
+                'Commands: (none — triggers automatically on first character login)'
+            ;;
+        mod-ale)
+            printf '%s\n' \
+                'AzerothCore Lua Engine (ALE)' \
+                'The core C++ module that enables Lua scripting on AzerothCore. Required by all ALE Lua Mods. Exposes server events to Lua scripts placed in the lua_scripts/ directory.' \
+                '' \
+                'Commands:' \
+                '[GM] .reload ale         — Reload all Lua scripts without restarting the worldserver'
+            ;;
+    esac
+}
+
+# Write or replace the === key === section in INGAME_COMMANDS_FILE.
+# Uses unique temp files + atomic mv to avoid partial writes.
+# Pass --quiet as second argument to suppress the print_info notification.
+upsert_mod_commands() {
+    local key="$1" quiet="${2:-}"
+    local content; content=$(_cmd_block_for "$key")
+    [ -z "$content" ] && return 0
+
+    local outfile="$INGAME_COMMANDS_FILE"
+    [ -z "$outfile" ] && return 0
+    local marker="=== ${key} ==="
+
+    local tmpblock; tmpblock=$(mktemp)
+    printf '%s\n%s\n' "$marker" "$content" > "$tmpblock"
+
+    if [ ! -f "$outfile" ]; then
+        mv "$tmpblock" "$outfile"
+        [ "$quiet" != "--quiet" ] && print_info "📋 In-game commands reference created: $outfile"
+        return 0
     fi
+
+    if grep -Fxq "$marker" "$outfile" 2>/dev/null; then
+        local tmpout; tmpout=$(mktemp)
+        awk -v marker="$marker" -v newfile="$tmpblock" '
+        $0 == marker {
+            while ((getline line < newfile) > 0) print line
+            close(newfile)
+            skip=1; next
+        }
+        skip && /^=== .+ ===$/ { skip=0 }
+        !skip { print }
+        ' "$outfile" > "$tmpout" && mv "$tmpout" "$outfile"
+    else
+        printf '\n' >> "$outfile"
+        cat "$tmpblock" >> "$outfile"
+    fi
+    rm -f "$tmpblock"
+    [ "$quiet" != "--quiet" ] && print_info "📋 In-game commands reference updated: $outfile"
+}
+
+# Remove the === key === section from INGAME_COMMANDS_FILE.
+remove_mod_commands() {
+    local key="$1"
+    local outfile="$INGAME_COMMANDS_FILE"
+    [ -z "$outfile" ] || [ ! -f "$outfile" ] && return 0
+    local marker="=== ${key} ==="
+    grep -Fxq "$marker" "$outfile" 2>/dev/null || return 0
+
+    local tmpout; tmpout=$(mktemp)
+    awk -v marker="$marker" '
+    $0 == marker { skip=1; next }
+    skip && /^=== .+ ===$/ { skip=0 }
+    !skip { print }
+    ' "$outfile" > "$tmpout" && mv "$tmpout" "$outfile"
+    print_info "📋 Removed $key from in-game commands reference."
+}
+
+# Print INGAME_COMMANDS_FILE to the terminal with basic colour formatting.
+show_ingame_commands() {
+    local outfile="$INGAME_COMMANDS_FILE"
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    if [ -z "$outfile" ] || [ ! -f "$outfile" ] || [ ! -s "$outfile" ]; then
+        echo ""
+        print_info "No in-game commands recorded yet."
+        print_info "Install any mod (Modules, ALE Lua Mods, or SQL Mods) to populate this file."
+        echo ""
+        press_enter
+        return
+    fi
+
+    echo ""
+    echo -e "  ${GOLD}${BOLD}In-Game Commands Reference${RST}"
+    echo -e "  ${GOLD}══════════════════════════════════════════════${RST}"
+    echo -e "  ${DIM}Source: $outfile${RST}"
+    echo ""
+
+    while IFS= read -r line; do
+        if [[ "$line" == "=== "* ]]; then
+            echo -e "\n  ${GOLD}${BOLD}${line}${RST}"
+        elif [[ "$line" == "Commands:"* ]] || [[ "$line" == "NPC Spawn Commands"* ]]; then
+            echo -e "  ${WHITE}${BOLD}${line}${RST}"
+        elif [[ "$line" == "."* ]] || [[ "$line" == "[GM]"* ]] || \
+             [[ "$line" == "[ADMIN]"* ]] || [[ "$line" == "npc add"* ]]; then
+            echo -e "  ${CYAN}${line}${RST}"
+        elif [[ "$line" == "(none"* ]] || [[ "$line" == "WARNING:"* ]] || \
+             [[ "$line" == "NOTICE:"* ]]; then
+            echo -e "  ${YELLOW}${line}${RST}"
+        elif [[ -z "$line" ]]; then
+            echo ""
+        else
+            echo -e "  ${line}"
+        fi
+    done < "$outfile"
+
+    echo ""
+    echo -e "  ${DIM}Full file: $outfile${RST}"
+    echo ""
+    press_enter
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -303,6 +744,7 @@ WORLD_CONTAINER=""
 DB_CONTAINER=""
 AUTH_CONTAINER=""
 DB_ROOT_PASSWORD="password"   # acore-docker default
+INGAME_COMMANDS_FILE=""       # set to $SERVER_DIR/ingame-commands.txt after detect_install
 
 # Session counter for NPC spawn coordinate staggering (deterministic per known entry)
 _NPC_SPAWN_IDX=0
@@ -409,6 +851,7 @@ detect_install() {
 
     # Find running containers (will be empty if server is stopped — that's OK)
     refresh_container_names
+    INGAME_COMMANDS_FILE="$SERVER_DIR/ingame-commands.txt"
 }
 
 # Classify an install by looking at directory name AND, if needed,
@@ -2566,6 +3009,10 @@ ale_script_install() {
                 print_info "Remember to apply SQL manually from:"
                 print_info "  $clone_dir/sql/"
             fi
+            echo ""
+            print_info "Battle Pass Ticker (entry 90100) needs to be placed in the world."
+            _offer_npc_in_capitals 90100 "Battle Pass Ticker" \
+                "Run after reloading ALE scripts or restarting the worldserver."
             ;;
         paragon)
             echo ""
@@ -2578,6 +3025,10 @@ ale_script_install() {
             if ask_yes_no "Configure Black Market AH (NPC ID + client addon info) now?"; then
                 configure_ale_bmah
             fi
+            echo ""
+            print_info "Black Market AH Auctioneer (entry 2069430) needs to be placed in the world."
+            _offer_npc_in_capitals 2069430 "Black Market AH Auctioneer" \
+                "Run after reloading ALE scripts or restarting the worldserver."
             ;;
         sitmeanrest)
             echo ""
@@ -2602,6 +3053,7 @@ ale_script_install() {
     echo ""
     print_info "Reload Lua scripts in-game with: ${CYAN}.reload ale${RST}"
     print_info "Or restart the worldserver from the main menu."
+    upsert_mod_commands "$key"
     return 0
 }
 
@@ -2671,6 +3123,7 @@ ale_script_remove() {
     fi
 
     print_info "(Database tables created by this script are kept — removing them risks data loss.)"
+    remove_mod_commands "$key"
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -2848,6 +3301,7 @@ _sqlmod_install_clone_sql() {
     if sqlmod_run_sql_file "acore_world" "$up_sql"; then
         touch "$SQLMOD_MARKER_DIR/$key.installed"
         print_success "$name installed successfully!"
+        upsert_mod_commands "$key"
     else
         print_error "SQL apply failed for $name"
         return 1
@@ -2880,6 +3334,7 @@ _sqlmod_install_hearthstone() {
     if sqlmod_run_sql_file "acore_world" "$sql_file"; then
         echo "HEARTHSTONE_COOLDOWN=$cooldown_choice" > "$SQLMOD_MARKER_DIR/$key.installed"
         print_success "$name installed ($cooldown_choice)!"
+        upsert_mod_commands "$key"
     else
         print_error "SQL apply failed"
         return 1
@@ -2932,10 +3387,10 @@ _sqlmod_install_clone_dist() {
 
     touch "$SQLMOD_MARKER_DIR/$key.installed"
     print_success "$name installed successfully!"
+    upsert_mod_commands "$key"
 }
 
-_sqlmod_install_conf_module() {
-    local key="$1" name="$2" url="$3"
+_sqlmod_install_conf_module() {    local key="$1" name="$2" url="$3"
     local module_dir="$SERVER_DIR/modules/$key"
     if [ -d "$module_dir/.git" ]; then
         print_info "Updating $key module..."
@@ -2958,6 +3413,7 @@ _sqlmod_install_conf_module() {
     print_success "$name cloned to modules/!"
     print_warning "A worldserver rebuild is required to activate this module."
     print_info "Use 'Rebuild worldserver' from the main menu to compile."
+    upsert_mod_commands "$key"
 }
 
 _sqlmod_install_tweak() {
@@ -3005,6 +3461,7 @@ _sqlmod_install_tweak() {
             "$h_mult" "$d_mult" "$a_mult" "$spd_mult" > "$SQLMOD_MARKER_DIR/$key.installed"
         print_success "$name applied!"
         print_warning "Applying again stacks multipliers. Use Remove to reverse."
+        upsert_mod_commands "$key"
     else
         print_error "SQL failed for $name"
         return 1
@@ -3024,6 +3481,7 @@ sqlmod_remove() {
             if ! ask_yes_no "Remove $name module directory? A rebuild will be required."; then return 0; fi
             rm -rf "$SERVER_DIR/modules/$key"
             print_success "$name removed. Rebuild worldserver to deactivate."
+            remove_mod_commands "$key"
             return 0
             ;;
         conf_xp)
@@ -3109,6 +3567,7 @@ _sqlmod_remove_clone_sql() {
     if sqlmod_run_sql_file "acore_world" "$down_sql"; then
         rm -f "$SQLMOD_MARKER_DIR/$key.installed"
         print_success "$name removed!"
+        remove_mod_commands "$key"
     else
         print_error "SQL remove failed"
         return 1
@@ -3123,6 +3582,7 @@ _sqlmod_remove_hearthstone() {
     if sqlmod_run_sql "acore_world" "$sql"; then
         rm -f "$SQLMOD_MARKER_DIR/$key.installed"
         print_success "$name removed (30-min cooldown restored)!"
+        remove_mod_commands "$key"
     else
         print_error "SQL reset failed"; return 1
     fi
@@ -3137,13 +3597,13 @@ _sqlmod_remove_npc_teleporter() {
     if sqlmod_run_sql "acore_world" "$sql"; then
         rm -f "$SQLMOD_MARKER_DIR/$key.installed"
         print_success "$name removed!"
+        remove_mod_commands "$key"
     else
         print_error "SQL removal failed"; return 1
     fi
 }
 
-_sqlmod_remove_tweak() {
-    local key="$1" name="$2"
+_sqlmod_remove_tweak() {    local key="$1" name="$2"
     local marker_file="$SQLMOD_MARKER_DIR/$key.installed"
 
     # Known defaults per tweak (fallback if marker lacks APPLIED_* values)
@@ -3182,13 +3642,13 @@ _sqlmod_remove_tweak() {
     if sqlmod_run_sql "acore_world" "$sql"; then
         rm -f "$SQLMOD_MARKER_DIR/$key.installed"
         print_success "$name reversed!"
+        remove_mod_commands "$key"
     else
         print_error "SQL failed"; return 1
     fi
 }
 
-_sqlmod_remove_xprates() {
-    local conf_path="$SERVER_DIR/env/dist/etc/worldserver.conf"
+_sqlmod_remove_xprates() {    local conf_path="$SERVER_DIR/env/dist/etc/worldserver.conf"
     if [ ! -f "$conf_path" ]; then
         print_error "worldserver.conf not found at $conf_path"; return 1
     fi
@@ -4160,6 +4620,7 @@ menu_modules() {
                 for entry in "${to_install[@]}"; do
                     IFS='|' read -r key name url sql_dirs <<< "$entry"
                     module_install "$key" "$name" "$url" "$sql_dirs" || true
+                    upsert_mod_commands "$key"
                     echo ""
                 done
                 print_info "Modules cloned. SQL files will be applied automatically on next server start."
@@ -4241,6 +4702,9 @@ menu_modules() {
                 fi
                 printf '\033[%d;1H\033[J' "$MENU_START_ROW"
                 module_remove "$key" "$name"
+                if ! module_is_installed "$key"; then
+                    remove_mod_commands "$key"
+                fi
                 if [ "$SERVER_TYPE" = "playerbots" ]; then
                     echo ""
                     print_info "Rebuild needed for module removal to take effect."
@@ -5087,6 +5551,7 @@ main_menu() {
         printf "  ${WHITE}12)${RST} View logs\n"
         printf "  ${WHITE}13)${RST} Attach to console\n"
         printf "  ${WHITE}14)${RST} Server maintenance\n"
+        printf "  ${WHITE}15)${RST} View In-Game Commands\n"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
         printf "  ${GOLD} Q)${RST} Quit\n"
 
@@ -5111,6 +5576,7 @@ main_menu() {
             12) with_full_screen server_logs ;;
             13) with_full_screen server_attach ;;
             14) menu_server_maintenance ;;
+            15) show_ingame_commands ;;
             q)  echo ""; print_info "Goodbye!"; exit 0 ;;
         esac
     done
@@ -5119,7 +5585,45 @@ main_menu() {
 # ─────────────────────────────────────────────────────────────
 # ENTRYPOINT
 # ─────────────────────────────────────────────────────────────
+
+# Scan all three mod registries and silently populate ingame-commands.txt
+# for any mods already installed. Handles upgrades from older manager versions
+# that pre-date the commands file system.
+sync_ingame_commands_for_installed() {
+    [ -z "$INGAME_COMMANDS_FILE" ] && return 0
+    local key name entry count=0
+
+    for entry in "${MODULE_REGISTRY[@]}"; do
+        IFS='|' read -r key name _ _ <<< "$entry"
+        if module_is_installed "$key"; then
+            upsert_mod_commands "$key" --quiet
+            count=$((count + 1))
+        fi
+    done
+
+    for entry in "${ALE_SCRIPT_REGISTRY[@]}"; do
+        IFS='|' read -r key name _ <<< "$entry"
+        if ale_script_is_installed "$key"; then
+            upsert_mod_commands "$key" --quiet
+            count=$((count + 1))
+        fi
+    done
+
+    sqlmod_init
+    for entry in "${SQL_MOD_REGISTRY[@]}"; do
+        IFS='|' read -r key name _ _ <<< "$entry"
+        if sqlmod_is_installed "$key"; then
+            upsert_mod_commands "$key" --quiet
+            count=$((count + 1))
+        fi
+    done
+
+    [ "$count" -gt 0 ] && \
+        print_info "📋 In-game commands reference synced for $count installed mod(s): $INGAME_COMMANDS_FILE"
+}
+
 start_logo_animation
 detect_install
+sync_ingame_commands_for_installed
 show_first_run_welcome
 main_menu

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -140,7 +140,7 @@ _draw_logo_static() {
     printf '\033[38;5;196m%s\033[K\033[0m\n' "$_LOGO_L7"
     printf '\n'
     printf '\033[38;5;220m ══════════════════════════════════════════════════════════════════════════════════\033[K\033[0m\n'
-    printf '   \033[2m⚔︎ WotLK Mod & Server Manager\033[0m  ✦  \033[2mv%s\033[0m\033[K\n' "$MANAGER_VERSION" ⚔︎
+    printf '   \033[2m⚔︎ WotLK Mod and Server Manager\033[0m  ✦  \033[2mv%s\033[0m\033[K\n' "$MANAGER_VERSION"
     printf '\033[38;5;220m ══════════════════════════════════════════════════════════════════════════════════\033[K\033[0m\n'
     printf '\n'
 }

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -2686,7 +2686,7 @@ SQLMOD_BACKUP_DIR=""
 
 sqlmod_init() {
     [ -n "$SQLMOD_BASE_DIR" ] && return 0   # already initialised
-    SQLMOD_BASE_DIR="$SERVER_DIR/.sqlmods"
+    SQLMOD_BASE_DIR="$SERVER_DIR/sql_scripts"
     SQLMOD_MARKER_DIR="$SQLMOD_BASE_DIR/installed"
     SQLMOD_CLONE_DIR="$SQLMOD_BASE_DIR/clones"
     SQLMOD_CONFIG_DIR="$SQLMOD_BASE_DIR/config"
@@ -3204,6 +3204,51 @@ _sqlmod_remove_xprates() {
     print_info "Run '.reload config' in-game or restart the world server to apply."
 }
 
+# ── Reapply helper (remove + reinstall without user prompts) ─
+# Used by configure functions to immediately apply config changes.
+# Usage: _sqlmod_reapply <key>
+_sqlmod_reapply() {
+    local key="$1"
+    local name="" url="" type=""
+    local entry
+    for entry in "${SQL_MOD_REGISTRY[@]}"; do
+        IFS='|' read -r k n u t <<< "$entry"
+        if [ "$k" = "$key" ]; then name="$n"; url="$u"; type="$t"; break; fi
+    done
+    [ -z "$name" ] && return 1
+
+    if ! sqlmod_is_installed "$key"; then return 0; fi
+
+    if ! container_running "$DB_CONTAINER"; then
+        print_error "Database container is not running. Cannot reapply $name."
+        print_info "Start the server, then reconfigure to apply changes."
+        return 1
+    fi
+
+    echo ""
+    print_info "Reapplying $name with new configuration..."
+    sqlmod_backup_world || return 1
+
+    case "$type" in
+        clone_sql)      _sqlmod_remove_clone_sql "$key" "$name" ;;
+        clone_sql_pick) _sqlmod_remove_hearthstone "$key" "$name" ;;
+        clone_dist)     _sqlmod_remove_npc_teleporter "$key" "$name" ;;
+        tweak_world)    _sqlmod_remove_tweak "$key" "$name" ;;
+        clone_sql_norevert)
+            rm -f "$SQLMOD_MARKER_DIR/$key.installed"
+            _sqlmod_install_clone_sql "$key" "$name" "$url"
+            return
+            ;;
+    esac
+
+    case "$type" in
+        clone_sql|clone_sql_norevert) _sqlmod_install_clone_sql "$key" "$name" "$url" ;;
+        clone_sql_pick)               _sqlmod_install_hearthstone "$key" "$name" "$url" ;;
+        clone_dist)                   _sqlmod_install_clone_dist "$key" "$name" "$url" ;;
+        tweak_world)                  _sqlmod_install_tweak "$key" "$name" ;;
+    esac
+}
+
 # ── Configure dispatcher ──────────────────────────────────────
 sqlmod_configure() {
     local key="$1" name="$2"
@@ -3224,8 +3269,7 @@ sqlmod_configure() {
 configure_sqlmod_portals() {
     printf '\033[%d;1H\033[J' "$MENU_START_ROW"
     printf "  ${GOLD}── Configure: Portals in All Capitals ──${RST}\n\n"
-    printf "  ${DIM}Adjust GO_TEMPLATE/GO_SPAWN base IDs if they conflict with other mods.${RST}\n"
-    printf "  ${DIM}Changes apply on next (re)install.${RST}\n\n"
+    printf "  ${DIM}Adjust GO_TEMPLATE/GO_SPAWN base IDs if they conflict with other mods.${RST}\n\n"
 
     local cfg_file="$SQLMOD_CONFIG_DIR/portals-capitals.conf"
     local cur_tpl=500000 cur_spn=2000000
@@ -3246,15 +3290,19 @@ configure_sqlmod_portals() {
     fi
 
     printf 'PORTALS_GO_TEMPLATE=%s\nPORTALS_GO_SPAWN=%s\n' "$new_tpl" "$new_spn" > "$cfg_file"
-    print_success "Config saved. Remove + reinstall Portals to apply new IDs."
+    print_success "Configuration saved."
+    if sqlmod_is_installed "portals-capitals"; then
+        _sqlmod_reapply "portals-capitals"
+    else
+        print_info "Install Portals in All Capitals to apply these settings."
+    fi
     press_enter
 }
 
 configure_sqlmod_stackables() {
     printf '\033[%d;1H\033[J' "$MENU_START_ROW"
     printf "  ${GOLD}── Configure: All Stackables ──${RST}\n\n"
-    printf "  ${DIM}Set the maximum stack size. Default is 200.${RST}\n"
-    printf "  ${DIM}Changes apply on next (re)install.${RST}\n\n"
+    printf "  ${DIM}Set the maximum stack size. Default is 200.${RST}\n\n"
 
     local cfg_file="$SQLMOD_CONFIG_DIR/all-stackables.conf"
     local cur_size=200
@@ -3268,7 +3316,12 @@ configure_sqlmod_stackables() {
     if ! [[ "$new_size" =~ ^[0-9]+$ ]]; then print_error "Invalid value."; press_enter; return; fi
 
     printf 'STACKABLES_SIZE=%s\n' "$new_size" > "$cfg_file"
-    print_success "Config saved (stack size = $new_size). Remove + reinstall to apply."
+    print_success "Configuration saved (stack size = $new_size)."
+    if sqlmod_is_installed "all-stackables"; then
+        _sqlmod_reapply "all-stackables"
+    else
+        print_info "Install All Stackables to apply this setting."
+    fi
     press_enter
 }
 
@@ -3301,14 +3354,19 @@ configure_sqlmod_npc_teleporter() {
 
     printf 'NPC_TELEPORTER_ONY_LEVEL=%s\nNPC_TELEPORTER_CAPITAL=%s\nNPC_TELEPORTER_STARTZONE=%s\n' \
         "$new_ony" "$new_capital" "$new_startzone" > "$cfg_file"
-    print_success "Config saved. Remove + reinstall to apply."
+    print_success "Configuration saved."
+    if sqlmod_is_installed "npc-teleporter"; then
+        _sqlmod_reapply "npc-teleporter"
+    else
+        print_info "Install NPC Teleporter to apply these settings."
+    fi
     press_enter
 }
 
 configure_sqlmod_hearthstone() {
     printf '\033[%d;1H\033[J' "$MENU_START_ROW"
     printf "  ${GOLD}── Configure: Hearthstone Cooldowns ──${RST}\n\n"
-    printf "  ${DIM}Select the Hearthstone cooldown. Remove + reinstall to apply.${RST}\n\n"
+    printf "  ${DIM}Select the Hearthstone cooldown.${RST}\n\n"
     printf "  1) 30 minutes (WotLK default)\n"
     printf "  2) 15 minutes\n"
     printf "  3) 5 minutes\n"
@@ -3329,7 +3387,12 @@ configure_sqlmod_hearthstone() {
         4) sel="1min"  ;; 5) sel="1sec"  ;; *) sel="$cur" ;;
     esac
     printf 'HEARTHSTONE_COOLDOWN=%s\n' "$sel" > "$cfg_file"
-    print_success "Config saved ($sel). Remove + reinstall to apply."
+    print_success "Configuration saved ($sel)."
+    if sqlmod_is_installed "hearthstone-cd"; then
+        _sqlmod_reapply "hearthstone-cd"
+    else
+        print_info "Install Hearthstone Cooldown Tweaks to apply this setting."
+    fi
     press_enter
 }
 
@@ -3356,7 +3419,7 @@ configure_sqlmod_tweak() {
     printf '\033[%d;1H\033[J' "$MENU_START_ROW"
     printf "  ${GOLD}── Configure: %s ──${RST}\n\n" "$name"
     printf "  ${DIM}Adjust creature_template multipliers. Leave blank to keep current.${RST}\n"
-    printf "  ${DIM}Values must be positive numbers > 0 (used for reversal on remove).${RST}\n\n"
+    printf "  ${DIM}Values must be positive numbers > 0. Changes apply immediately if installed.${RST}\n\n"
 
     local def_h def_d def_a def_spd
     case "$key" in
@@ -3398,7 +3461,12 @@ configure_sqlmod_tweak() {
 
     printf 'TWEAK_HP_MULT=%s\nTWEAK_DMG_MULT=%s\nTWEAK_ARM_MULT=%s\nTWEAK_SPD_MULT=%s\n' \
         "$new_h" "$new_d" "$new_a" "$new_spd" > "$cfg_file"
-    print_success "Config saved. Install (or remove + reinstall) to apply."
+    print_success "Configuration saved."
+    if sqlmod_is_installed "$key"; then
+        _sqlmod_reapply "$key"
+    else
+        print_info "Install $name to apply these settings."
+    fi
     press_enter
 }
 

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -26,7 +26,7 @@
 #  https://github.com/DadsMmoLab/dads-mmo-lab
 # ============================================================
 
-MANAGER_VERSION="2.1.0 - ALE Drinker Edition"
+MANAGER_VERSION="2.1.5 - ALE Drinker Edition"
 
 set -o pipefail
 
@@ -140,7 +140,7 @@ _draw_logo_static() {
     printf '\033[38;5;196m%s\033[K\033[0m\n' "$_LOGO_L7"
     printf '\n'
     printf '\033[38;5;220m ══════════════════════════════════════════════════════════════════════════════════\033[K\033[0m\n'
-    printf '   \033[2mWoW Module Manager\033[0m  ✦  \033[2mv%s\033[0m\033[K\n' "$MANAGER_VERSION"
+    printf '   \033[2m⚔︎ WotLK Mod & Server Manager\033[0m  ✦  \033[2mv%s\033[0m\033[K\n' "$MANAGER_VERSION" ⚔︎
     printf '\033[38;5;220m ══════════════════════════════════════════════════════════════════════════════════\033[K\033[0m\n'
     printf '\n'
 }

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -244,15 +244,19 @@ DB_ROOT_PASSWORD="password"   # acore-docker default
 
 # Module registry: key|name|repo url|sql dirs (comma-sep)
 declare -a MODULE_REGISTRY=(
-    "mod-ah-bot|Auction House Bot|https://github.com/azerothcore/mod-ah-bot.git|world"
-    "mod-solocraft|Solocraft (solo dungeon/raid scaling)|https://github.com/azerothcore/mod-solocraft.git|world"
-    "mod-aoe-loot|AoE Loot|https://github.com/azerothcore/mod-aoe-loot.git|world"
-    "mod-learn-spells|Learn Spells on Levelup|https://github.com/azerothcore/mod-learn-spells.git|world"
-    "mod-individual-progression|Individual Progression (Vanilla → TBC → WotLK)|https://github.com/ZhengPeiRu21/mod-individual-progression.git|world,characters"
-    "mod-autobalance|Auto Balance (dynamic difficulty)|https://github.com/azerothcore/mod-autobalance.git|world"
-    "mod-transmog|Transmogrification|https://github.com/azerothcore/mod-transmog.git|world,characters"
     "mod-1v1-arena|1v1 Arena|https://github.com/azerothcore/mod-1v1-arena.git|characters"
+    "mod-aoe-loot|AoE Loot|https://github.com/azerothcore/mod-aoe-loot.git|world"
+    "mod-ah-bot|Auction House Bot|https://github.com/azerothcore/mod-ah-bot.git|world"
+    "mod-autobalance|Auto Balance (dynamic difficulty)|https://github.com/azerothcore/mod-autobalance.git|world"
     "mod-ale|AzerothCore Lua Engine (ALE)|https://github.com/azerothcore/mod-ale.git|"
+    "mod-player-bot-level-brackets|Bot Level Brackets (Playerbot distribution)|https://github.com/DustinHendrickson/mod-player-bot-level-brackets.git|world,characters"
+    "mod-challenge-modes|Challenge Modes (Hardcore, Iron Man, etc.)|https://github.com/ZhengPeiRu21/mod-challenge-modes.git|world,characters"
+    "mod-individual-progression|Individual Progression (Vanilla → TBC → WotLK)|https://github.com/ZhengPeiRu21/mod-individual-progression.git|world,characters"
+    "mod-junk-to-gold|Junk to Gold (auto-sell gray items)|https://github.com/noisiver/mod-junk-to-gold.git|world"
+    "mod-learn-spells|Learn Spells on Levelup|https://github.com/azerothcore/mod-learn-spells.git|world"
+    "mod-npc-beastmaster|NPC Beastmaster (pets for all classes)|https://github.com/azerothcore/mod-npc-beastmaster.git|world,characters"
+    "mod-solocraft|Solocraft (solo dungeon/raid scaling)|https://github.com/azerothcore/mod-solocraft.git|world"
+    "mod-transmog|Transmogrification|https://github.com/azerothcore/mod-transmog.git|world,characters"
 )
 
 # ─────────────────────────────────────────────────────────────
@@ -1331,6 +1335,120 @@ configure_ale() {
     print_info "Place your Lua scripts in:"
     print_info "  $lua_scripts_dir"
     print_info "Restart the worldserver for changes to take effect."
+}
+
+# ─────────────────────────────────────────────────────────────
+# configure_module_challenge_modes
+#   Copies challenge_modes.conf.dist → challenge_modes.conf and opens
+#   it in the editor.  Also reminds user about EnablePlayerSettings.
+#   Note: if no conf.dist is present, a worldserver rebuild is needed
+#   first so the build system produces the conf files.
+# ─────────────────────────────────────────────────────────────
+configure_module_challenge_modes() {
+    print_step "Configuring Challenge Modes"
+
+    local module_dir="$SERVER_DIR/modules/mod-challenge-modes"
+    if [ ! -d "$module_dir" ]; then
+        print_error "Challenge Modes module not installed (expected at $module_dir)."
+        return 1
+    fi
+
+    local conf_dist="$module_dir/conf/challenge_modes.conf.dist"
+    local conf_dest="$SERVER_DIR/env/dist/etc/modules/challenge_modes.conf"
+    mkdir -p "$SERVER_DIR/env/dist/etc/modules"
+
+    if [ ! -f "$conf_dest" ]; then
+        if [ -f "$conf_dist" ]; then
+            cp "$conf_dist" "$conf_dest"
+            print_success "Created $conf_dest"
+        else
+            print_warning "conf.dist not found at $conf_dist"
+            print_info "The worldserver must be rebuilt once before conf files are generated."
+            print_info "After rebuilding, re-run this configure option."
+            return 0
+        fi
+    fi
+
+    print_info "⚠  Challenge Modes requires  EnablePlayerSettings = 1  in worldserver.conf."
+    echo ""
+    ${EDITOR:-nano} "$conf_dest"
+    echo ""
+    print_info "Restart the worldserver for conf changes to take effect."
+}
+
+# ─────────────────────────────────────────────────────────────
+# configure_module_bot_level_brackets
+#   Copies mod_player_bot_level_brackets.conf.dist and opens it.
+#   Reminds user that the Playerbots module is required.
+# ─────────────────────────────────────────────────────────────
+configure_module_bot_level_brackets() {
+    print_step "Configuring Bot Level Brackets"
+
+    local module_dir="$SERVER_DIR/modules/mod-player-bot-level-brackets"
+    if [ ! -d "$module_dir" ]; then
+        print_error "Bot Level Brackets module not installed (expected at $module_dir)."
+        return 1
+    fi
+
+    local conf_dist="$module_dir/conf/mod_player_bot_level_brackets.conf.dist"
+    local conf_dest="$SERVER_DIR/env/dist/etc/modules/mod_player_bot_level_brackets.conf"
+    mkdir -p "$SERVER_DIR/env/dist/etc/modules"
+
+    if [ ! -f "$conf_dest" ]; then
+        if [ -f "$conf_dist" ]; then
+            cp "$conf_dist" "$conf_dest"
+            print_success "Created $conf_dest"
+        else
+            print_warning "conf.dist not found at $conf_dist"
+            print_info "The worldserver must be rebuilt once before conf files are generated."
+            print_info "After rebuilding, re-run this configure option."
+            return 0
+        fi
+    fi
+
+    print_info "⚠  Bot Level Brackets requires the Playerbots module to function."
+    echo ""
+    ${EDITOR:-nano} "$conf_dest"
+    echo ""
+    print_info "Restart the worldserver for conf changes to take effect."
+}
+
+# ─────────────────────────────────────────────────────────────
+# configure_module_npc_beastmaster
+#   Copies mod_npc_beastmaster.conf.dist and opens it.
+#   Reminds user about the Creatures.CustomIDs worldserver.conf tip.
+# ─────────────────────────────────────────────────────────────
+configure_module_npc_beastmaster() {
+    print_step "Configuring NPC Beastmaster"
+
+    local module_dir="$SERVER_DIR/modules/mod-npc-beastmaster"
+    if [ ! -d "$module_dir" ]; then
+        print_error "NPC Beastmaster module not installed (expected at $module_dir)."
+        return 1
+    fi
+
+    local conf_dist="$module_dir/conf/mod_npc_beastmaster.conf.dist"
+    local conf_dest="$SERVER_DIR/env/dist/etc/modules/mod_npc_beastmaster.conf"
+    mkdir -p "$SERVER_DIR/env/dist/etc/modules"
+
+    if [ ! -f "$conf_dest" ]; then
+        if [ -f "$conf_dist" ]; then
+            cp "$conf_dist" "$conf_dest"
+            print_success "Created $conf_dest"
+        else
+            print_warning "conf.dist not found at $conf_dist"
+            print_info "The worldserver must be rebuilt once before conf files are generated."
+            print_info "After rebuilding, re-run this configure option."
+            return 0
+        fi
+    fi
+
+    print_info "Tip: Add 601026 to Creatures.CustomIDs in worldserver.conf to suppress"
+    print_info "     a harmless gossip-menu warning in server logs."
+    echo ""
+    ${EDITOR:-nano} "$conf_dest"
+    echo ""
+    print_info "Restart the worldserver for conf changes to take effect."
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -3336,6 +3454,39 @@ _get_about_text() {
                 'interchangeable with standard Eluna scripts. Supports' \
                 'LuaJIT (recommended), Lua 5.2, 5.3, and 5.4.'
             ;;
+        mod-player-bot-level-brackets)
+            printf '%s\n' \
+                'Distributes Playerbot random bots across configurable level brackets' \
+                '(e.g. 12% in 1-9, 11% in 10-19) and auto-rebalances bots from' \
+                'overpopulated brackets to deficit ones. Supports dynamic distribution' \
+                'weighted by real player activity, guild/friend exclusions, and a Death' \
+                'Knight level safeguard (min 55). Full and lite debug logging included.' \
+                'Requires the Playerbots module and a worldserver rebuild.'
+            ;;
+        mod-challenge-modes)
+            printf '%s\n' \
+                'Adds opt-in per-character challenge modes selected at level 1 via a' \
+                'Shrine of Challenge NPC near each starting zone. Modes: Hardcore' \
+                '(permanent ghost on death), Semi-Hardcore (lose gear/gold on death),' \
+                'Self-Crafted, Item-Quality Level, Slow/Very Slow XP, Quest-XP Only,' \
+                'and Iron Man. Configurable rewards (items, titles, XP rate bonus).' \
+                'Requires EnablePlayerSettings = 1 in worldserver.conf.'
+            ;;
+        mod-junk-to-gold)
+            printf '%s\n' \
+                'Automatically sells gray (vendor-junk) items directly to vendor price' \
+                'when looted by the player, keeping bags free of clutter. No in-game' \
+                'toggle or configuration file required -- install, rebuild, and it works.'
+            ;;
+        mod-npc-beastmaster)
+            printf '%s\n' \
+                'Lets all classes (not just Hunters) adopt and use hunter pets via a' \
+                'special NPC. Provides pet adoption (normal, rare, exotic), Hunter' \
+                'skills for non-hunters, a pet food vendor, stables, and a tracked-pets' \
+                'system (summon, rename, delete). Players summon the NPC anywhere via' \
+                '.beastmaster. NPC entry: 601026 (White Fang). Add 601026 to' \
+                'Creatures.CustomIDs in worldserver.conf to silence a harmless warning.'
+            ;;
         accountwide)
             printf '%s\n' \
                 'Syncs achievements, currencies, gold, mounts, and pets across' \
@@ -3807,7 +3958,7 @@ menu_modules() {
             [ "$current_page" -lt "$total_pages" ]  && nav+="   ${WHITE}> next${RST}"
             printf "%b\n" "$nav"
         fi
-        printf "  ${WHITE}i <nums>${RST} Install   ${WHITE}r <num>${RST} Remove   ${WHITE}?<num>${RST} About   ${WHITE}ENTER${RST} Back\n"
+        printf "  ${WHITE}i <nums>${RST} Install   ${WHITE}r <num>${RST} Remove   ${WHITE}c <num>${RST} Config   ${WHITE}?<num>${RST} About   ${WHITE}ENTER${RST} Back\n"
 
         _read_menu_input "$(( tlines - 1 ))"
         local raw_choice="$_MENU_INPUT"
@@ -3863,7 +4014,10 @@ menu_modules() {
                     module_install "$key" "$name" "$url" "$sql_dirs" || true
                     echo ""
                 done
-                print_info "Modules cloned and SQL imported."
+                print_info "Modules cloned. SQL files will be applied automatically on next server start."
+                print_info "All C++ modules require a worldserver rebuild before they can load."
+                print_info "Conf files can be set up via 'Configure' — run configure after a rebuild if"
+                print_info "the conf.dist files are not yet present."
 
                 if [ "$SERVER_TYPE" = "playerbots" ]; then
                     print_info "Rebuild the worldserver to compile the new modules in."
@@ -3886,6 +4040,24 @@ menu_modules() {
                         echo ""
                         print_info "ALE requires post-install setup (lua_scripts dir + conf)."
                         if ask_yes_no "Configure ALE now?"; then configure_ale; fi
+                    fi
+                    if [ "$key" = "mod-challenge-modes" ]; then
+                        echo ""
+                        print_info "Challenge Modes has a conf file and requires EnablePlayerSettings = 1."
+                        print_info "Note: rebuild the worldserver first if the conf.dist is not yet present."
+                        if ask_yes_no "Configure Challenge Modes now?"; then configure_module_challenge_modes; fi
+                    fi
+                    if [ "$key" = "mod-player-bot-level-brackets" ]; then
+                        echo ""
+                        print_info "Bot Level Brackets requires the Playerbots module to function."
+                        print_info "Note: rebuild the worldserver first if the conf.dist is not yet present."
+                        if ask_yes_no "Configure Bot Level Brackets now?"; then configure_module_bot_level_brackets; fi
+                    fi
+                    if [ "$key" = "mod-npc-beastmaster" ]; then
+                        echo ""
+                        print_info "NPC Beastmaster has a conf file and SQL in db-world and db-characters."
+                        print_info "Note: rebuild the worldserver first if the conf.dist is not yet present."
+                        if ask_yes_no "Configure NPC Beastmaster now?"; then configure_module_npc_beastmaster; fi
                     fi
                 done
                 press_enter
@@ -3913,6 +4085,28 @@ menu_modules() {
                 fi
                 press_enter
                 ;;
+            c)
+                local cnum; cnum="${nums//[[:space:]]/}"
+                if ! [[ "$cnum" =~ ^[0-9]+$ ]] || \
+                   [ "$cnum" -lt 1 ] || [ "$cnum" -gt "$total" ]; then
+                    print_warning "Invalid module number — e.g. c3"
+                    press_enter; continue
+                fi
+                IFS='|' read -r key name _ _ <<< "${available_entries[$((cnum - 1))]}"
+                printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                case "$key" in
+                    mod-ah-bot)                  configure_ahbot ;;
+                    mod-ale)                     configure_ale ;;
+                    mod-challenge-modes)         configure_module_challenge_modes ;;
+                    mod-player-bot-level-brackets) configure_module_bot_level_brackets ;;
+                    mod-npc-beastmaster)         configure_module_npc_beastmaster ;;
+                    *)
+                        print_info "$name has no dedicated configure option."
+                        print_info "Edit its .conf file in $SERVER_DIR/env/dist/etc/modules/ directly."
+                        ;;
+                esac
+                press_enter
+                ;;
             [?])
                 local anum; anum="${nums//[[:space:]]/}"
                 if ! [[ "$anum" =~ ^[0-9]+$ ]] || \
@@ -3924,7 +4118,7 @@ menu_modules() {
                 show_about "$key" "$name" "$url"
                 ;;
             *)
-                print_warning "Unknown command. Use i <nums>, r <num>, ?<num>, or ENTER."
+                print_warning "Unknown command. Use i <nums>, r <num>, c <num>, ?<num>, or ENTER."
                 press_enter
                 ;;
         esac
@@ -3978,32 +4172,52 @@ show_first_run_welcome() {
         echo -e "${WHITE}You have ${BOLD}$user_module_count user-added module(s)${RST}${WHITE} already installed.${RST}"
     fi
     echo ""
+
+    echo -e "${WHITE}${BOLD}Three ways to modify your server:${RST}"
+    echo ""
+    echo -e "${GOLD}  1) AzerothCore Modules${RST}"
+    echo -e "${WHITE}     C++ plugins that rebuild into the worldserver binary. Add new${RST}"
+    echo -e "${WHITE}     features, mechanics, and systems. Require a ${BOLD}worldserver rebuild${RST}"
+    echo -e "${WHITE}     (30–90 min on Steam Deck) before they take effect.${RST}"
+    echo ""
+    echo -e "${GOLD}  2) ALE Lua Mods${RST}"
+    echo -e "${WHITE}     Lightweight Lua scripts that run inside the server at runtime —${RST}"
+    echo -e "${WHITE}     no rebuild needed after the first time. ${BOLD}Requires the AzerothCore${RST}"
+    echo -e "${WHITE}     ${BOLD}Lua Engine (ALE) module to be installed and configured first${RST}${WHITE}.${RST}"
+    echo -e "${WHITE}     Install ALE via option 1, then configure it via option 5.${RST}"
+    echo ""
+    echo -e "${GOLD}  3) SQL Mods${RST}"
+    echo -e "${WHITE}     Direct database tweaks: buff/nerf mobs, custom login messages,${RST}"
+    echo -e "${WHITE}     teleporters, rare drops, and more. Apply instantly — no rebuild.${RST}"
+    echo -e "${WHITE}     Databases are backed up automatically before each install.${RST}"
+    echo ""
+
     echo -e "${WHITE}${BOLD}A few things to know:${RST}"
     echo ""
     echo -e "${GREEN}  ✓${RST} ${WHITE}Nothing changes until you explicitly choose an action.${RST}"
-    echo -e "${WHITE}    Option 6 (Server status) and 10 (View logs) are read-only${RST}"
-    echo -e "${WHITE}    — safe to poke around and see what your install looks like.${RST}"
+    echo -e "${WHITE}    Options 7 (Server status) and 11 (View logs) are read-only.${RST}"
     echo ""
     echo -e "${GREEN}  ✓${RST} ${WHITE}You'll be asked before anything destructive.${RST}"
-    echo -e "${WHITE}    Adding/removing modules, rebuilding the worldserver, and${RST}"
-    echo -e "${WHITE}    the repair function all ask for confirmation first.${RST}"
+    echo -e "${WHITE}    Installs, removes, rebuilds, and database operations all ask first.${RST}"
     echo ""
-    echo -e "${GREEN}  ✓${RST} ${WHITE}Adding any module triggers a worldserver rebuild.${RST}"
-    echo -e "${WHITE}    On Steam Deck this takes 30-90 minutes. Plug in and${RST}"
-    echo -e "${WHITE}    keep the device on a flat surface for airflow.${RST}"
+    echo -e "${GREEN}  ✓${RST} ${WHITE}Option 13 → Server Maintenance has backup, restore, and repair tools.${RST}"
+    echo -e "${WHITE}    Repair only clears SQL update-tracking rows — it never drops tables.${RST}"
     echo ""
-    echo -e "${GREEN}  ✓${RST} ${WHITE}The repair function (option 13 → Server Maintenance) only clears SQL update${RST}"
-    echo -e "${WHITE}    tracking rows. It never drops database tables.${RST}"
-    echo ""
+
     if [ "$user_module_count" -eq 0 ]; then
         echo -e "${WHITE}${BOLD}Suggested first steps for a fresh install:${RST}"
-        echo -e "${WHITE}  1. Option ${CYAN}6${WHITE} (Server status) — see what containers are running${RST}"
-        echo -e "${WHITE}  2. Option ${CYAN}1${WHITE} (Modules) — browse and install modules${RST}"
+        echo -e "${WHITE}  1. Option ${CYAN}7${WHITE} (Server status) — confirm your containers are running${RST}"
+        echo -e "${WHITE}  2. Option ${CYAN}3${WHITE} (SQL Mods) — safe first tweaks, no rebuild needed${RST}"
+        echo -e "${WHITE}  3. Option ${CYAN}1${WHITE} (Modules) — browse and install C++ modules${RST}"
+        echo -e "${WHITE}  4. Option ${CYAN}5${WHITE} (Configure ALE) — if you installed the ALE module,${RST}"
+        echo -e "${WHITE}     configure it here, then use option ${CYAN}2${WHITE} to add Lua mods${RST}"
     else
         echo -e "${WHITE}${BOLD}Useful options for an existing install:${RST}"
-        echo -e "${WHITE}  • Option ${CYAN}1${WHITE} (Modules) — browse installed and available modules${RST}"
-        echo -e "${WHITE}  • Option ${CYAN}6${WHITE} (Server status) — check container state${RST}"
-        echo -e "${WHITE}  • Option ${CYAN}12${WHITE} (Repair) — if ac-db-import is failing${RST}"
+        echo -e "${WHITE}  • Option ${CYAN}1${WHITE} (Modules) — browse installed and available C++ modules${RST}"
+        echo -e "${WHITE}  • Option ${CYAN}2${WHITE} (ALE Lua Mods) — manage Lua scripts (needs ALE installed)${RST}"
+        echo -e "${WHITE}  • Option ${CYAN}3${WHITE} (SQL Mods) — database tweaks, no rebuild required${RST}"
+        echo -e "${WHITE}  • Option ${CYAN}7${WHITE} (Server status) — check container state${RST}"
+        echo -e "${WHITE}  • Option ${CYAN}13${WHITE} (Server Maintenance) — backup, restore, repair${RST}"
     fi
     echo ""
     echo -e "${DIM}This welcome shows once per install. The marker file at${RST}"

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -2456,6 +2456,187 @@ ale_script_remove() {
     print_info "(Database tables created by this script are kept — removing them risks data loss.)"
 }
 
+# ─────────────────────────────────────────────────────────────
+# ABOUT PANELS
+# ─────────────────────────────────────────────────────────────
+
+_get_about_text() {
+    local key="$1"
+    case "$key" in
+        mod-ah-bot)
+            printf '%s\n' \
+                'An Auction House bot that populates faction AH listings' \
+                'by automatically placing and bidding on auctions. Assign' \
+                'a dedicated bot character via account and character IDs,' \
+                'then enable seller, buyer, or both modes. Item quotas per' \
+                'quality tier are adjustable in config or the database table.'
+            ;;
+        mod-solocraft)
+            printf '%s\n' \
+                'Scales player stats inside dungeons and raids based on group' \
+                'size, making solo play viable at appropriate difficulty.' \
+                'Provides configurable per-instance difficulty settings, a' \
+                'spellpower buff, and an optional debuff for overpowered' \
+                'groups. Level thresholds prevent over-buffing characters.'
+            ;;
+        mod-aoe-loot)
+            printf '%s\n' \
+                'Enables Area-of-Effect looting -- interacting with one corpse' \
+                'automatically collects loot from all nearby corpses in a' \
+                'single window. Players toggle per-character via .aoeloot' \
+                'on/off. Configurable range, group support, and a 15-item cap' \
+                'per window keep server load stable.'
+            ;;
+        mod-learn-spells)
+            printf '%s\n' \
+                'Automatically teaches all available class spells on level-up,' \
+                'mimicking the Cataclysm auto-learn system. New abilities' \
+                'appear in the spellbook the moment a level is reached --' \
+                'no more visiting class trainers to unlock new skills.'
+            ;;
+        mod-individual-progression)
+            printf '%s\n' \
+                'Simulates a per-player Vanilla to TBC to WotLK content' \
+                'journey. NPCs, world objects, and quests phase in based on' \
+                'individual progression stage. Catch-up mechanics are removed' \
+                'to make each character journey meaningful. Works great' \
+                'alongside Playerbots or NPCBots.'
+            ;;
+        mod-autobalance)
+            printf '%s\n' \
+                'Dynamically scales dungeon and raid mob health, mana, and' \
+                'damage based on player count. Use .ab mapstat and' \
+                '.ab creaturestat in-game to inspect current multipliers.' \
+                'A GM .ab setoffset command tweaks server-wide difficulty.' \
+                'Config hot-reloads via .reload config.'
+            ;;
+        mod-transmog)
+            printf '%s\n' \
+                'Adds a Transmogrification NPC (entry 190010) letting players' \
+                'change the visual appearance of their gear. Based on the' \
+                'Rochet2 transmog script. Spawn the NPC anywhere with' \
+                '.npc add 190010. An optional TransmogPlus variant is' \
+                'available via mod-acore-subscriptions.'
+            ;;
+        mod-1v1-arena)
+            printf '%s\n' \
+                'Introduces solo 1v1 arena brackets so players can queue for' \
+                'ranked matches without needing a partner. Adds its own arena' \
+                'season structure and rating/reward system alongside the' \
+                'standard 2v2, 3v3, and 5v5 brackets.'
+            ;;
+        mod-ale)
+            printf '%s\n' \
+                'AzerothCore Lua Engine -- a powerful AzerothCore-specific' \
+                'Lua scripting runtime. Enables custom gameplay features,' \
+                'events, and mechanics without modifying core C++ code.' \
+                'Diverged from original Eluna; ALE scripts are NOT' \
+                'interchangeable with standard Eluna scripts. Supports' \
+                'LuaJIT (recommended), Lua 5.2, 5.3, and 5.4.'
+            ;;
+        accountwide)
+            printf '%s\n' \
+                'Syncs achievements, currencies, gold, mounts, and pets across' \
+                'all characters on an account. Each system is independently' \
+                'toggle-able in config. A mandatory helper script' \
+                '(00_AccountWideUtils.lua) must always be present alongside' \
+                'other scripts from this repo. Best installed on a fresh server.'
+            ;;
+        levelupreward)
+            printf '%s\n' \
+                'Sends in-game mail with gold or items when players hit' \
+                'configured levels. A lore-friendly mode includes the player' \
+                'rank in the mail text. Default rewards scale from 1g at' \
+                'level 10 up to generous amounts at higher levels. Fully' \
+                'customizable per level in the Lua config.'
+            ;;
+        exchangenpc)
+            printf '%s\n' \
+                'Spawns a configurable NPC that swaps items for other items --' \
+                'a custom material-exchange vendor. Define exchange pairs in' \
+                'the Lua config, run the world SQL to place the NPC, and' \
+                'players interact with it directly to trade materials.'
+            ;;
+        activechat)
+            printf '%s\n' \
+                'Simulates lively world and guild chat with scripted dialogues' \
+                'between fake players, making low-population servers feel' \
+                'inhabited. Chat text tables are fully customizable -- add new' \
+                'lines to npc_text.lua and npc_text_guild.lua to expand the' \
+                'conversation pool.'
+            ;;
+        battlepass)
+            printf '%s\n' \
+                'A complete Battle Pass progression system with XP earned from' \
+                'kills, quests, PvP, and dungeons. Rewards include items, gold,' \
+                'titles, and spells. Comes with an in-game client addon for' \
+                'progress tracking and an NPC vendor fallback. Players use .bp' \
+                'commands; GMs use .bpadmin. Requires the CSMH library.'
+            ;;
+        paragon)
+            printf '%s\n' \
+                'Endless post-max-level stat progression for AzerothCore.' \
+                'After reaching level 80, players earn Paragon XP that' \
+                'converts into stat bonuses, keeping end-game progression' \
+                'meaningful. Serverside is feature-complete; the clientside' \
+                'addon UI is in beta. Full architecture documentation included.'
+            ;;
+        bmah)
+            printf '%s\n' \
+                'A faithful backport of the Mists of Pandaria Black Market' \
+                'Auction House to AzerothCore 3.3.5 via Eluna Lua. Recreates' \
+                'the authentic MoP BMAH UI and server-side auction logic.' \
+                'Configure which NPC hosts the BMAH, the item pool, and bid' \
+                'timers. Includes a matching client addon for the full MoP look.'
+            ;;
+        lootpet)
+            printf '%s\n' \
+                'Turns your vanity pet into a functional auto-looter. The pet' \
+                'physically walks to nearby corpses to collect loot, adding' \
+                'immersion. Party-aware with configurable loot distance and' \
+                'group toggle. Default pet: Warbot (entry 34587, item 46767).' \
+                'Summon your Warbot and start hunting.'
+            ;;
+        sod)
+            printf '%s\n' \
+                'Awards a tiered XP bonus buff mimicking the Season of' \
+                'Discovery Discoverer Delight experience. Applies bonuses' \
+                'from +50% to +300% based on player level range, using custom' \
+                'spell IDs 80865 through 80870. Requires the matching spell' \
+                'data to be present on the server.'
+            ;;
+        sitmeanrest)
+            printf '%s\n' \
+                'Grants a regeneration buff (Graccu Fruitcake, spell 25990)' \
+                'when players use the /sit emote. The buff is instantly removed' \
+                'on any movement or entering combat, preventing exploit healing.' \
+                'Duration and regen spell ID are configurable in the CONFIG' \
+                'table at the top of SitMeansRest.lua.'
+            ;;
+        unlimitedammo)
+            printf '%s\n' \
+                'Automatically refills Hunter ammo (arrows or bullets) when' \
+                'the stack drops below a configurable threshold (default: 52).' \
+                'Keeps exactly one ammo type in bags -- no more running dry' \
+                'mid-fight. Enable via the ENABLED flag in config, or use' \
+                'the .ua GM command for runtime-only toggling.'
+            ;;
+        *)
+            printf '%s\n' 'No description available. See the GitHub link below.'
+            ;;
+    esac
+}
+
+show_about() {
+    local key="$1" name="$2" url="$3"
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    printf "  ${GOLD}── About: %s ──${RST}\n\n" "$name"
+    _get_about_text "$key" | sed 's/^/  /'
+    printf "\n  ${DIM}Source: %s${RST}\n" "$url"
+    printf "\n  ${DIM}Press ENTER to return...${RST}\n"
+    read -r _
+}
+
 # ── ALE Scripts submenu ───────────────────────────────────────
 menu_ale_scripts() {
     local page_start=0
@@ -2530,7 +2711,7 @@ menu_ale_scripts() {
             [ "$current_page" -lt "$total_pages" ]  && nav+="   ${WHITE}> next${RST}"
             printf "%b\n" "$nav"
         fi
-        printf "  ${WHITE}i<nums>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}ENTER${RST} Back\n"
+        printf "  ${WHITE}i<nums>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}?<num>${RST} About   ${WHITE}ENTER${RST} Back\n"
 
         _read_menu_input "$(( tlines - 1 ))"
         local raw_choice="$_MENU_INPUT"
@@ -2608,8 +2789,18 @@ menu_ale_scripts() {
                 esac
                 press_enter
                 ;;
+            [?])
+                local anum; anum="${nums//[[:space:]]/}"
+                if ! [[ "$anum" =~ ^[0-9]+$ ]] || \
+                   [ "$anum" -lt 1 ] || [ "$anum" -gt "$total" ]; then
+                    print_warning "Invalid script number -- e.g. ?5"
+                    press_enter; continue
+                fi
+                IFS='|' read -r key name url <<< "${available_entries[$((anum - 1))]}"
+                show_about "$key" "$name" "$url"
+                ;;
             *)
-                print_warning "Unknown command. Use i<nums>, r<num>, c<num>, or ENTER."
+                print_warning "Unknown command. Use i<nums>, r<num>, c<num>, ?<num>, or ENTER."
                 press_enter
                 ;;
         esac
@@ -2722,7 +2913,7 @@ menu_modules() {
             [ "$current_page" -lt "$total_pages" ]  && nav+="   ${WHITE}> next${RST}"
             printf "%b\n" "$nav"
         fi
-        printf "  ${WHITE}i <nums>${RST} Install   ${WHITE}r <num>${RST} Remove   ${WHITE}ENTER${RST} Back\n"
+        printf "  ${WHITE}i <nums>${RST} Install   ${WHITE}r <num>${RST} Remove   ${WHITE}?<num>${RST} About   ${WHITE}ENTER${RST} Back\n"
 
         _read_menu_input "$(( tlines - 1 ))"
         local raw_choice="$_MENU_INPUT"
@@ -2828,8 +3019,18 @@ menu_modules() {
                 fi
                 press_enter
                 ;;
+            [?])
+                local anum; anum="${nums//[[:space:]]/}"
+                if ! [[ "$anum" =~ ^[0-9]+$ ]] || \
+                   [ "$anum" -lt 1 ] || [ "$anum" -gt "$total" ]; then
+                    print_warning "Invalid module number -- e.g. ?3"
+                    press_enter; continue
+                fi
+                IFS='|' read -r key name url _sql_dirs <<< "${available_entries[$((anum - 1))]}"
+                show_about "$key" "$name" "$url"
+                ;;
             *)
-                print_warning "Unknown command. Use i <nums>, r <num>, or ENTER."
+                print_warning "Unknown command. Use i <nums>, r <num>, ?<num>, or ENTER."
                 press_enter
                 ;;
         esac
@@ -2945,7 +3146,7 @@ main_menu() {
             "$(basename "$SERVER_DIR")" "$state_str" "$build_str"
         printf "\n  ${GOLD}${BOLD}Server Modifications${RST}\n"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
-        printf "  ${WHITE}1)${RST} Manage Modules\n"
+        printf "  ${WHITE}1)${RST} Manage AzerothCore Modules\n"
         printf "  ${WHITE}2)${RST} Manage ALE Lua Mods\n"
         printf "  ${WHITE}3)${RST} Configure AH Bot\n"
         printf "  ${WHITE}4)${RST} Configure ALE\n"

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -588,7 +588,7 @@ server_start() {
             print_info "Most common causes and fixes:"
             print_info ""
             print_info "  • ${CYAN}'Table X already exists' errors${RST}: a previous module install"
-            print_info "    corrupted update tracking. Use option 13 → Server Maintenance → Repair install state."
+            print_info "    corrupted update tracking. Use option 14 → Server Maintenance → Repair install state."
             print_info ""
             print_info "  • ${CYAN}'Permission denied' errors${RST}: UID/GID mismatch on env/dist."
             print_info "    Run: sudo chown -R 1000:1000 env/dist/etc env/dist/logs"
@@ -1079,7 +1079,7 @@ repair_install_state() {
     esac
 
     echo ""
-    print_info "Done. Start the server (menu option 7) for AC to re-apply cleared SQL."
+    print_info "Done. Start the server (menu option 9) for AC to re-apply cleared SQL."
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -1243,11 +1243,10 @@ configure_ahbot() {
 
     if ! module_is_installed "mod-ah-bot"; then
         print_error "mod-ah-bot is not installed yet!"
-        print_info "Add it first via the main menu (Add modules)."
+        print_info "Add it first via main menu option 1 (Manage AzerothCore Modules)."
         return 1
     fi
 
-    echo ""
     echo -e "${WHITE}The Auction House Bot needs a player account and character${RST}"
     echo -e "${WHITE}to act as. The bot uses this character to list items.${RST}"
     echo ""
@@ -1355,7 +1354,7 @@ configure_ale() {
 
     if ! module_is_installed "mod-ale"; then
         print_error "mod-ale is not installed yet!"
-        print_info "Add it first via the main menu (Add modules)."
+        print_info "Add it first via main menu option 1 (Manage AzerothCore Modules)."
         return 1
     fi
 
@@ -2563,7 +2562,7 @@ ale_script_install() {
             if ask_yes_no "Configure Battle Pass SQL and settings now?"; then
                 configure_ale_battlepass
             else
-                print_info "Run option 4 → c5 to reconfigure Battle Pass later."
+                print_info "Run main menu option 5 (Configure ALE) to reconfigure Battle Pass later."
                 print_info "Remember to apply SQL manually from:"
                 print_info "  $clone_dir/sql/"
             fi
@@ -3842,7 +3841,7 @@ menu_ale_scripts() {
 
         if ! module_is_installed "mod-ale"; then
             printf "  ${RED}✗ mod-ale (ALE Lua Engine) is not installed.${RST}\n"
-            printf "  ${WHITE}Install via main menu option 1, then configure via option 3.${RST}\n"
+            printf "  ${WHITE}Install via main menu option 1, then configure via option 5.${RST}\n"
             printf "\n  ${DIM}Press ENTER to return...${RST}\n"
             read -r _
             return
@@ -4402,7 +4401,7 @@ _module_conf_hints() {
                 '  - AuctionHouseBot.EnableBuyer' \
                 '  - AuctionHouseBot.Account / GUID / GUIDs' \
                 '  - AuctionHouseBot.Trace* debugging flags' \
-                'Tip: use top-level option 5 for guided AH Bot setup.'
+                'Tip: use top-level option 4 for guided AH Bot setup.'
             ;;
         mod-autobalance)
             printf '%s\n' \
@@ -4416,7 +4415,7 @@ _module_conf_hints() {
                 'Common options:' \
                 '  - ALE.ScriptPath' \
                 '  - ALE.EnableLuaEngine' \
-                'Tip: use top-level option 6 for guided ALE setup.'
+                'Tip: use top-level option 5 for guided ALE setup.'
             ;;
         mod-player-bot-level-brackets)
             printf '%s\n' \
@@ -4590,7 +4589,7 @@ menu_module_management() {
                 fi
                 if ! module_is_installed "$key"; then
                     print_warning "$name is not installed."
-                    print_info "Install it first from top-level option Install modules, then rebuild via Rebuild worldserver."
+                    print_info "Install it first via main menu option 1 (Manage AzerothCore Modules), then rebuild via option 7 (Rebuild worldserver)."
                     press_enter
                     continue
                 fi
@@ -4734,18 +4733,18 @@ show_first_run_welcome() {
     echo -e "${WHITE}${BOLD}A few things to know:${RST}"
     echo ""
     echo -e "${GREEN}  ✓${RST} ${WHITE}Nothing changes until you explicitly choose an action.${RST}"
-    echo -e "${WHITE}    Options 7 (Server status) and 11 (View logs) are read-only.${RST}"
+    echo -e "${WHITE}    Options 8 (Server status) and 12 (View logs) are read-only.${RST}"
     echo ""
     echo -e "${GREEN}  ✓${RST} ${WHITE}You'll be asked before anything destructive.${RST}"
     echo -e "${WHITE}    Installs, removes, rebuilds, and database operations all ask first.${RST}"
     echo ""
-    echo -e "${GREEN}  ✓${RST} ${WHITE}Option 13 → Server Maintenance has backup, restore, and repair tools.${RST}"
+    echo -e "${GREEN}  ✓${RST} ${WHITE}Option 14 → Server Maintenance has backup, restore, and repair tools.${RST}"
     echo -e "${WHITE}    Repair only clears SQL update-tracking rows — it never drops tables.${RST}"
     echo ""
 
     if [ "$user_module_count" -eq 0 ]; then
         echo -e "${WHITE}${BOLD}Suggested first steps for a fresh install:${RST}"
-        echo -e "${WHITE}  1. Option ${CYAN}7${WHITE} (Server status) — confirm your containers are running${RST}"
+        echo -e "${WHITE}  1. Option ${CYAN}8${WHITE} (Server status) — confirm your containers are running${RST}"
         echo -e "${WHITE}  2. Option ${CYAN}3${WHITE} (SQL Mods) — safe first tweaks, no rebuild needed${RST}"
         echo -e "${WHITE}  3. Option ${CYAN}1${WHITE} (Modules) — browse and install C++ modules${RST}"
         echo -e "${WHITE}  4. Option ${CYAN}5${WHITE} (Configure ALE) — if you installed the ALE module,${RST}"
@@ -4755,8 +4754,8 @@ show_first_run_welcome() {
         echo -e "${WHITE}  • Option ${CYAN}1${WHITE} (Modules) — browse installed and available C++ modules${RST}"
         echo -e "${WHITE}  • Option ${CYAN}2${WHITE} (ALE Lua Mods) — manage Lua scripts (needs ALE installed)${RST}"
         echo -e "${WHITE}  • Option ${CYAN}3${WHITE} (SQL Mods) — database tweaks, no rebuild required${RST}"
-        echo -e "${WHITE}  • Option ${CYAN}7${WHITE} (Server status) — check container state${RST}"
-        echo -e "${WHITE}  • Option ${CYAN}13${WHITE} (Server Maintenance) — backup, restore, repair${RST}"
+        echo -e "${WHITE}  • Option ${CYAN}8${WHITE} (Server status) — check container state${RST}"
+        echo -e "${WHITE}  • Option ${CYAN}14${WHITE} (Server Maintenance) — backup, restore, repair${RST}"
     fi
     echo ""
     echo -e "${DIM}This welcome shows once per install. The marker file at${RST}"

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -274,7 +274,7 @@ _offer_npc_in_capitals() {
     echo -e "  ${WHITE}In-game GM:${RST}  ${CYAN}.npc add $npc_entry 1 $og_x $og_y 17.5 4.5${RST}"
     echo -e "  ${WHITE}WS console:${RST}  ${CYAN}npc add $npc_entry 1 $og_x $og_y 17.5 4.5${RST}"
     echo ""
-    print_info "Access the worldserver console via option 12 from the main menu."
+    print_info "Access the worldserver console via option 13 from the main menu."
     print_info "If the NPC lands in a bad spot, use .npc delete (in-game) or"
     print_info "npc delete (console) then re-place with your own coordinates."
     echo ""
@@ -1310,8 +1310,8 @@ configure_ahbot() {
         return 1
     fi
 
-    mkdir -p "$SERVER_DIR/conf/modules"
-    local conf_active="$SERVER_DIR/conf/modules/mod_ahbot.conf"
+    mkdir -p "$SERVER_DIR/env/dist/etc/modules"
+    local conf_active="$SERVER_DIR/env/dist/etc/modules/mod_ahbot.conf"
     cp "$conf_dist" "$conf_active"
 
     sed -i \
@@ -4291,6 +4291,379 @@ menu_modules() {
     done
 }
 
+# ── Module Management (conf files) ────────────────────────────
+_module_conf_name() {
+    case "$1" in
+        mod-1v1-arena)                  echo "1v1arena.conf" ;;
+        mod-aoe-loot)                   echo "mod_aoe_loot.conf" ;;
+        mod-ah-bot)                     echo "mod_ahbot.conf" ;;
+        mod-autobalance)                echo "AutoBalance.conf" ;;
+        mod-ale)                        echo "mod_ale.conf" ;;
+        mod-player-bot-level-brackets)  echo "mod_player_bot_level_brackets.conf" ;;
+        mod-challenge-modes)            echo "challenge_modes.conf" ;;
+        mod-individual-progression)     echo "individualProgression.conf" ;;
+        mod-junk-to-gold)               echo "" ;;
+        mod-learn-spells)               echo "mod_learnspells.conf" ;;
+        mod-npc-beastmaster)            echo "mod_npc_beastmaster.conf" ;;
+        mod-solocraft)                  echo "Solocraft.conf" ;;
+        mod-transmog)                   echo "transmog.conf" ;;
+        *)                              echo "" ;;
+    esac
+}
+
+_module_conf_active_path() {
+    local conf_name; conf_name=$(_module_conf_name "$1")
+    [ -z "$conf_name" ] && return 1
+    echo "$SERVER_DIR/env/dist/etc/modules/$conf_name"
+}
+
+_module_conf_dist_path() {
+    local key="$1"
+    local conf_name; conf_name=$(_module_conf_name "$key")
+    [ -z "$conf_name" ] && return 1
+
+    local expected="$SERVER_DIR/modules/$key/conf/${conf_name}.dist"
+    [ -f "$expected" ] && { echo "$expected"; return 0; }
+
+    local found
+    found=$(find "$SERVER_DIR/modules/$key" -maxdepth 4 -type f -name "${conf_name}.dist" 2>/dev/null | head -1)
+    [ -n "$found" ] && { echo "$found"; return 0; }
+    return 1
+}
+
+_module_conf_sync_legacy_if_needed() {
+    local key="$1"
+    [ "$key" != "mod-ah-bot" ] && return 0
+    local active legacy
+    active=$(_module_conf_active_path "$key") || return 0
+    legacy="$SERVER_DIR/conf/modules/mod_ahbot.conf"
+    if [ ! -f "$active" ] && [ -f "$legacy" ]; then
+        mkdir -p "$(dirname "$active")"
+        cp "$legacy" "$active"
+    fi
+}
+
+_module_conf_status() {
+    local key="$1"
+    local conf_name; conf_name=$(_module_conf_name "$key")
+    if [ -z "$conf_name" ]; then
+        echo "${DIM}No conf${RST}"
+        return 0
+    fi
+
+    _module_conf_sync_legacy_if_needed "$key"
+    local active
+    active=$(_module_conf_active_path "$key") || true
+
+    if ! module_is_installed "$key"; then
+        if [ -n "$active" ] && [ -f "$active" ]; then
+            echo "${YELLOW}⚠ Conf exists, module missing${RST}"
+        else
+            echo "${DIM}○ Not installed${RST}"
+        fi
+        return 0
+    fi
+
+    if [ -n "$active" ] && [ -f "$active" ]; then
+        echo "${GREEN}✓ Active${RST}"
+        return 0
+    fi
+
+    if _module_conf_dist_path "$key" >/dev/null 2>&1; then
+        echo "${CYAN}◑ Ready to activate${RST}"
+    else
+        echo "${YELLOW}⚠ Rebuild needed${RST}"
+    fi
+}
+
+_module_conf_hints() {
+    case "$1" in
+        mod-1v1-arena)
+            printf '%s\n' \
+                'Common options:' \
+                '  - Arena1v1.Enable' \
+                '  - Arena1v1.MinLevel' \
+                '  - Arena1v1.Costs' \
+                '  - Arena1v1.Announcer' \
+                '  - Arena1v1.PreventHealingTalents'
+            ;;
+        mod-aoe-loot)
+            printf '%s\n' \
+                'Common options:' \
+                '  - AOELoot.Enable' \
+                '  - AOELoot.Message' \
+                '  - AOELoot.Range' \
+                '  - AOELoot.Group'
+            ;;
+        mod-ah-bot)
+            printf '%s\n' \
+                'Common options:' \
+                '  - AuctionHouseBot.EnableSeller' \
+                '  - AuctionHouseBot.EnableBuyer' \
+                '  - AuctionHouseBot.Account / GUID / GUIDs' \
+                '  - AuctionHouseBot.Trace* debugging flags' \
+                'Tip: use top-level option 5 for guided AH Bot setup.'
+            ;;
+        mod-autobalance)
+            printf '%s\n' \
+                'Common options:' \
+                '  - AutoBalance.Enable.* toggles' \
+                '  - Scaling controls by map size/content' \
+                '  - Dungeon/raid coverage toggles'
+            ;;
+        mod-ale)
+            printf '%s\n' \
+                'Common options:' \
+                '  - ALE.ScriptPath' \
+                '  - ALE.EnableLuaEngine' \
+                'Tip: use top-level option 6 for guided ALE setup.'
+            ;;
+        mod-player-bot-level-brackets)
+            printf '%s\n' \
+                'Common options:' \
+                '  - BotLevelBrackets.Enabled' \
+                '  - CheckFrequency / CheckFlaggedFrequency' \
+                '  - IgnoreGuildBotsWithRealPlayers' \
+                '  - IgnoreArenaTeamBots' \
+                'Requires Playerbots module.'
+            ;;
+        mod-challenge-modes)
+            printf '%s\n' \
+                'Common options:' \
+                '  - ChallengeModes.Enable' \
+                '  - Hardcore.Enable' \
+                '  - Hardcore.XPMultiplier' \
+                '  - Hardcore.TalentRewards / ItemRewards' \
+                'Also requires EnablePlayerSettings = 1 in worldserver.conf.'
+            ;;
+        mod-individual-progression)
+            printf '%s\n' \
+                'Common options:' \
+                '  - IndividualProgression.Enable' \
+                '  - EnforceGroupRules' \
+                '  - VanillaPowerAdjustment / VanillaHealingAdjustment' \
+                '  - QuestXPFix'
+            ;;
+        mod-junk-to-gold)
+            printf '%s\n' \
+                'This module has no standard .conf.dist file.' \
+                'Behavior is module-driven with no exposed runtime conf here.'
+            ;;
+        mod-learn-spells)
+            printf '%s\n' \
+                'Common options:' \
+                '  - LearnSpells.Enable' \
+                '  - LearnSpells.Announce' \
+                '  - LearnSpells.OnFirstLogin' \
+                '  - LearnSpells.MaxLevel'
+            ;;
+        mod-npc-beastmaster)
+            printf '%s\n' \
+                'Common options:' \
+                '  - BeastMaster.Enable' \
+                '  - BeastMaster.HunterOnly' \
+                '  - BeastMaster.AllowedClasses' \
+                '  - BeastMaster.MinLevel' \
+                'Tip: add 601026 to Creatures.CustomIDs in worldserver.conf.'
+            ;;
+        mod-solocraft)
+            printf '%s\n' \
+                'Common options:' \
+                '  - Solocraft.Enable / Solocraft.Announce' \
+                '  - SoloCraft.Debuff.Enable' \
+                '  - SoloCraft.Spellpower.Mult / SoloCraft.Stats.Mult'
+            ;;
+        mod-transmog)
+            printf '%s\n' \
+                'Common options:' \
+                '  - Transmogrification.Enable' \
+                '  - ShowSetDisclaimer' \
+                '  - UseCollectionSystem / UseVendorInterface' \
+                '  - AllowHiddenTransmog'
+            ;;
+    esac
+}
+
+menu_module_management() {
+    local page_start=0
+    while true; do
+        local tlines; tlines=$(tput lines 2>/dev/null || echo 24)
+        printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+
+        local -a available_entries=()
+        local entry
+        for entry in "${MODULE_REGISTRY[@]}"; do available_entries+=("$entry"); done
+
+        local total=${#available_entries[@]}
+        local avail=$(( tlines - MENU_START_ROW - 1 ))
+        local page_size=$(( avail - 10 ))
+        [ "$page_size" -lt 3 ] && page_size=3
+        local max_start=$(( total - page_size ))
+        [ "$max_start" -lt 0 ] && max_start=0
+        [ "$page_start" -gt "$max_start" ] && page_start=$max_start
+        [ "$page_start" -lt 0 ] && page_start=0
+        local page_end=$(( page_start + page_size ))
+        [ "$page_end" -gt "$total" ] && page_end=$total
+        local total_pages=$(( (total + page_size - 1) / page_size ))
+        local current_page=$(( page_start / page_size + 1 ))
+
+        printf "  ${GOLD}── Module Management ─────────────────────────────${RST}\n"
+        printf "  ${DIM}Conf files are activated by copying: .conf.dist -> .conf${RST}\n"
+        printf "  ${DIM}Path: $SERVER_DIR/env/dist/etc/modules/${RST}\n"
+        printf "  ${YELLOW}⚠  After installing modules, run top-level option 7 (Rebuild worldserver) first.${RST}\n"
+        printf "  ${DIM}%-4s %-34s %s${RST}\n" "Num" "Module" "Conf Status"
+        printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
+
+        local idx key name url sql_dirs
+        for (( idx=page_start; idx<page_end; idx++ )); do
+            IFS='|' read -r key name url sql_dirs <<< "${available_entries[$idx]}"
+            printf "  ${WHITE}%2d)${RST} %-34s %b\n" "$(( idx + 1 ))" "$name" "$(_module_conf_status "$key")"
+        done
+
+        printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
+        if [ "$total_pages" -gt 1 ]; then
+            local nav="  ${DIM}Page $current_page/$total_pages${RST}"
+            [ "$current_page" -gt 1 ] && nav+="   ${WHITE}< prev${RST}"
+            [ "$current_page" -lt "$total_pages" ] && nav+="   ${WHITE}> next${RST}"
+            printf "%b\n" "$nav"
+        fi
+        printf "  ${WHITE}a<num>${RST} Activate conf   ${WHITE}e<num>${RST} Edit conf   ${WHITE}r<num>${RST} Reset defaults   ${WHITE}?<num>${RST} Help   ${WHITE}ENTER${RST} Back\n"
+
+        _read_menu_input "$(( tlines - 1 ))"
+        local raw_choice="$_MENU_INPUT"
+        [ -z "$raw_choice" ] && return
+
+        local action nums inum
+        action="${raw_choice:0:1}"
+        nums="${raw_choice:1}"
+
+        case "${action,,}" in
+            '<')
+                page_start=$(( page_start - page_size ))
+                [ "$page_start" -lt 0 ] && page_start=0
+                ;;
+            '>')
+                page_start=$(( page_start + page_size ))
+                [ "$page_start" -gt "$max_start" ] && page_start=$max_start
+                ;;
+            a|e|r|?)
+                inum="${nums//[[:space:]]/}"
+                if ! [[ "$inum" =~ ^[0-9]+$ ]] || [ "$inum" -lt 1 ] || [ "$inum" -gt "$total" ]; then
+                    print_warning "Invalid module number."
+                    press_enter
+                    continue
+                fi
+                IFS='|' read -r key name url sql_dirs <<< "${available_entries[$((inum - 1))]}"
+
+                if [ "${action,,}" = "?" ]; then
+                    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                    printf "  ${GOLD}── Module Config Help: %s ──${RST}\n\n" "$name"
+                    local conf_name conf_dist conf_active
+                    conf_name=$(_module_conf_name "$key")
+                    if [ -z "$conf_name" ]; then
+                        printf "  ${DIM}No standard .conf.dist for this module.${RST}\n"
+                    else
+                        conf_dist=$(_module_conf_dist_path "$key" 2>/dev/null || true)
+                        conf_active=$(_module_conf_active_path "$key" 2>/dev/null || true)
+                        printf "  ${CYAN}Expected active file:${RST} %s\n" "$conf_active"
+                        if [ -n "$conf_dist" ]; then
+                            printf "  ${CYAN}Template (.dist):${RST} %s\n" "$conf_dist"
+                        else
+                            printf "  ${YELLOW}Template (.dist):${RST} not found yet (install + rebuild worldserver first)\n"
+                        fi
+                    fi
+                    echo ""
+                    _module_conf_hints "$key" | sed 's/^/  /'
+                    echo ""
+                    printf "  ${DIM}After conf changes: restart worldserver to apply.${RST}\n"
+                    printf "  ${DIM}Press ENTER to return...${RST}\n"
+                    read -r _
+                    continue
+                fi
+
+                local conf_name conf_dist conf_active
+                conf_name=$(_module_conf_name "$key")
+                if [ -z "$conf_name" ]; then
+                    print_warning "$name has no standard .conf.dist configuration file."
+                    press_enter
+                    continue
+                fi
+                if ! module_is_installed "$key"; then
+                    print_warning "$name is not installed."
+                    print_info "Install it first from top-level option 1, then rebuild via option 7."
+                    press_enter
+                    continue
+                fi
+
+                _module_conf_sync_legacy_if_needed "$key"
+                conf_dist=$(_module_conf_dist_path "$key" 2>/dev/null || true)
+                conf_active=$(_module_conf_active_path "$key" 2>/dev/null || true)
+                mkdir -p "$SERVER_DIR/env/dist/etc/modules"
+
+                if [ "${action,,}" = "a" ]; then
+                    if [ -z "$conf_dist" ] || [ ! -f "$conf_dist" ]; then
+                        print_warning "Template .dist not found for $name."
+                        print_info "Run top-level option 7 (Rebuild worldserver), then try again."
+                        press_enter
+                        continue
+                    fi
+                    if [ -f "$conf_active" ] && ! ask_yes_no "Active conf already exists. Overwrite it?"; then
+                        print_info "Kept existing conf."
+                        press_enter
+                        continue
+                    fi
+                    cp "$conf_dist" "$conf_active"
+                    print_success "Activated conf: $conf_active"
+                    print_info "Restart worldserver (top-level option 11) to apply."
+                    press_enter
+                    continue
+                fi
+
+                if [ "${action,,}" = "e" ]; then
+                    if [ ! -f "$conf_active" ]; then
+                        if [ -n "$conf_dist" ] && [ -f "$conf_dist" ] && ask_yes_no "No active conf yet. Create it from .dist now?"; then
+                            cp "$conf_dist" "$conf_active"
+                            print_success "Created $conf_active"
+                        else
+                            print_warning "No active conf file to edit."
+                            print_info "Use a<num> to activate first."
+                            press_enter
+                            continue
+                        fi
+                    fi
+                    ${EDITOR:-nano} "$conf_active"
+                    print_info "Restart worldserver (top-level option 11) to apply."
+                    press_enter
+                    continue
+                fi
+
+                if [ "${action,,}" = "r" ]; then
+                    if [ -z "$conf_dist" ] || [ ! -f "$conf_dist" ]; then
+                        print_warning "Template .dist not found for $name."
+                        print_info "Run top-level option 7 (Rebuild worldserver), then try again."
+                        press_enter
+                        continue
+                    fi
+                    if ! ask_yes_no "Reset $name conf to defaults? This overwrites current changes."; then
+                        print_info "Canceled."
+                        press_enter
+                        continue
+                    fi
+                    cp "$conf_dist" "$conf_active"
+                    print_success "Reset to defaults: $conf_active"
+                    print_info "Restart worldserver (top-level option 11) to apply."
+                    press_enter
+                    continue
+                fi
+                ;;
+            *)
+                print_warning "Unknown command. Use a<num>, e<num>, r<num>, ?<num>, or ENTER."
+                press_enter
+                ;;
+        esac
+    done
+}
+
 # ─────────────────────────────────────────────────────────────
 # FIRST-RUN WELCOME
 # ─────────────────────────────────────────────────────────────
@@ -4436,7 +4809,7 @@ menu_sql_mods() {
         local current_page=$(( page_start / page_size + 1 ))
 
         printf "  ${GOLD}── SQL Mods ──────────────────────────────────────${RST}\n"
-        printf "  ${YELLOW}⚠  Edits the world DB — auto-backup runs before each install${RST}\n"
+        printf "  ${YELLOW}⚠  Edits the world DB — auto-backup runs before each install (see \"sql_scripts\" directory)${RST}\n"
         printf "  ${DIM}%-4s %-40s %s${RST}\n" "Num" "Mod" "Status"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
 

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # ============================================================
 #  Dad's MMO Lab — WoW Module Manager
-#  manage-wow-modules.sh
+#  wow-manage.sh
 #
 #  Post-install management for AzerothCore WoW servers:
 #    - Add/remove modules (AH Bot, Solocraft, Transmog, etc.)
@@ -20,8 +20,8 @@
 #  is EXPERIMENTAL and clearly marked.
 #
 #  Usage:
-#    chmod +x manage-wow-modules.sh
-#    ./manage-wow-modules.sh
+#    chmod +x wow-manage.sh
+#    ./wow-manage.sh
 #
 #  https://github.com/DadsMmoLab/dads-mmo-lab
 # ============================================================
@@ -36,22 +36,20 @@ BLUE='\033[0;34m'; WHITE='\033[1;37m'; CYAN='\033[0;36m'
 GOLD='\033[38;5;220m'; DIM='\033[2m'
 
 # ─────────────────────────────────────────────────────────────
-# UI HELPERS
+# SCREEN SETUP & UI HELPERS
 # ─────────────────────────────────────────────────────────────
-# ─────────────────────────────────────────────────────────────
-# LOGO & SCREEN SETUP
-# ─────────────────────────────────────────────────────────────
-# Layout (1-indexed rows):
-#   Row  1    : blank
-#   Rows 2-9  : 8 logo lines  (animated during intro, static thereafter)
-#   Row  10   : blank
-#   Row  11   : separator bar
-#   Row  12   : "WoW Module Manager  ✦  vX.Y.Z"
-#   Row  13   : separator bar
-#   Row  14   : blank
-#   Row  15+  : menu content
+# Layout modes (1-indexed rows):
+#
+#   Full-logo mode  (_IN_MENU=false, e.g. intro / first-run):
+#     Rows 1–9  : 8-line logo + animation   →  MENU_START_ROW=15
+#
+#   Slim-banner mode  (_IN_MENU=true, i.e. any menu screen):
+#     Rows 1–4  : 4-row compact banner      →  MENU_START_ROW=5
+#
+#   Narrow-fallback mode  (terminal width < 80 cols):
+#     Rows 1–5  : minimal header            →  MENU_START_ROW=6
+#
 MENU_START_ROW=15
-MENU_INPUT_ROW=24
 _TERM_LINES=24
 _TERM_COLS=80
 _RESIZE_NEEDED=false
@@ -141,7 +139,71 @@ _read_menu_input() {
     _MENU_INPUT=""
     printf '\033[%d;3H\033[K' "$_input_row"
     printf "${WHITE}Choice: ${RST}"
-    read -r _MENU_INPUT || { [ -z "$_MENU_INPUT" ] && return 2; }
+    read -r _MENU_INPUT
+    local _rc=$?
+    if [ $_rc -ne 0 ]; then
+        # SIGWINCH interrupts read and sets _RESIZE_NEEDED=true — that is a resize event.
+        # Anything else (Ctrl-D, closed stdin) is treated as EOF → callers should exit.
+        [ "$_RESIZE_NEEDED" = true ] && return 2   # resize — caller should continue/redraw
+        return 3                                    # EOF / broken stdin — caller should exit
+    fi
+}
+
+_PARSED_INDEX=""
+_parse_single_index() {
+    local raw="$1" max="$2"
+    # Allow surrounding whitespace but reject embedded spaces (e.g. "1 2" must not become "12").
+    if ! [[ "$raw" =~ ^[[:space:]]*([0-9]+)[[:space:]]*$ ]]; then
+        return 1
+    fi
+    local idx="${BASH_REMATCH[1]}"
+    if [ "$idx" -lt 1 ] || [ "$idx" -gt "$max" ]; then
+        return 1
+    fi
+    _PARSED_INDEX="$idx"
+}
+
+# Keep only the $3 (default: 2) most-recent routine backup files matching glob
+# $2 inside directory $1.  Safety/pre-restore backups (names containing
+# "_pre_restore_") are never touched.
+_prune_backup_files() {
+    local dir="$1" pattern="$2" keep="${3:-2}"
+    local -a files=()
+    while IFS= read -r f; do
+        [[ "$(basename "$f")" == *_pre_restore_* ]] && continue
+        files+=("$f")
+    done < <(ls -t "$dir"/$pattern 2>/dev/null)
+    local i
+    for (( i=keep; i<${#files[@]}; i++ )); do
+        rm -f "${files[$i]}"
+    done
+}
+
+# Returns 0 if running on a Steam Deck (SteamOS).
+_is_steam_deck() {
+    grep -qi 'ID.*steamos\|ID_LIKE.*steamos' /etc/os-release 2>/dev/null
+}
+
+# Open a text file for editing.
+# On Steam Deck: nano has no Ctrl key to exit, so show the path and offer Kate.
+# Elsewhere: open nano directly.
+_open_text_file() {
+    local filepath="$1"
+    if _is_steam_deck; then
+        echo ""
+        print_info "File location:"
+        echo -e "  ${CYAN}${filepath}${RST}"
+        echo ""
+        if command -v kate &>/dev/null; then
+            if ask_yes_no "Open in Kate (graphical text editor)?"; then
+                kate "$filepath" &>/dev/null &
+            fi
+        else
+            print_info "Open this file with your preferred text editor."
+        fi
+    else
+        nano "$filepath"
+    fi
 }
 
 _screen_int_handler() {
@@ -150,6 +212,12 @@ _screen_int_handler() {
         exit 0
     fi
     # Inside with_full_screen: SIGINT already killed the foreground child — just return
+}
+
+_screen_term_handler() {
+    # SIGTERM always restores the terminal and exits cleanly.
+    printf '\033[r\033[?1049l\033[?25h'
+    exit 0
 }
 
 # Draw the logo + subtitle bar statically (full clear + redraw).
@@ -215,7 +283,8 @@ _setup_screen() {
 start_logo_animation() {
     _setup_screen
     trap 'tput smam 2>/dev/null || true; printf "\033[r\033[?1049l\033[?25h"' EXIT
-    trap '_screen_int_handler' INT TERM
+    trap '_screen_int_handler' INT
+    trap '_screen_term_handler' TERM
     trap '_handle_resize' WINCH
 
     # Start animation subprocess
@@ -234,7 +303,7 @@ start_logo_animation() {
     printf '\033[?25l'
     _draw_logo_static
     printf '\033[?25h'
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
 }
 
 # Clear screen, run a function, restore the static logo + scroll region.
@@ -248,7 +317,7 @@ with_full_screen() {
     trap '_handle_resize' WINCH
     _ALLOW_INT_EXIT=true
     _setup_screen
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
 }
 
 print_header() {
@@ -257,8 +326,8 @@ print_header() {
 }
 
 print_step()    { echo ""; echo -e "${GOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
-                   echo -e "${WHITE}${BOLD} $1${RST}"
-                   echo -e "${GOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"; }
+                    echo -e "${WHITE}${BOLD} $1${RST}"
+                    echo -e "${GOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"; }
 print_success() { echo -e "${GREEN}✅ $1${RST}"; }
 print_warning() { echo -e "${YELLOW}⚠️  $1${RST}"; }
 print_error()   { echo -e "${RED}❌ $1${RST}"; }
@@ -486,26 +555,27 @@ _cmd_block_for() {
         battlepass)
             printf '%s\n' \
                 'Battle Pass (ALE)' \
-                'A seasonal challenge/reward system. Players complete tasks to earn points and claim rewards. Admins manage seasons and reward pools. Requires the Battle Pass Ticker NPC (entry 90100) placed in the world.' \
+                'A complete seasonal XP progression system. Players earn XP from kills, quests,' \
+                'PvP, dungeons, and daily logins, then claim rewards (items, gold, titles, spells).' \
+                'Requires the Battle Pass NPC (entry 90100) placed in the world and the client' \
+                'addon installed in WoW Interface/AddOns/BattlePass/.' \
                 '' \
                 'Commands:' \
-                '.bp status               — View your current Battle Pass progress' \
-                '.bp rewards              — List available rewards this season' \
-                '.bp claim <n>            — Claim reward number n' \
+                '.bp                      — Show your current Battle Pass progress' \
+                '.bp rewards              — List available rewards' \
+                '.bp claim <level>        — Claim reward for a specific level' \
                 '.bp claimall             — Claim all currently available rewards' \
-                '.bp preview              — Preview upcoming rewards' \
-                '.bp help                 — Show Battle Pass command help' \
-                '[GM] .bpadmin season start  — Start a new Battle Pass season' \
-                '[GM] .bpadmin season end    — End the current season' \
-                '[GM] .bpadmin season list   — List all seasons' \
-                '[GM] .bpadmin reward add    — Add a reward to the current season' \
-                '[GM] .bpadmin reward list   — List rewards for the current season' \
-                '[GM] .bpadmin player list   — List player progress for the current season' \
-                '[GM] .bpadmin help          — Show admin command help' \
+                '.bp preview [level]      — Preview upcoming rewards' \
+                '[GM] .bpadmin addxp <amount> [player]   — Grant XP to a player' \
+                '[GM] .bpadmin setlevel <level> [player] — Set a player'"'"'s level' \
+                '[GM] .bpadmin unclaim <level> [player]  — Un-claim a reward' \
+                '[GM] .bpadmin reset [player]            — Reset a player'"'"'s progress' \
+                '[GM] .bpadmin reload                    — Reload Battle Pass config' \
+                '[GM] .bpadmin stats                     — Show server-wide stats' \
                 '' \
                 'NPC Spawn Commands (worldserver console; prefix with . for in-game GM):' \
-                'npc add 90100 0 -8819.3 636.2 94.1 3.7   — Battle Pass Ticker, Stormwind (Alliance)' \
-                'npc add 90100 1 1609.2 -4407.7 17.5 4.5  — Battle Pass Ticker, Orgrimmar (Horde)'
+                'npc add 90100 0 -8819.3 636.2 94.1 3.7   — Battle Pass NPC, Stormwind (Alliance)' \
+                'npc add 90100 1 1609.2 -4407.7 17.5 4.5  — Battle Pass NPC, Orgrimmar (Horde)'
             ;;
         paragon)
             printf '%s\n' \
@@ -828,7 +898,7 @@ remove_mod_commands() {
 # Print INGAME_COMMANDS_FILE to the terminal with basic colour formatting.
 show_ingame_commands() {
     local outfile="$INGAME_COMMANDS_FILE"
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     if [ -z "$outfile" ] || [ ! -f "$outfile" ] || [ ! -s "$outfile" ]; then
         echo ""
         print_info "No in-game commands recorded yet."
@@ -838,7 +908,22 @@ show_ingame_commands() {
         return
     fi
 
-    with_full_screen nano "$outfile"
+    if _is_steam_deck; then
+        echo ""
+        print_info "In-game commands file:"
+        echo -e "  ${CYAN}${outfile}${RST}"
+        echo ""
+        if command -v kate &>/dev/null; then
+            if ask_yes_no "Open in Kate (graphical text editor)?"; then
+                kate "$outfile" &>/dev/null &
+            fi
+        else
+            print_info "Open this file with your preferred text editor."
+        fi
+        press_enter
+    else
+        with_full_screen nano "$outfile"
+    fi
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -922,8 +1007,8 @@ detect_install() {
             printf "${WHITE}Choose [1-%d]: ${RST}" "${#found_dirs[@]}"
             read -r choice
             if [[ "$choice" =~ ^[0-9]+$ ]] && \
-               [ "$choice" -ge 1 ] && \
-               [ "$choice" -le "${#found_dirs[@]}" ]; then
+                [ "$choice" -ge 1 ] && \
+                [ "$choice" -le "${#found_dirs[@]}" ]; then
                 SERVER_DIR="${found_dirs[$((choice - 1))]}"
                 break
             fi
@@ -972,14 +1057,14 @@ detect_type_for() {
     # For dirs not named with a suffix, peek at the compose / override
     # for telltale strings.
     if [ -f "$d/docker-compose.override.yml" ] && \
-       grep -qi "playerbot\|AC_AI_PLAYERBOT" "$d/docker-compose.override.yml" 2>/dev/null; then
+        grep -qi "playerbot\|AC_AI_PLAYERBOT" "$d/docker-compose.override.yml" 2>/dev/null; then
         echo "playerbots"; return
     fi
     if [ -d "$d/modules/mod-playerbots" ]; then
         echo "playerbots"; return
     fi
     if [ -d "$d/data/sql/custom/db_world" ] && \
-       ls "$d/data/sql/custom/db_world"/*npcbot* &>/dev/null; then
+        ls "$d/data/sql/custom/db_world"/*npcbot* &>/dev/null; then
         echo "npcbots"; return
     fi
     echo "base"
@@ -1130,7 +1215,7 @@ server_start() {
         echo ""
         # Diagnose the most common failure modes
         if grep -q "didn't complete successfully" "$up_log" 2>/dev/null && \
-           grep -q "ac-db-import" "$up_log" 2>/dev/null; then
+            grep -q "ac-db-import" "$up_log" 2>/dev/null; then
             print_warning "DIAGNOSIS: ac-db-import failed."
             print_info "Check the real error with:"
             print_info "  docker compose logs ac-db-import | tail -50"
@@ -1170,7 +1255,7 @@ server_start() {
     local i
     for i in $(seq 1 18); do
         if docker logs "$WORLD_CONTAINER" 2>&1 | \
-           grep -qiE "World initialized|Loading World|Loading complete"; then
+            grep -qiE "World initialized|Loading World|Loading complete"; then
             print_success "Worldserver is ready! ⚔️"
             return 0
         fi
@@ -1616,8 +1701,8 @@ repair_install_state() {
             ;;
         *)
             if [[ "$choice" =~ ^[0-9]+$ ]] && \
-               [ "$choice" -ge 1 ] && \
-               [ "$choice" -le "${#repair_keys[@]}" ]; then
+                [ "$choice" -ge 1 ] && \
+                [ "$choice" -le "${#repair_keys[@]}" ]; then
                 local idx=$((choice - 1))
                 local db="${repair_dbs[$idx]}"
                 [ -z "$db" ] && db="acore_world"
@@ -1637,20 +1722,7 @@ repair_install_state() {
 # ─────────────────────────────────────────────────────────────
 module_is_installed() {
     local key="$1"
-    [ -d "$SERVER_DIR/modules/$key" ]
-}
-
-# Source-build state — is the worldserver service set up to build from source?
-# For Playerbots, this is ALWAYS true (install-wow sets it up that way).
-# For Base/NPCBots, this is false by default (uses prebuilt image).
-worldserver_is_source_build() {
-    if [ "$SERVER_TYPE" = "playerbots" ]; then
-        return 0
-    fi
-    local override="$SERVER_DIR/docker-compose.override.yml"
-    [ -f "$override" ] && \
-        grep -qE "^\s*build:" "$override" && \
-        grep -qE "ac-worldserver:" "$override"
+    [ -d "$SERVER_DIR/modules/$key/.git" ]
 }
 
 # Clone a module into the install's modules/ directory.
@@ -1676,7 +1748,12 @@ module_install() {
             print_warning "git pull failed — using existing copy"
     else
         mkdir -p "$SERVER_DIR/modules"
+        if [ -d "$SERVER_DIR/modules/$key" ] && [ ! -d "$SERVER_DIR/modules/$key/.git" ]; then
+            print_warning "Removing incomplete clone at modules/$key"
+            rm -rf "$SERVER_DIR/modules/$key"
+        fi
         if ! git clone --depth 1 "$url" "$SERVER_DIR/modules/$key"; then
+            rm -rf "$SERVER_DIR/modules/$key"
             print_error "Clone failed for $name!"
             return 1
         fi
@@ -1985,7 +2062,7 @@ configure_module_challenge_modes() {
 
     print_info "⚠  Challenge Modes requires  EnablePlayerSettings = 1  in worldserver.conf."
     echo ""
-    nano "$conf_dest"
+    _open_text_file "$conf_dest"
     echo ""
     print_info "Restart the worldserver for conf changes to take effect."
 }
@@ -2022,7 +2099,7 @@ configure_module_bot_level_brackets() {
 
     print_info "⚠  Bot Level Brackets requires the Playerbots module to function."
     echo ""
-    nano "$conf_dest"
+    _open_text_file "$conf_dest"
     echo ""
     print_info "Restart the worldserver for conf changes to take effect."
 }
@@ -2060,8 +2137,9 @@ configure_module_npc_beastmaster() {
     print_info "Tip: Add 601026 to Creatures.CustomIDs in worldserver.conf to suppress"
     print_info "     a harmless gossip-menu warning in server logs."
     echo ""
-    nano "$conf_dest"
+    _open_text_file "$conf_dest"
     echo ""
+    print_info "You must enable non-hunters in the conf to allow other classes to get pets."
     print_info "Restart the worldserver for conf changes to take effect."
 }
 
@@ -2085,20 +2163,20 @@ ale_lua_is_deployed() {
     lua_dir=$(ale_lua_scripts_dir)
     case "$key" in
         accountwide)   [ -d "$lua_dir/accountwide" ] && \
-                       ls "$lua_dir/accountwide"/*.lua &>/dev/null ;;
+                        ls "$lua_dir/accountwide"/*.lua &>/dev/null ;;
         levelupreward) ls "$lua_dir"/LevelUpReward*.lua &>/dev/null 2>&1 || \
-                       ls "$lua_dir"/levelup*.lua &>/dev/null 2>&1 || \
-                       ls "$lua_dir"/LevelUp*.lua &>/dev/null 2>&1 ;;
+                        ls "$lua_dir"/levelup*.lua &>/dev/null 2>&1 || \
+                        ls "$lua_dir"/LevelUp*.lua &>/dev/null 2>&1 ;;
         exchangenpc)   ls "$lua_dir"/Exchange*.lua &>/dev/null 2>&1 || \
-                       ls "$lua_dir"/exchange*.lua &>/dev/null 2>&1 ;;
+                        ls "$lua_dir"/exchange*.lua &>/dev/null 2>&1 ;;
         activechat)    [ -d "$lua_dir/activechat" ] ;;
         battlepass)    [ -d "$lua_dir/battlepass" ] ;;
         paragon)       [ -d "$lua_dir/paragon" ] ;;
         bmah)          [ -f "$lua_dir/bmah_server.lua" ] ;;
         lootpet)       [ -f "$lua_dir/LootPet.lua" ] ;;
         sod)           ls "$lua_dir"/sod*.lua &>/dev/null 2>&1 || \
-                       ls "$lua_dir"/SoD*.lua &>/dev/null 2>&1 || \
-                       ls "$lua_dir"/season*.lua &>/dev/null 2>&1 ;;
+                        ls "$lua_dir"/SoD*.lua &>/dev/null 2>&1 || \
+                        ls "$lua_dir"/season*.lua &>/dev/null 2>&1 ;;
         sitmeanrest)   [ -f "$lua_dir/SitMeansRest.lua" ] ;;
         unlimitedammo) [ -f "$lua_dir/UnlimitedAmmo.lua" ] ;;
         *)             false ;;
@@ -2168,20 +2246,41 @@ configure_ale_battlepass() {
         echo ""
         print_info "Configure Battle Pass settings (press ENTER to keep defaults):"
         echo ""
-        local max_level exp_per_level debug_mode
-        printf "${WHITE}  Max Battle Pass level     [100]: ${RST}"; read -r max_level
-        printf "${WHITE}  Base XP required per level [1000]: ${RST}"; read -r exp_per_level
-        printf "${WHITE}  Enable debug logging  (0=off/1=on) [0]: ${RST}"; read -r debug_mode
+        local enabled max_level exp_per_level exp_scaling npc_entry debug_mode
+        printf "${WHITE}  Enable Battle Pass        (1=on/0=off) [1]: ${RST}"; read -r enabled
+        printf "${WHITE}  Max Battle Pass level               [100]: ${RST}"; read -r max_level
+        printf "${WHITE}  Base XP required per level         [1000]: ${RST}"; read -r exp_per_level
+        printf "${WHITE}  XP scaling factor per level         [1.1]: ${RST}"; read -r exp_scaling
+        printf "${WHITE}  Battle Pass NPC entry ID          [90100]: ${RST}"; read -r npc_entry
+        printf "${WHITE}  Enable debug logging    (0=off/1=on)  [0]: ${RST}"; read -r debug_mode
+        enabled=${enabled:-1}
         max_level=${max_level:-100}
         exp_per_level=${exp_per_level:-1000}
+        exp_scaling=${exp_scaling:-1.1}
+        npc_entry=${npc_entry:-90100}
         debug_mode=${debug_mode:-0}
 
         if docker exec "$DB_CONTAINER" mysql -uroot -p"$DB_ROOT_PASSWORD" acore_world \
-            -e "UPDATE battlepass_config SET value='$max_level'    WHERE \`key\`='max_level';
+            -e "UPDATE battlepass_config SET value='$enabled'       WHERE \`key\`='enabled';
+                UPDATE battlepass_config SET value='$max_level'     WHERE \`key\`='max_level';
                 UPDATE battlepass_config SET value='$exp_per_level' WHERE \`key\`='exp_per_level';
-                UPDATE battlepass_config SET value='$debug_mode'   WHERE \`key\`='debug_mode';" \
+                UPDATE battlepass_config SET value='$exp_scaling'   WHERE \`key\`='exp_scaling';
+                UPDATE battlepass_config SET value='$npc_entry'     WHERE \`key\`='npc_entry';
+                UPDATE battlepass_config SET value='$debug_mode'    WHERE \`key\`='debug_mode';" \
             2>/dev/null; then
-            print_success "Battle Pass config applied."
+            # UPDATE succeeds even when 0 rows match (older schema missing some keys).
+            # Verify all 6 keys are actually present in the table.
+            local found_keys
+            found_keys=$(docker exec "$DB_CONTAINER" mysql -uroot -p"$DB_ROOT_PASSWORD" acore_world \
+                -sN -e "SELECT COUNT(*) FROM battlepass_config WHERE \`key\` IN \
+                        ('enabled','max_level','exp_per_level','exp_scaling','npc_entry','debug_mode');" \
+                2>/dev/null)
+            if [ "${found_keys:-0}" -ge 6 ]; then
+                print_success "Battle Pass config applied (all 6 keys updated)."
+            else
+                print_warning "Only ${found_keys:-0}/6 config keys were found in battlepass_config."
+                print_info "The table may be from an older install. Re-run the SQL files, then reconfigure."
+            fi
         else
             print_warning "Config update failed — the battlepass_config table may not exist yet."
             print_info "Run the SQL files above first, then reconfigure via option C."
@@ -2197,8 +2296,9 @@ configure_ale_battlepass() {
     echo -e "  ${CYAN}Source:${RST}      $clone_dir/BattlePass/"
     echo -e "  ${CYAN}Destination:${RST} <WoW_Client>/Interface/AddOns/BattlePass/"
     echo ""
-    echo -e "${WHITE}Use ${CYAN}/bp${WHITE} or ${CYAN}/battlepass${WHITE} in-game to open the Battle Pass frame.${RST}"
-    echo -e "${WHITE}Player commands: ${CYAN}.bp${WHITE} | ${CYAN}.bp rewards${WHITE} | ${CYAN}.bp claim <level>${RST}"
+    echo -e "${WHITE}Use ${CYAN}/bp${WHITE} or ${CYAN}/battlepass${WHITE} in the WoW chat to open the Battle Pass frame.${RST}"
+    echo -e "${WHITE}Server commands: ${CYAN}.bp${WHITE} | ${CYAN}.bp rewards${WHITE} | ${CYAN}.bp claim <level>${WHITE} | ${CYAN}.bp claimall${RST}"
+    echo -e "${WHITE}Admin commands:  ${CYAN}.bpadmin addxp${WHITE} | ${CYAN}.bpadmin setlevel${WHITE} | ${CYAN}.bpadmin reset${WHITE} | ${CYAN}.bpadmin reload${RST}"
 }
 
 configure_ale_paragon() {
@@ -2419,13 +2519,13 @@ configure_ale_bmah() {
     # Parallel arrays — index-aligned (Bash 3 compatible; no associative arrays).
     local -a BNPC_IDS=(   45281   2496  11183   8921   3162  14740  11504  10834)
     local -a BNPC_NAMES=( "Slytter"
-                          "Krazek"
-                          "Dirge Quikcleave"
-                          "Ravenholdt Guards"
-                          "Slyres Notrash"
-                          "Stonard Smuggler"
-                          "Baron Vardus"
-                          "Count Remo" )
+                        "Krazek"
+                        "Dirge Quikcleave"
+                        "Ravenholdt Guards"
+                        "Slyres Notrash"
+                        "Stonard Smuggler"
+                        "Baron Vardus"
+                        "Count Remo" )
 
 
     print_step "Black Market AH — NPC Vendor Configuration"
@@ -2509,7 +2609,7 @@ configure_ale_bmah() {
         local tok
         for tok in $_bsel; do
             if [[ "$tok" =~ ^[0-9]+$ ]] && \
-               [ "$tok" -ge 1 ] && [ "$tok" -le "${#BNPC_IDS[@]}" ]; then
+                [ "$tok" -ge 1 ] && [ "$tok" -le "${#BNPC_IDS[@]}" ]; then
                 sel_ids+=("${BNPC_IDS[$((tok - 1))]}")
                 sel_names+=("${BNPC_NAMES[$((tok - 1))]}")
             else
@@ -2576,11 +2676,7 @@ configure_ale_bmah() {
             return 1
         }
         for id in "${final_ids[@]}"; do
-            label=""
-            for (( j=0; j<${#BNPC_IDS[@]}; j++ )); do
-                [ "${BNPC_IDS[$j]}" = "$id" ] && label=" --${BNPC_NAMES[$j]}" && break
-            done
-            printf "  %s,%s\n" "$id" "$label" >> "$ids_file"
+            printf "  %s,\n" "$id" >> "$ids_file"
         done
 
         # awk replaces the BMAH_VENDOR_NPCs block — handles both inline and
@@ -3028,7 +3124,12 @@ ale_script_install() {
         (cd "$clone_dir" && git pull --depth 1 2>/dev/null) || \
             print_warning "git pull failed — using existing copy"
     else
+        if [ -d "$clone_dir" ] && [ ! -d "$clone_dir/.git" ]; then
+            print_warning "Removing incomplete clone at $clone_dir"
+            rm -rf "$clone_dir"
+        fi
         if ! git clone --depth 1 "$url" "$clone_dir"; then
+            rm -rf "$clone_dir"
             print_error "Clone failed for $name!"
             return 1
         fi
@@ -3198,7 +3299,7 @@ ale_script_remove() {
     case "$key" in
         accountwide) deployed_hint="$lua_dir/accountwide/" ;;
         activechat)  deployed_hint="$lua_dir/activechat/" ;;
-        battlepass)  deployed_hint="$lua_dir/battlepass/  and  $lua_dir/lib/" ;;
+        battlepass)  deployed_hint="$lua_dir/battlepass/  and  $lua_dir/lib/CSMH/" ;;
         paragon)     deployed_hint="$lua_dir/paragon/" ;;
         bmah)        deployed_hint="$lua_dir/bmah_server.lua" ;;
         lootpet)     deployed_hint="$lua_dir/LootPet.lua" ;;
@@ -3213,7 +3314,7 @@ ale_script_remove() {
         case "$key" in
             accountwide) rm -rf "$lua_dir/accountwide" ;;
             activechat)  rm -rf "$lua_dir/activechat" ;;
-            battlepass)  rm -rf "$lua_dir/battlepass" "$lua_dir/lib" ;;
+            battlepass)  rm -rf "$lua_dir/battlepass" "$lua_dir/lib/CSMH" ;;
             paragon)     rm -rf "$lua_dir/paragon" ;;
             bmah)        rm -f  "$lua_dir/bmah_server.lua" ;;
             lootpet)     rm -f  "$lua_dir/LootPet.lua" ;;
@@ -3260,7 +3361,7 @@ sqlmod_is_installed() {
     for entry in "${SQL_MOD_REGISTRY[@]}"; do
         IFS='|' read -r k _ _ t <<< "$entry"
         if [ "$k" = "$key" ] && [ "$t" = "conf_module" ]; then
-            [ -d "$SERVER_DIR/modules/$key" ] && return 0 || return 1
+            [ -d "$SERVER_DIR/modules/$key/.git" ] && return 0 || return 1
         fi
     done
     [ -f "$SQLMOD_MARKER_DIR/$key.installed" ]
@@ -3275,9 +3376,12 @@ sqlmod_backup_world() {
     local ts; ts=$(date +%Y%m%d_%H%M%S)
     local bfile="$SQLMOD_BACKUP_DIR/${ts}_acore_world.sql.gz"
     print_info "Backing up acore_world → $(basename "$bfile") ..."
-    if docker exec "$DB_CONTAINER" mysqldump -uroot -p"$DB_ROOT_PASSWORD" acore_world \
-       2>/dev/null | gzip > "$bfile"; then
+    if ( set -o pipefail
+         docker exec "$DB_CONTAINER" mysqldump -uroot -p"$DB_ROOT_PASSWORD" acore_world \
+             2>/dev/null | gzip > "$bfile"
+    ); then
         print_success "Backup saved: $bfile"
+        _prune_backup_files "$SQLMOD_BACKUP_DIR" "*_acore_world.sql.gz" 2
         return 0
     else
         rm -f "$bfile"
@@ -3306,7 +3410,12 @@ _sqlmod_clone_or_update() {
         git -C "$target" pull --ff-only -q 2>&1 || true
     else
         print_info "Cloning $key..."
+        if [ -d "$target" ]; then
+            print_warning "Removing incomplete clone at $target"
+            rm -rf "$target"
+        fi
         git clone --depth=1 -q "$url" "$target" 2>&1 || {
+            rm -rf "$target"
             print_error "Clone failed for $url"
             return 1
         }
@@ -3335,7 +3444,7 @@ sqlmod_install() {
         return 1
     fi
 
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     printf "  ${YELLOW}⚠  WARNING: SQL Mods modify the world database.${RST}\n"
     printf "  ${DIM}These changes are unlikely to corrupt the server, but a backup${RST}\n"
     printf "  ${DIM}will be taken automatically before proceeding.${RST}\n\n"
@@ -3504,7 +3613,12 @@ _sqlmod_install_conf_module() {    local key="$1" name="$2" url="$3"
         git -C "$module_dir" pull --ff-only -q 2>&1 || true
     else
         print_info "Cloning $key into modules/..."
+        if [ -d "$module_dir" ]; then
+            print_warning "Removing incomplete clone at $module_dir"
+            rm -rf "$module_dir"
+        fi
         git clone --depth=1 -q "$url" "$module_dir" 2>&1 || {
+            rm -rf "$module_dir"
             print_error "Clone failed"; return 1
         }
     fi
@@ -3833,7 +3947,7 @@ sqlmod_configure() {
 }
 
 configure_sqlmod_portals() {
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     printf "  ${GOLD}── Configure: Portals in All Capitals ──${RST}\n\n"
     printf "  ${DIM}Adjust GO_TEMPLATE/GO_SPAWN base IDs if they conflict with other mods.${RST}\n\n"
 
@@ -3866,7 +3980,7 @@ configure_sqlmod_portals() {
 }
 
 configure_sqlmod_stackables() {
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     printf "  ${GOLD}── Configure: All Stackables ──${RST}\n\n"
     printf "  ${DIM}Set the maximum stack size. Default is 200.${RST}\n\n"
 
@@ -3892,7 +4006,7 @@ configure_sqlmod_stackables() {
 }
 
 configure_sqlmod_npc_teleporter() {
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     printf "  ${GOLD}── Configure: NPC Teleporter ──${RST}\n\n"
 
     local cfg_file="$SQLMOD_CONFIG_DIR/npc-teleporter.conf"
@@ -3930,7 +4044,7 @@ configure_sqlmod_npc_teleporter() {
 }
 
 configure_sqlmod_hearthstone() {
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     printf "  ${GOLD}── Configure: Hearthstone Cooldowns ──${RST}\n\n"
     printf "  ${DIM}Select the Hearthstone cooldown.${RST}\n\n"
     printf "  1) 30 minutes (WotLK default)\n"
@@ -3976,13 +4090,13 @@ configure_sqlmod_custom_login() {
             print_error "Config not found. Install mod first."; press_enter; return
         fi
     fi
-    print_info "Opening mod_customlogin.conf in nano..."
-    nano "$conf_dest"
+    print_info "Opening mod_customlogin.conf..."
+    _open_text_file "$conf_dest"
 }
 
 configure_sqlmod_tweak() {
     local key="$1" name="$2"
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     printf "  ${GOLD}── Configure: %s ──${RST}\n\n" "$name"
     printf "  ${DIM}Adjust creature_template multipliers. Leave blank to keep current.${RST}\n"
     printf "  ${DIM}Values must be positive numbers > 0. Changes apply immediately if installed.${RST}\n\n"
@@ -4018,7 +4132,7 @@ configure_sqlmod_tweak() {
     local invalid=false
     for v in "$new_h" "$new_d" "$new_a" "$new_spd"; do
         if ! [[ "$v" =~ ^[0-9]+([.][0-9]+)?$ ]] || \
-           ! awk "BEGIN{exit !($v > 0)}" 2>/dev/null; then invalid=true; fi
+            ! awk "BEGIN{exit !($v > 0)}" 2>/dev/null; then invalid=true; fi
     done
     if $invalid; then
         print_error "All multipliers must be positive numbers greater than 0."
@@ -4038,7 +4152,7 @@ configure_sqlmod_tweak() {
 
 configure_sqlmod_xprates() {
     sqlmod_init
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     printf "  ${GOLD}── Configure: XP Rates ──${RST}\n\n"
 
     local conf_path="$SERVER_DIR/env/dist/etc/worldserver.conf"
@@ -4068,7 +4182,7 @@ configure_sqlmod_xprates() {
     local invalid=false
     for v in "$new_kill" "$new_quest" "$new_explore"; do
         if ! [[ "$v" =~ ^[0-9]+([.][0-9]+)?$ ]] || \
-           ! awk "BEGIN{exit !($v > 0)}" 2>/dev/null; then invalid=true; fi
+            ! awk "BEGIN{exit !($v > 0)}" 2>/dev/null; then invalid=true; fi
     done
     if $invalid; then
         print_error "XP multipliers must be positive numbers greater than 0."
@@ -4389,7 +4503,7 @@ _get_about_text() {
 
 show_about() {
     local key="$1" name="$2" url="$3"
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     printf "  ${GOLD}── About: %s ──${RST}\n\n" "$name"
     _get_about_text "$key" | sed 's/^/  /'
     [ -n "$url" ] && printf "\n  ${DIM}Source: %s${RST}\n" "$url"
@@ -4409,7 +4523,7 @@ menu_ale_scripts() {
         local tlines; tlines=$_TERM_LINES
 
         # Clear menu area
-        printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+        print_header
 
         if ! module_is_installed "mod-ale"; then
             printf "  ${RED}✗ mod-ale (ALE Lua Engine) is not installed.${RST}\n"
@@ -4478,9 +4592,13 @@ menu_ale_scripts() {
         fi
         local page_hint=""
         [ "$total_pages" -gt 1 ] && page_hint="   ${WHITE}< >${RST} Page"
-        printf "  ${WHITE}i<nums>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}?<num>${RST} About${page_hint}   ${WHITE}ENTER${RST} Back\n"
+        printf "  ${WHITE}i<num>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}?<num>${RST} About${page_hint}   ${WHITE}ENTER${RST} Back\n"
 
-        _read_menu_input "$(( tlines - 1 ))" || continue
+        if ! _read_menu_input "$(( tlines - 1 ))"; then
+            local _read_rc=$?
+            [ "$_read_rc" -eq 2 ] && continue
+            return
+        fi
         local raw_choice="$_MENU_INPUT"
 
         [ -z "$raw_choice" ] && return
@@ -4499,51 +4617,31 @@ menu_ale_scripts() {
                 [ "$page_start" -gt "$max_start" ] && page_start=$max_start
                 ;;
             i)
-                local -a num_tokens=()
-                if [[ "$nums" =~ ^[0-9]+$ ]] && [ "${#nums}" -gt 1 ]; then
-                    local ch
-                    for (( ch=0; ch<${#nums}; ch++ )); do
-                        num_tokens+=("${nums:$ch:1}")
-                    done
-                else
-                    read -r -a num_tokens <<< "$nums"
-                fi
-                local -a to_install=()
-                for c in "${num_tokens[@]}"; do
-                    if [[ "$c" =~ ^[0-9]+$ ]] && \
-                       [ "$c" -ge 1 ] && [ "$c" -le "$total" ]; then
-                        to_install+=("${available_entries[$((c - 1))]}")
-                    fi
-                done
-                if [ "${#to_install[@]}" -eq 0 ]; then
-                    print_warning "No valid script numbers — e.g. i135"
+                if ! _parse_single_index "$nums" "$total"; then
+                    print_warning "Invalid script number — e.g. i3"
                     press_enter; continue
                 fi
-                for entry in "${to_install[@]}"; do
-                    IFS='|' read -r key name url <<< "$entry"
-                    ale_script_install "$key" "$name" "$url" || true
-                    echo ""
-                done
+                local inum="$_PARSED_INDEX"
+                IFS='|' read -r key name url <<< "${available_entries[$((inum - 1))]}"
+                ale_script_install "$key" "$name" "$url" || true
                 press_enter
                 ;;
             r)
-                local rnum; rnum=$(echo "$nums" | tr -d ' ')
-                if ! [[ "$rnum" =~ ^[0-9]+$ ]] || \
-                   [ "$rnum" -lt 1 ] || [ "$rnum" -gt "$total" ]; then
+                if ! _parse_single_index "$nums" "$total"; then
                     print_warning "Invalid script number — e.g. r2"
                     press_enter; continue
                 fi
+                local rnum="$_PARSED_INDEX"
                 IFS='|' read -r key name url <<< "${available_entries[$((rnum - 1))]}"
                 ale_script_remove "$key" "$name"
                 press_enter
                 ;;
             c)
-                local cnum; cnum=$(echo "$nums" | tr -d ' ')
-                if ! [[ "$cnum" =~ ^[0-9]+$ ]] || \
-                   [ "$cnum" -lt 1 ] || [ "$cnum" -gt "$total" ]; then
+                if ! _parse_single_index "$nums" "$total"; then
                     print_warning "Invalid script number — e.g. c5"
                     press_enter; continue
                 fi
+                local cnum="$_PARSED_INDEX"
                 IFS='|' read -r key name url <<< "${available_entries[$((cnum - 1))]}"
                 case "$key" in
                     accountwide) configure_ale_accountwide ;;
@@ -4559,7 +4657,7 @@ menu_ale_scripts() {
             [?])
                 local anum; anum="${nums//[[:space:]]/}"
                 if ! [[ "$anum" =~ ^[0-9]+$ ]] || \
-                   [ "$anum" -lt 1 ] || [ "$anum" -gt "$total" ]; then
+                    [ "$anum" -lt 1 ] || [ "$anum" -gt "$total" ]; then
                     print_warning "Invalid script number -- e.g. ?5"
                     press_enter; continue
                 fi
@@ -4567,7 +4665,7 @@ menu_ale_scripts() {
                 show_about "$key" "$name" "$url"
                 ;;
             *)
-                print_warning "Unknown command. Use i<nums>, r<num>, c<num>, ?<num>, or ENTER."
+                print_warning "Unknown command. Use i<num>, r<num>, c<num>, ?<num>, or ENTER."
                 press_enter
                 ;;
         esac
@@ -4577,6 +4675,57 @@ menu_ale_scripts() {
 # ─────────────────────────────────────────────────────────────
 # MAIN MENUS
 # ─────────────────────────────────────────────────────────────
+
+_module_post_install_hook() {
+    local key="$1"
+    case "$key" in
+        mod-ah-bot)
+            echo ""
+            print_info "AH Bot installed — configure a bot character?"
+            if ask_yes_no "Configure AH Bot now?"; then configure_ahbot; fi
+            ;;
+        mod-ale)
+            echo ""
+            print_info "ALE requires post-install setup (lua_scripts dir + conf)."
+            if ask_yes_no "Configure ALE now?"; then configure_ale; fi
+            ;;
+        mod-challenge-modes)
+            echo ""
+            print_info "Challenge Modes has a conf file and requires EnablePlayerSettings = 1."
+            print_info "Note: rebuild the worldserver first if the conf.dist is not yet present."
+            if ask_yes_no "Configure Challenge Modes now?"; then configure_module_challenge_modes; fi
+            ;;
+        mod-player-bot-level-brackets)
+            echo ""
+            print_info "Bot Level Brackets requires the Playerbots module to function."
+            print_info "Note: rebuild the worldserver first if the conf.dist is not yet present."
+            if ask_yes_no "Configure Bot Level Brackets now?"; then configure_module_bot_level_brackets; fi
+            ;;
+        mod-npc-beastmaster)
+            echo ""
+            print_info "NPC Beastmaster has a conf file and SQL in db-world and db-characters."
+            print_info "Note: rebuild the worldserver first if the conf.dist is not yet present."
+            if ask_yes_no "Configure NPC Beastmaster now?"; then configure_module_npc_beastmaster; fi
+            echo ""
+            print_info "Players can summon the Beastmaster NPC anywhere via .beastmaster."
+            print_info "You can also permanently place it in capital cities."
+            _offer_npc_in_capitals 601026 "White Fang (Beastmaster NPC)" \
+                "Run these commands after rebuilding and starting the worldserver."
+            ;;
+        mod-transmog)
+            echo ""
+            print_info "Transmogrification adds NPC entry 190010 — it must be manually placed in the world."
+            _offer_npc_in_capitals 190010 "Transmogrifier NPC" \
+                "Run these commands after rebuilding and starting the worldserver."
+            ;;
+        mod-1v1-arena)
+            echo ""
+            print_info "1v1 Arena adds a Battlemaster NPC (entry 999991) — it must be manually placed in the world."
+            _offer_npc_in_capitals 999991 "Arena Battlemaster 1v1" \
+                "Run these commands after rebuilding and starting the worldserver."
+            ;;
+    esac
+}
 
 # ── Unified module browser ────────────────────────────────────
 # i <nums>  Install one or more (space-separated)
@@ -4657,7 +4806,7 @@ menu_modules() {
         local current_page=$(( page_start / page_size + 1 ))
 
         # Clear and draw
-        printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+        print_header
         printf "  ${GOLD}── Modules ──────────────────────────────────────${RST}\n"
         printf "  ${DIM}%-4s %-42s %s${RST}\n" "Num" "Module" "Status"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
@@ -4687,9 +4836,13 @@ menu_modules() {
         fi
         local page_hint=""
         [ "$total_pages" -gt 1 ] && page_hint="   ${WHITE}< >${RST} Page"
-        printf "  ${WHITE}i <nums>${RST} Install   ${WHITE}r <num>${RST} Remove   ${WHITE}c <num>${RST} Config   ${WHITE}?<num>${RST} About${page_hint}   ${WHITE}ENTER${RST} Back\n"
+        printf "  ${WHITE}i<num>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}?<num>${RST} About${page_hint}   ${WHITE}ENTER${RST} Back\n"
 
-        _read_menu_input "$(( tlines - 1 ))" || continue
+        if ! _read_menu_input "$(( tlines - 1 ))"; then
+            local _read_rc=$?
+            [ "$_read_rc" -eq 2 ] && continue
+            return
+        fi
         local raw_choice="$_MENU_INPUT"
 
         [ -z "$raw_choice" ] && return
@@ -4709,13 +4862,15 @@ menu_modules() {
                 [ "$page_start" -gt "$max_start" ] && page_start=$max_start
                 ;;
             i)
-                if [ -z "$nums" ]; then
-                    print_warning "Specify numbers — e.g. i 1 3"
+                if ! _parse_single_index "$nums" "$total"; then
+                    print_warning "Invalid module number — e.g. i3"
                     press_enter; continue
                 fi
+                local inum="$_PARSED_INDEX"
+                IFS='|' read -r key name url sql_dirs <<< "${available_entries[$((inum - 1))]}"
 
                 if [ "$SERVER_TYPE" != "playerbots" ]; then
-                    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                    print_header
                     print_warning "Module installs on $SERVER_NAME are experimental."
                     print_info "Modules will be cloned but rebuilding is not supported on this install type."
                     print_info "Recommended: reinstall as Playerbots for full module support."
@@ -4723,34 +4878,16 @@ menu_modules() {
                     if ! ask_yes_no "Continue anyway?"; then continue; fi
                 fi
 
-                local -a to_install=()
-                local c
-                for c in $nums; do
-                    if [[ "$c" =~ ^[0-9]+$ ]] && \
-                       [ "$c" -ge 1 ] && [ "$c" -le "$total" ]; then
-                        to_install+=("${available_entries[$((c - 1))]}")
-                    fi
-                done
-
-                if [ "${#to_install[@]}" -eq 0 ]; then
-                    print_warning "No valid module numbers — e.g. i 1 3"
-                    press_enter; continue
-                fi
-
-                printf '\033[%d;1H\033[J' "$MENU_START_ROW"
-                for entry in "${to_install[@]}"; do
-                    IFS='|' read -r key name url sql_dirs <<< "$entry"
-                    module_install "$key" "$name" "$url" "$sql_dirs" || true
-                    upsert_mod_commands "$key"
-                    echo ""
-                done
-                print_info "Modules cloned. SQL files will be applied automatically on next server start."
+                print_header
+                module_install "$key" "$name" "$url" "$sql_dirs" || true
+                upsert_mod_commands "$key"
+                print_info "Module cloned. SQL files will be applied automatically on next server start."
                 print_info "All C++ modules require a worldserver rebuild before they can load."
                 print_info "Conf files can be set up via 'Configure' — run configure after a rebuild if"
                 print_info "the conf.dist files are not yet present."
 
                 if [ "$SERVER_TYPE" = "playerbots" ]; then
-                    print_info "Rebuild the worldserver to compile the new modules in."
+                    print_info "Rebuild the worldserver to compile the new module in."
                     echo ""
                     if ask_yes_no "Rebuild the worldserver now?"; then
                         rebuild_worldserver
@@ -4759,69 +4896,21 @@ menu_modules() {
                     print_info "(Skipping rebuild — not supported on this install type.)"
                 fi
 
-                for entry in "${to_install[@]}"; do
-                    IFS='|' read -r key name _ _ <<< "$entry"
-                    if [ "$key" = "mod-ah-bot" ]; then
-                        echo ""
-                        print_info "AH Bot installed — configure a bot character?"
-                        if ask_yes_no "Configure AH Bot now?"; then configure_ahbot; fi
-                    fi
-                    if [ "$key" = "mod-ale" ]; then
-                        echo ""
-                        print_info "ALE requires post-install setup (lua_scripts dir + conf)."
-                        if ask_yes_no "Configure ALE now?"; then configure_ale; fi
-                    fi
-                    if [ "$key" = "mod-challenge-modes" ]; then
-                        echo ""
-                        print_info "Challenge Modes has a conf file and requires EnablePlayerSettings = 1."
-                        print_info "Note: rebuild the worldserver first if the conf.dist is not yet present."
-                        if ask_yes_no "Configure Challenge Modes now?"; then configure_module_challenge_modes; fi
-                    fi
-                    if [ "$key" = "mod-player-bot-level-brackets" ]; then
-                        echo ""
-                        print_info "Bot Level Brackets requires the Playerbots module to function."
-                        print_info "Note: rebuild the worldserver first if the conf.dist is not yet present."
-                        if ask_yes_no "Configure Bot Level Brackets now?"; then configure_module_bot_level_brackets; fi
-                    fi
-                    if [ "$key" = "mod-npc-beastmaster" ]; then
-                        echo ""
-                        print_info "NPC Beastmaster has a conf file and SQL in db-world and db-characters."
-                        print_info "Note: rebuild the worldserver first if the conf.dist is not yet present."
-                        if ask_yes_no "Configure NPC Beastmaster now?"; then configure_module_npc_beastmaster; fi
-                        echo ""
-                        print_info "Players can summon the Beastmaster NPC anywhere via .beastmaster."
-                        print_info "You can also permanently place it in capital cities."
-                        _offer_npc_in_capitals 601026 "White Fang (Beastmaster NPC)" \
-                            "Run these commands after rebuilding and starting the worldserver."
-                    fi
-                    if [ "$key" = "mod-transmog" ]; then
-                        echo ""
-                        print_info "Transmogrification adds NPC entry 190010 — it must be manually placed in the world."
-                        _offer_npc_in_capitals 190010 "Transmogrifier NPC" \
-                            "Run these commands after rebuilding and starting the worldserver."
-                    fi
-                    if [ "$key" = "mod-1v1-arena" ]; then
-                        echo ""
-                        print_info "1v1 Arena adds a Battlemaster NPC (entry 999991) — it must be manually placed in the world."
-                        _offer_npc_in_capitals 999991 "Arena Battlemaster 1v1" \
-                            "Run these commands after rebuilding and starting the worldserver."
-                    fi
-                done
+                _module_post_install_hook "$key"
                 press_enter
                 ;;
             r)
-                local rnum; rnum=$(echo "$nums" | tr -d ' ')
-                if ! [[ "$rnum" =~ ^[0-9]+$ ]] || \
-                   [ "$rnum" -lt 1 ] || [ "$rnum" -gt "$total" ]; then
+                if ! _parse_single_index "$nums" "$total"; then
                     print_warning "Invalid module number — e.g. r2"
                     press_enter; continue
                 fi
+                local rnum="$_PARSED_INDEX"
                 IFS='|' read -r key name _ _ <<< "${available_entries[$((rnum - 1))]}"
                 if ! module_is_installed "$key"; then
                     print_warning "$name is not installed."
                     press_enter; continue
                 fi
-                printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                print_header
                 module_remove "$key" "$name"
                 if ! module_is_installed "$key"; then
                     remove_mod_commands "$key"
@@ -4838,12 +4927,12 @@ menu_modules() {
             c)
                 local cnum; cnum="${nums//[[:space:]]/}"
                 if ! [[ "$cnum" =~ ^[0-9]+$ ]] || \
-                   [ "$cnum" -lt 1 ] || [ "$cnum" -gt "$total" ]; then
+                    [ "$cnum" -lt 1 ] || [ "$cnum" -gt "$total" ]; then
                     print_warning "Invalid module number — e.g. c3"
                     press_enter; continue
                 fi
                 IFS='|' read -r key name _ _ <<< "${available_entries[$((cnum - 1))]}"
-                printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                print_header
                 case "$key" in
                     mod-ah-bot)                  configure_ahbot ;;
                     mod-ale)                     configure_ale ;;
@@ -4860,7 +4949,7 @@ menu_modules() {
             [?])
                 local anum; anum="${nums//[[:space:]]/}"
                 if ! [[ "$anum" =~ ^[0-9]+$ ]] || \
-                   [ "$anum" -lt 1 ] || [ "$anum" -gt "$total" ]; then
+                    [ "$anum" -lt 1 ] || [ "$anum" -gt "$total" ]; then
                     print_warning "Invalid module number -- e.g. ?3"
                     press_enter; continue
                 fi
@@ -4868,7 +4957,7 @@ menu_modules() {
                 show_about "$key" "$name" "$url"
                 ;;
             *)
-                print_warning "Unknown command. Use i <nums>, r <num>, c <num>, ?<num>, or ENTER."
+                print_warning "Unknown command. Use i<num>, r<num>, c<num>, ?<num>, or ENTER."
                 press_enter
                 ;;
         esac
@@ -5077,7 +5166,7 @@ menu_module_management() {
             _setup_screen
         fi
         local tlines; tlines=$_TERM_LINES
-        printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+        print_header
 
         local -a available_entries=()
         local entry
@@ -5120,7 +5209,11 @@ menu_module_management() {
         [ "$total_pages" -gt 1 ] && page_hint="   ${WHITE}< >${RST} Page"
         printf "  ${WHITE}a<num>${RST} Activate conf   ${WHITE}e<num>${RST} Edit conf   ${WHITE}r<num>${RST} Reset defaults   ${WHITE}?<num>${RST} Help${page_hint}   ${WHITE}ENTER${RST} Back\n"
 
-        _read_menu_input "$(( tlines - 1 ))" || continue
+        if ! _read_menu_input "$(( tlines - 1 ))"; then
+            local _read_rc=$?
+            [ "$_read_rc" -eq 2 ] && continue
+            return
+        fi
         local raw_choice="$_MENU_INPUT"
         [ -z "$raw_choice" ] && return
 
@@ -5138,16 +5231,16 @@ menu_module_management() {
                 [ "$page_start" -gt "$max_start" ] && page_start=$max_start
                 ;;
             a|e|r|?)
-                inum="${nums//[[:space:]]/}"
-                if ! [[ "$inum" =~ ^[0-9]+$ ]] || [ "$inum" -lt 1 ] || [ "$inum" -gt "$total" ]; then
+                if ! _parse_single_index "$nums" "$total"; then
                     print_warning "Invalid module number."
                     press_enter
                     continue
                 fi
+                inum="$_PARSED_INDEX"
                 IFS='|' read -r key name url sql_dirs <<< "${available_entries[$((inum - 1))]}"
 
                 if [ "${action,,}" = "?" ]; then
-                    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                    print_header
                     printf "  ${GOLD}── Module Config Help: %s ──${RST}\n\n" "$name"
                     local conf_name conf_dist conf_active
                     conf_name=$(_module_conf_name "$key")
@@ -5222,7 +5315,7 @@ menu_module_management() {
                             continue
                         fi
                     fi
-                    nano "$conf_active"
+                    _open_text_file "$conf_active"
                     print_info "Restart worldserver to apply."
                     press_enter
                     continue
@@ -5267,7 +5360,7 @@ show_first_run_welcome() {
     local marker="$SERVER_DIR/.dml-manager-seen"
     # Returning user: clear the detect_install output and go straight to the menu
     if [ -f "$marker" ]; then
-        printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+        print_header
         return 0
     fi
 
@@ -5359,7 +5452,7 @@ show_first_run_welcome() {
     touch "$marker" 2>/dev/null || true
     # Restore static logo now that the welcome screen is done
     _setup_screen
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
 }
 
 # ── SQL Mods submenu ──────────────────────────────────────────
@@ -5373,7 +5466,7 @@ menu_sql_mods() {
             _setup_screen
         fi
         local tlines; tlines=$_TERM_LINES
-        printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+        print_header
 
         local -a available_entries=()
         local -a markers=()
@@ -5426,7 +5519,11 @@ menu_sql_mods() {
         [ "$total_pages" -gt 1 ] && page_hint="   ${WHITE}< >${RST} Page"
         printf "  ${WHITE}i<num>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}?<num>${RST} About${page_hint}   ${WHITE}ENTER${RST} Back\n"
 
-        _read_menu_input "$(( tlines - 1 ))" || continue
+        if ! _read_menu_input "$(( tlines - 1 ))"; then
+            local _read_rc=$?
+            [ "$_read_rc" -eq 2 ] && continue
+            return
+        fi
         local raw_choice="$_MENU_INPUT"
         [ -z "$raw_choice" ] && return
 
@@ -5444,47 +5541,43 @@ menu_sql_mods() {
                 [ "$page_start" -gt "$max_start" ] && page_start=$max_start
                 ;;
             i)
-                local inum; inum="${nums//[[:space:]]/}"
-                if ! [[ "$inum" =~ ^[0-9]+$ ]] || \
-                   [ "$inum" -lt 1 ] || [ "$inum" -gt "$total" ]; then
+                if ! _parse_single_index "$nums" "$total"; then
                     print_warning "Invalid mod number — e.g. i3"
                     press_enter; continue
                 fi
+                local inum="$_PARSED_INDEX"
                 IFS='|' read -r key name url type <<< "${available_entries[$((inum - 1))]}"
-                printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                print_header
                 sqlmod_install "$key" "$name" "$url" "$type" || true
                 press_enter
                 ;;
             r)
-                local rnum; rnum="${nums//[[:space:]]/}"
-                if ! [[ "$rnum" =~ ^[0-9]+$ ]] || \
-                   [ "$rnum" -lt 1 ] || [ "$rnum" -gt "$total" ]; then
+                if ! _parse_single_index "$nums" "$total"; then
                     print_warning "Invalid mod number — e.g. r3"
                     press_enter; continue
                 fi
+                local rnum="$_PARSED_INDEX"
                 IFS='|' read -r key name url type <<< "${available_entries[$((rnum - 1))]}"
-                printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                print_header
                 sqlmod_remove "$key" "$name" "$url" "$type" || true
                 press_enter
                 ;;
             c)
-                local cnum; cnum="${nums//[[:space:]]/}"
-                if ! [[ "$cnum" =~ ^[0-9]+$ ]] || \
-                   [ "$cnum" -lt 1 ] || [ "$cnum" -gt "$total" ]; then
+                if ! _parse_single_index "$nums" "$total"; then
                     print_warning "Invalid mod number — e.g. c5"
                     press_enter; continue
                 fi
+                local cnum="$_PARSED_INDEX"
                 IFS='|' read -r key name url type <<< "${available_entries[$((cnum - 1))]}"
-                printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                print_header
                 sqlmod_configure "$key" "$name"
                 ;;
             [?])
-                local anum; anum="${nums//[[:space:]]/}"
-                if ! [[ "$anum" =~ ^[0-9]+$ ]] || \
-                   [ "$anum" -lt 1 ] || [ "$anum" -gt "$total" ]; then
+                if ! _parse_single_index "$nums" "$total"; then
                     print_warning "Invalid mod number -- e.g. ?3"
                     press_enter; continue
                 fi
+                local anum="$_PARSED_INDEX"
                 IFS='|' read -r key name url type <<< "${available_entries[$((anum - 1))]}"
                 show_about "$key" "$name" "$url"
                 ;;
@@ -5504,7 +5597,7 @@ menu_server_maintenance() {
             _RESIZE_NEEDED=false
             _setup_screen
         fi
-        printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+        print_header
         printf "  ${GOLD}${BOLD}Server Maintenance${RST}\n"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
         printf "  ${WHITE}1)${RST} Repair install state\n"
@@ -5514,7 +5607,11 @@ menu_server_maintenance() {
         printf "  ${DIM}  [ENTER] Back${RST}\n"
 
         local _tlines; _tlines=$_TERM_LINES
-        _read_menu_input "$(( _tlines - 1 ))" || continue
+        if ! _read_menu_input "$(( _tlines - 1 ))"; then
+            local _read_rc=$?
+            [ "$_read_rc" -eq 2 ] && continue
+            return
+        fi
         local choice="${_MENU_INPUT,,}"
 
         case "$choice" in
@@ -5533,16 +5630,19 @@ _maintenance_backup_all() {
         print_error "Database container is not running."
         return 1
     fi
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     printf "  ${GOLD}── Database Backup ──${RST}\n\n"
     local ts; ts=$(date +%Y%m%d_%H%M%S)
     local failed=0
     for db in acore_world acore_characters acore_auth; do
         local bfile="$SQLMOD_BACKUP_DIR/${ts}_${db}.sql.gz"
         print_info "Backing up ${db} → $(basename "$bfile") ..."
-        if docker exec "$DB_CONTAINER" mysqldump -uroot -p"$DB_ROOT_PASSWORD" "$db" \
-           2>/dev/null | gzip > "$bfile"; then
+        if ( set -o pipefail
+             docker exec "$DB_CONTAINER" mysqldump -uroot -p"$DB_ROOT_PASSWORD" "$db" \
+                 2>/dev/null | gzip > "$bfile"
+        ); then
             print_success "  ✓ $db"
+            _prune_backup_files "$SQLMOD_BACKUP_DIR" "*_${db}.sql.gz" 2
         else
             rm -f "$bfile"
             print_error "  ✗ $db backup failed"
@@ -5565,7 +5665,7 @@ _maintenance_import() {
         press_enter; return
     fi
 
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     printf "  ${GOLD}── Restore / Import Backup ──${RST}\n\n"
 
     # List available backups sorted newest-first
@@ -5626,8 +5726,10 @@ _maintenance_import() {
     print_info "Taking safety backup of current ${target_db} before restore..."
     local ts; ts=$(date +%Y%m%d_%H%M%S)
     local safefile="$SQLMOD_BACKUP_DIR/${ts}_pre_restore_${target_db}.sql.gz"
-    if docker exec "$DB_CONTAINER" mysqldump -uroot -p"$DB_ROOT_PASSWORD" "$target_db" \
-       2>/dev/null | gzip > "$safefile"; then
+    if ( set -o pipefail
+         docker exec "$DB_CONTAINER" mysqldump -uroot -p"$DB_ROOT_PASSWORD" "$target_db" \
+             2>/dev/null | gzip > "$safefile"
+    ); then
         print_success "Safety backup: $(basename "$safefile")"
     else
         rm -f "$safefile"
@@ -5636,15 +5738,17 @@ _maintenance_import() {
 
     print_info "Restoring ${target_db} from $(basename "$chosen_file")..."
     if [[ "$chosen_file" == *.gz ]]; then
-        if gzip -dc "$chosen_file" | docker exec -i "$DB_CONTAINER" \
-           mysql -uroot -p"$DB_ROOT_PASSWORD" "$target_db" 2>&1; then
+        if ( set -o pipefail
+             gzip -dc "$chosen_file" | docker exec -i "$DB_CONTAINER" \
+                 mysql -uroot -p"$DB_ROOT_PASSWORD" "$target_db" 2>&1
+        ); then
             print_success "Restore complete!"
         else
             print_error "Restore failed. Check the file and try again."
         fi
     else
         if docker exec -i "$DB_CONTAINER" \
-           mysql -uroot -p"$DB_ROOT_PASSWORD" "$target_db" < "$chosen_file" 2>&1; then
+            mysql -uroot -p"$DB_ROOT_PASSWORD" "$target_db" < "$chosen_file" 2>&1; then
             print_success "Restore complete!"
         else
             print_error "Restore failed. Check the file and try again."
@@ -5656,7 +5760,7 @@ _maintenance_import() {
 main_menu() {
     _IN_MENU=true
     _setup_screen
-    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    print_header
     while true; do
         _RESIZE_NEEDED=false
         _setup_screen
@@ -5674,7 +5778,7 @@ main_menu() {
         fi
 
         # Clear from menu area downward, then print single-column menu
-        printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+        print_header
 
         printf "  ${WHITE}Server:${RST} ${CYAN}%s${RST}  ${GOLD}✦${RST}  ${WHITE}State:${RST} %b  ${GOLD}✦${RST}  ${WHITE}Build:${RST} %b\n" \
             "$(basename "$SERVER_DIR")" "$state_str" "$build_str"
@@ -5703,7 +5807,11 @@ main_menu() {
         # Input at second-to-last terminal row so it's always visible
         local _tlines; _tlines=$_TERM_LINES
         local _irow=$(( _tlines - 1 ))
-        _read_menu_input "$_irow" || continue
+        if ! _read_menu_input "$_irow"; then
+            local _read_rc=$?
+            [ "$_read_rc" -eq 2 ] && continue
+            return
+        fi
         local choice="${_MENU_INPUT,,}"
 
         case "$choice" in

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -2755,7 +2755,7 @@ _sqlmod_install_conf_module() {
     fi
 
     local conf_dist="$module_dir/conf/mod_customlogin.conf.dist"
-    local conf_dest="$SERVER_DIR/env/docker/etc/modules/mod_customlogin.conf"
+    local conf_dest="$SERVER_DIR/env/dist/etc/modules/mod_customlogin.conf"
     if [ -f "$conf_dist" ] && [ ! -f "$conf_dest" ]; then
         mkdir -p "$(dirname "$conf_dest")"
         cp "$conf_dist" "$conf_dest"
@@ -2771,6 +2771,18 @@ _sqlmod_install_tweak() {
     local key="$1" name="$2"
     local cfg_file="$SQLMOD_CONFIG_DIR/${key}.conf"
     local h_mult d_mult a_mult spd_mult
+
+    # Mob tweaks are mutually exclusive — auto-remove any active sibling first
+    local siblings=("buff-mobs" "xbuff-mobs" "nerf-mobs" "baby-mobs")
+    for sibling in "${siblings[@]}"; do
+        if [ "$sibling" != "$key" ] && [ -f "$SQLMOD_MARKER_DIR/$sibling.installed" ]; then
+            print_warning "Removing conflicting tweak '$sibling' before applying '$key'..."
+            _sqlmod_remove_tweak "$sibling" "$sibling" || {
+                print_error "Failed to remove '$sibling'. Aborting to avoid stacking tweaks."
+                return 1
+            }
+        fi
+    done
 
     case "$key" in
         buff-mobs)  h_mult=2;    d_mult=1.5;  a_mult=1.5;  spd_mult=0.8 ;;
@@ -2972,7 +2984,7 @@ _sqlmod_remove_tweak() {
 }
 
 _sqlmod_remove_xprates() {
-    local conf_path="$SERVER_DIR/env/docker/etc/worldserver.conf"
+    local conf_path="$SERVER_DIR/env/dist/etc/worldserver.conf"
     if [ ! -f "$conf_path" ]; then
         print_error "worldserver.conf not found at $conf_path"; return 1
     fi
@@ -3118,7 +3130,7 @@ configure_sqlmod_hearthstone() {
 
 configure_sqlmod_custom_login() {
     sqlmod_init
-    local conf_dest="$SERVER_DIR/env/docker/etc/modules/mod_customlogin.conf"
+    local conf_dest="$SERVER_DIR/env/dist/etc/modules/mod_customlogin.conf"
     if [ ! -f "$conf_dest" ]; then
         local module_dir="$SERVER_DIR/modules/custom-login"
         local conf_dist="$module_dir/conf/mod_customlogin.conf.dist"
@@ -3189,7 +3201,7 @@ configure_sqlmod_xprates() {
     printf '\033[%d;1H\033[J' "$MENU_START_ROW"
     printf "  ${GOLD}── Configure: XP Rates ──${RST}\n\n"
 
-    local conf_path="$SERVER_DIR/env/docker/etc/worldserver.conf"
+    local conf_path="$SERVER_DIR/env/dist/etc/worldserver.conf"
     if [ ! -f "$conf_path" ]; then
         print_error "worldserver.conf not found at $conf_path"
         print_info "Make sure your AzerothCore install is complete."

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -55,6 +55,7 @@ MENU_INPUT_ROW=24
 _TERM_LINES=24
 _TERM_COLS=80
 _RESIZE_NEEDED=false
+_IN_MENU=false   # true once we enter main_menu; switches to the slim banner
 ANIM_PID=""
 _IN_ALT_SCREEN=false
 
@@ -121,7 +122,9 @@ _get_term_size() {
 _handle_resize() {
     _RESIZE_NEEDED=true
     _get_term_size
-    if [ "${_TERM_COLS:-80}" -ge 80 ]; then
+    if [ "$_IN_MENU" = true ]; then
+        MENU_START_ROW=5
+    elif [ "${_TERM_COLS:-80}" -ge 80 ]; then
         MENU_START_ROW=15
     else
         MENU_START_ROW=6
@@ -153,7 +156,14 @@ _screen_int_handler() {
 _draw_logo_static() {
     printf '\033[1;1H\033[J'
     tput rmam 2>/dev/null || true  # disable line wrap — logo/bars truncate cleanly on narrow terminals
-    if [ "${_TERM_COLS:-80}" -ge 80 ]; then
+    if [ "$_IN_MENU" = true ]; then
+        # Slim in-menu banner: 4 rows → MENU_START_ROW=5.
+        # Keeps vertical space for menu content on short terminals (e.g. Steam Deck 30 rows).
+        printf '\n'
+        printf '\033[38;5;220m ════════════════════════════════════════════════════════════════════════════════\033[K\033[0m\n'
+        printf '   \033[38;5;220m⚔︎\033[0m  \033[1mDad'"'"'s MMO Lab\033[0m  \033[2m✦  WotLK Server Manager  ✦  v%s\033[0m\033[K\n' "$MANAGER_VERSION"
+        printf '\033[38;5;220m ════════════════════════════════════════════════════════════════════════════════\033[K\033[0m\n'
+    elif [ "${_TERM_COLS:-80}" -ge 80 ]; then
         printf '\n'
         printf '\033[2m%s\033[K\033[0m\n'       "$_LOGO_L0"
         printf '\033[38;5;220m%s\033[K\033[0m\n' "$_LOGO_L1"
@@ -187,7 +197,9 @@ _setup_screen() {
         _IN_ALT_SCREEN=true
     fi
     _get_term_size
-    if [ "${_TERM_COLS:-80}" -ge 80 ]; then
+    if [ "$_IN_MENU" = true ]; then
+        MENU_START_ROW=5
+    elif [ "${_TERM_COLS:-80}" -ge 80 ]; then
         MENU_START_ROW=15
     else
         MENU_START_ROW=6
@@ -675,6 +687,84 @@ _cmd_block_for() {
     esac
 }
 
+# Rebuild the "=== NPC Spawn Quick Reference ===" block at the top of
+# INGAME_COMMANDS_FILE by scanning all mod sections for "npc add" lines.
+# Uses [mod-key] labels (not === markers) to avoid confusing the section parser.
+_rebuild_npc_spawn_header() {
+    local outfile="$INGAME_COMMANDS_FILE"
+    [ -z "$outfile" ] || [ ! -f "$outfile" ] && return 0
+
+    local header_marker="=== NPC Spawn Quick Reference ==="
+    local -a spawn_entries=()
+    local current_section="" in_skip=false
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^"=== "(.+)" ===" ]]; then
+            local sec="${BASH_REMATCH[1]}"
+            if [ "$sec" = "NPC Spawn Quick Reference" ]; then
+                in_skip=true
+                current_section=""
+            else
+                in_skip=false
+                current_section="$sec"
+            fi
+        elif [ "$in_skip" = false ] && [[ "$line" == "npc add "* ]]; then
+            spawn_entries+=("${current_section}|${line}")
+        fi
+    done < "$outfile"
+
+    if [ ${#spawn_entries[@]} -eq 0 ]; then
+        # No spawn commands — remove the header block if present
+        if grep -Fxq "$header_marker" "$outfile" 2>/dev/null; then
+            local tmpout; tmpout=$(mktemp)
+            awk -v marker="$header_marker" '
+            $0 == marker { skip=1; next }
+            skip && /^=== .+ ===$/ { skip=0 }
+            !skip { print }
+            ' "$outfile" > "$tmpout" && mv "$tmpout" "$outfile"
+        fi
+        return 0
+    fi
+
+    # Build the new header block
+    local tmpblock; tmpblock=$(mktemp)
+    {
+        printf '%s\n' "$header_marker"
+        printf '%s\n' "Consolidated NPC spawn commands for all installed mods that require NPCs."
+        printf '%s\n' "  Worldserver console: npc add <entry> ...   |   In-game GM: .npc add <entry> ..."
+        printf '\n'
+        local prev_section=""
+        for entry in "${spawn_entries[@]}"; do
+            local sec="${entry%%|*}"
+            local cmd="${entry#*|}"
+            if [ "$sec" != "$prev_section" ]; then
+                [ -n "$prev_section" ] && printf '\n'
+                printf '  [%s]\n' "$sec"
+                prev_section="$sec"
+            fi
+            printf '%s\n' "  $cmd"
+        done
+        printf '\n'
+    } > "$tmpblock"
+
+    # Place at the very top of the file (replace if header exists, otherwise prepend)
+    local tmpout; tmpout=$(mktemp)
+    if grep -Fxq "$header_marker" "$outfile" 2>/dev/null; then
+        awk -v marker="$header_marker" -v newfile="$tmpblock" '
+        $0 == marker {
+            while ((getline line < newfile) > 0) print line
+            close(newfile)
+            skip=1; next
+        }
+        skip && /^=== .+ ===$/ { skip=0 }
+        !skip { print }
+        ' "$outfile" > "$tmpout" && mv "$tmpout" "$outfile"
+    else
+        cat "$tmpblock" "$outfile" > "$tmpout" && mv "$tmpout" "$outfile"
+    fi
+    rm -f "$tmpblock"
+}
+
 # Write or replace the === key === section in INGAME_COMMANDS_FILE.
 # Uses unique temp files + atomic mv to avoid partial writes.
 # Pass --quiet as second argument to suppress the print_info notification.
@@ -687,11 +777,13 @@ upsert_mod_commands() {
     [ -z "$outfile" ] && return 0
     local marker="=== ${key} ==="
 
+    # Each section ends with a trailing blank line for readability
     local tmpblock; tmpblock=$(mktemp)
-    printf '%s\n%s\n' "$marker" "$content" > "$tmpblock"
+    printf '%s\n%s\n\n' "$marker" "$content" > "$tmpblock"
 
     if [ ! -f "$outfile" ]; then
         mv "$tmpblock" "$outfile"
+        _rebuild_npc_spawn_header
         [ "$quiet" != "--quiet" ] && print_info "📋 In-game commands reference created: $outfile"
         return 0
     fi
@@ -708,10 +800,10 @@ upsert_mod_commands() {
         !skip { print }
         ' "$outfile" > "$tmpout" && mv "$tmpout" "$outfile"
     else
-        printf '\n' >> "$outfile"
         cat "$tmpblock" >> "$outfile"
     fi
     rm -f "$tmpblock"
+    _rebuild_npc_spawn_header
     [ "$quiet" != "--quiet" ] && print_info "📋 In-game commands reference updated: $outfile"
 }
 
@@ -729,6 +821,7 @@ remove_mod_commands() {
     skip && /^=== .+ ===$/ { skip=0 }
     !skip { print }
     ' "$outfile" > "$tmpout" && mv "$tmpout" "$outfile"
+    _rebuild_npc_spawn_header
     print_info "📋 Removed $key from in-game commands reference."
 }
 
@@ -745,34 +838,7 @@ show_ingame_commands() {
         return
     fi
 
-    echo ""
-    echo -e "  ${GOLD}${BOLD}In-Game Commands Reference${RST}"
-    echo -e "  ${GOLD}══════════════════════════════════════════════${RST}"
-    echo -e "  ${DIM}Source: $outfile${RST}"
-    echo ""
-
-    while IFS= read -r line; do
-        if [[ "$line" == "=== "* ]]; then
-            echo -e "\n  ${GOLD}${BOLD}${line}${RST}"
-        elif [[ "$line" == "Commands:"* ]] || [[ "$line" == "NPC Spawn Commands"* ]]; then
-            echo -e "  ${WHITE}${BOLD}${line}${RST}"
-        elif [[ "$line" == "."* ]] || [[ "$line" == "[GM]"* ]] || \
-             [[ "$line" == "[ADMIN]"* ]] || [[ "$line" == "npc add"* ]]; then
-            echo -e "  ${CYAN}${line}${RST}"
-        elif [[ "$line" == "(none"* ]] || [[ "$line" == "WARNING:"* ]] || \
-             [[ "$line" == "NOTICE:"* ]]; then
-            echo -e "  ${YELLOW}${line}${RST}"
-        elif [[ -z "$line" ]]; then
-            echo ""
-        else
-            echo -e "  ${line}"
-        fi
-    done < "$outfile"
-
-    echo ""
-    echo -e "  ${DIM}Full file: $outfile${RST}"
-    echo ""
-    press_enter
+    with_full_screen nano "$outfile"
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -1243,15 +1309,15 @@ declare -a MODULE_UPDATE_FILES=(
 # inside ale_script_install() and the configure_ale_* functions.
 declare -a ALE_SCRIPT_REGISTRY=(
     "accountwide|Accountwide Systems (achievements, currency, mounts, pets)|https://github.com/Aldori15/azerothcore-eluna-accountwide.git"
-    "levelupreward|Level Up Reward (mail gold/items on level-up)|https://github.com/55Honey/Acore_LevelUpReward.git"
-    "exchangenpc|Exchange NPC (configurable item-exchange vendor NPC)|https://github.com/55Honey/Acore_ExchangeNpc.git"
     "activechat|Active Chat (simulated world/guild chat for immersion)|https://github.com/Day36512/ActiveChat.git"
     "battlepass|Battle Pass System (XP progression + rewards + client addon)|https://github.com/Shonik/lua-battlepass.git"
-    "paragon|Paragon Anniversary (endless post-80 stat progression + client addon)|https://github.com/Grim-Batol/Paragon-Anniversary.git"
     "bmah|Black Market Auction House (MoP-style BMAH + client addon)|https://github.com/Youpeoples/Black-Market-Auction-House.git"
+    "exchangenpc|Exchange NPC (configurable item-exchange vendor NPC)|https://github.com/55Honey/Acore_ExchangeNpc.git"
+    "levelupreward|Level Up Reward (mail gold/items on level-up)|https://github.com/55Honey/Acore_LevelUpReward.git"
     "lootpet|Loot Pet (vanity pet auto-loots nearby corpses)|https://github.com/Brytenwally/Lootpet.git"
-    "sod|Season of Discovery Buffs (phased leveling XP rate bonus)|https://github.com/notepadguyOfficial/acore_sod.git"
+    "paragon|Paragon Anniversary (endless post-80 stat progression + client addon)|https://github.com/Grim-Batol/Paragon-Anniversary.git"
     "sitmeanrest|Sit Means Rest (regen buff on /sit; strips on movement)|https://github.com/Brytenwally/SitMeansRest.git"
+    "sod|Season of Discovery Buffs (phased leveling XP rate bonus)|https://github.com/notepadguyOfficial/acore_sod.git"
     "unlimitedammo|Unlimited Ammo (auto-refills Hunter arrows/bullets)|https://github.com/Day36512/Acore_Lua_Unlimited_Ammo.git"
 )
 
@@ -1265,17 +1331,17 @@ declare -a ALE_SCRIPT_REGISTRY=(
 #   tweak_world       — inline SQL tweaks on acore_world (no clone needed)
 #   conf_xp           — edits worldserver.conf XP rate settings (no DB change)
 declare -a SQL_MOD_REGISTRY=(
+    "all-stackables|All Stackables to 200|https://github.com/AsgavinYT/azerothcore-all-stackables-200.git|clone_sql"
+    "baby-mobs|Baby Mobs (HP×0.25 / DMG×0.25 / ARM×0.25)||tweak_world"
+    "buff-mobs|Buff Mobs (HP×2 / DMG×1.5 / ARM×1.5)||tweak_world"
+    "custom-login|Custom Login (starter gear + rep on first login)|https://github.com/azerothcore/mod-custom-login.git|conf_module"
+    "xbuff-mobs|Extreme Buff Mobs (HP×4 / DMG×2 / ARM×2)||tweak_world"
+    "hearthstone-cd|Hearthstone Cooldown Tweaks|https://github.com/AsgavinYT/hearthstone-cooldowns.git|clone_sql_pick"
+    "lvl1-mounts|Level One Mounts (ride at level 1)|https://github.com/tomcoffingiii/mod-level-one-mounts.git|clone_sql"
+    "nerf-mobs|Nerf Mobs (HP×0.5 / DMG×0.75 / ARM×0.75)||tweak_world"
+    "npc-teleporter|NPC Teleporter (capital + starting zones)|https://github.com/Zoidwaffle/sql-npc-teleporter.git|clone_dist"
     "portals-capitals|Portals in All Capitals|https://github.com/azerothcore/portals-in-all-capitals.git|clone_sql"
     "rare-drops|Rare Drops (450 Classic rares loot)|https://github.com/StraysFromPath/mod-rare-drops.git|clone_sql_norevert"
-    "lvl1-mounts|Level One Mounts (ride at level 1)|https://github.com/tomcoffingiii/mod-level-one-mounts.git|clone_sql"
-    "all-stackables|All Stackables to 200|https://github.com/AsgavinYT/azerothcore-all-stackables-200.git|clone_sql"
-    "custom-login|Custom Login (starter gear + rep on first login)|https://github.com/azerothcore/mod-custom-login.git|conf_module"
-    "npc-teleporter|NPC Teleporter (capital + starting zones)|https://github.com/Zoidwaffle/sql-npc-teleporter.git|clone_dist"
-    "hearthstone-cd|Hearthstone Cooldown Tweaks|https://github.com/AsgavinYT/hearthstone-cooldowns.git|clone_sql_pick"
-    "buff-mobs|Buff Mobs (HP×2 / DMG×1.5 / ARM×1.5)||tweak_world"
-    "xbuff-mobs|Extreme Buff Mobs (HP×4 / DMG×2 / ARM×2)||tweak_world"
-    "nerf-mobs|Nerf Mobs (HP×0.5 / DMG×0.75 / ARM×0.75)||tweak_world"
-    "baby-mobs|Baby Mobs (HP×0.25 / DMG×0.25 / ARM×0.25)||tweak_world"
     "xp-rates|XP Rate Customization (Kill/Quest/Explore)||conf_xp"
 )
 
@@ -1919,7 +1985,7 @@ configure_module_challenge_modes() {
 
     print_info "⚠  Challenge Modes requires  EnablePlayerSettings = 1  in worldserver.conf."
     echo ""
-    ${EDITOR:-nano} "$conf_dest"
+    nano "$conf_dest"
     echo ""
     print_info "Restart the worldserver for conf changes to take effect."
 }
@@ -1956,7 +2022,7 @@ configure_module_bot_level_brackets() {
 
     print_info "⚠  Bot Level Brackets requires the Playerbots module to function."
     echo ""
-    ${EDITOR:-nano} "$conf_dest"
+    nano "$conf_dest"
     echo ""
     print_info "Restart the worldserver for conf changes to take effect."
 }
@@ -1994,7 +2060,7 @@ configure_module_npc_beastmaster() {
     print_info "Tip: Add 601026 to Creatures.CustomIDs in worldserver.conf to suppress"
     print_info "     a harmless gossip-menu warning in server logs."
     echo ""
-    ${EDITOR:-nano} "$conf_dest"
+    nano "$conf_dest"
     echo ""
     print_info "Restart the worldserver for conf changes to take effect."
 }
@@ -3910,8 +3976,8 @@ configure_sqlmod_custom_login() {
             print_error "Config not found. Install mod first."; press_enter; return
         fi
     fi
-    print_info "Opening mod_customlogin.conf in ${EDITOR:-vi}..."
-    "${EDITOR:-vi}" "$conf_dest"
+    print_info "Opening mod_customlogin.conf in nano..."
+    nano "$conf_dest"
 }
 
 configure_sqlmod_tweak() {
@@ -4334,6 +4400,7 @@ show_about() {
 # ── ALE Scripts submenu ───────────────────────────────────────
 menu_ale_scripts() {
     local page_start=0
+    _setup_screen
     while true; do
         if [ "$_RESIZE_NEEDED" = true ]; then
             _RESIZE_NEEDED=false
@@ -4517,6 +4584,7 @@ menu_ale_scripts() {
 # ENTER     Return to main menu
 menu_modules() {
     local page_start=0
+    _setup_screen
     while true; do
         if [ "$_RESIZE_NEEDED" = true ]; then
             _RESIZE_NEEDED=false
@@ -5002,6 +5070,7 @@ _module_conf_hints() {
 # Show unified module list with conf status and actions for managing conf files
 menu_module_management() {
     local page_start=0
+    _setup_screen
     while true; do
         if [ "$_RESIZE_NEEDED" = true ]; then
             _RESIZE_NEEDED=false
@@ -5153,7 +5222,7 @@ menu_module_management() {
                             continue
                         fi
                     fi
-                    ${EDITOR:-nano} "$conf_active"
+                    nano "$conf_active"
                     print_info "Restart worldserver to apply."
                     press_enter
                     continue
@@ -5297,6 +5366,7 @@ show_first_run_welcome() {
 menu_sql_mods() {
     sqlmod_init
     local page_start=0
+    _setup_screen
     while true; do
         if [ "$_RESIZE_NEEDED" = true ]; then
             _RESIZE_NEEDED=false
@@ -5428,6 +5498,7 @@ menu_sql_mods() {
 
 # ── Server Maintenance submenu ───────────────────────────────
 menu_server_maintenance() {
+    _setup_screen
     while true; do
         if [ "$_RESIZE_NEEDED" = true ]; then
             _RESIZE_NEEDED=false
@@ -5583,11 +5654,12 @@ _maintenance_import() {
 }
 
 main_menu() {
+    _IN_MENU=true
+    _setup_screen
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
     while true; do
-        if [ "$_RESIZE_NEEDED" = true ]; then
-            _RESIZE_NEEDED=false
-            _setup_screen
-        fi
+        _RESIZE_NEEDED=false
+        _setup_screen
         refresh_container_names
         local state_str build_str
         if container_running "$WORLD_CONTAINER"; then

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -4483,7 +4483,7 @@ _module_conf_hints() {
             ;;
     esac
 }
-
+# Show unified module list with conf status and actions for managing conf files
 menu_module_management() {
     local page_start=0
     while true; do
@@ -4510,7 +4510,7 @@ menu_module_management() {
         printf "  ${GOLD}── Module Management ─────────────────────────────${RST}\n"
         printf "  ${DIM}Conf files are activated by copying: .conf.dist -> .conf${RST}\n"
         printf "  ${DIM}Path: $SERVER_DIR/env/dist/etc/modules/${RST}\n"
-        printf "  ${YELLOW}⚠  After installing modules, run top-level option 7 (Rebuild worldserver) first.${RST}\n"
+        printf "  ${YELLOW}⚠  After installing modules, Rebuild worldserver, if you did not do it during installation.${RST}\n"
         printf "  ${DIM}%-4s %-34s %s${RST}\n" "Num" "Module" "Conf Status"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
 
@@ -4590,7 +4590,7 @@ menu_module_management() {
                 fi
                 if ! module_is_installed "$key"; then
                     print_warning "$name is not installed."
-                    print_info "Install it first from top-level option 1, then rebuild via option 7."
+                    print_info "Install it first from top-level option Install modules, then rebuild via Rebuild worldserver."
                     press_enter
                     continue
                 fi
@@ -4603,7 +4603,7 @@ menu_module_management() {
                 if [ "${action,,}" = "a" ]; then
                     if [ -z "$conf_dist" ] || [ ! -f "$conf_dist" ]; then
                         print_warning "Template .dist not found for $name."
-                        print_info "Run top-level option 7 (Rebuild worldserver), then try again."
+                        print_info "Run top-level option Rebuild worldserver, then try again."
                         press_enter
                         continue
                     fi
@@ -4614,7 +4614,7 @@ menu_module_management() {
                     fi
                     cp "$conf_dist" "$conf_active"
                     print_success "Activated conf: $conf_active"
-                    print_info "Restart worldserver (top-level option 11) to apply."
+                    print_info "Restart worldserver to apply."
                     press_enter
                     continue
                 fi
@@ -4632,7 +4632,7 @@ menu_module_management() {
                         fi
                     fi
                     ${EDITOR:-nano} "$conf_active"
-                    print_info "Restart worldserver (top-level option 11) to apply."
+                    print_info "Restart worldserver to apply."
                     press_enter
                     continue
                 fi
@@ -4640,7 +4640,7 @@ menu_module_management() {
                 if [ "${action,,}" = "r" ]; then
                     if [ -z "$conf_dist" ] || [ ! -f "$conf_dist" ]; then
                         print_warning "Template .dist not found for $name."
-                        print_info "Run top-level option 7 (Rebuild worldserver), then try again."
+                        print_info "Run top-level option Rebuild worldserver, then try again."
                         press_enter
                         continue
                     fi
@@ -4651,7 +4651,7 @@ menu_module_management() {
                     fi
                     cp "$conf_dist" "$conf_active"
                     print_success "Reset to defaults: $conf_active"
-                    print_info "Restart worldserver (top-level option 11) to apply."
+                    print_info "Restart worldserver to apply."
                     press_enter
                     continue
                 fi
@@ -5077,16 +5077,17 @@ main_menu() {
         printf "  ${WHITE}3)${RST} Manage SQL Mods\n"
         printf "  ${WHITE}4)${RST} Configure AH Bot\n"
         printf "  ${WHITE}5)${RST} Configure ALE\n"
-        printf "  ${WHITE}6)${RST} Rebuild worldserver\n"
+        printf "  ${WHITE}6)${RST} Configure Modules\n"
+        printf "  ${WHITE}7)${RST} Rebuild worldserver\n"
         printf "\n  ${GOLD}${BOLD}Server Controls${RST}\n"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
-        printf "  ${WHITE}7)${RST} Server status\n"
-        printf "  ${WHITE}8)${RST} Start server\n"
-        printf "  ${WHITE}9)${RST} Stop server\n"
-        printf "  ${WHITE}10)${RST} Restart server\n"
-        printf "  ${WHITE}11)${RST} View logs\n"
-        printf "  ${WHITE}12)${RST} Attach to console\n"
-        printf "  ${WHITE}13)${RST} Server maintenance\n"
+        printf "  ${WHITE}8)${RST} Server status\n"
+        printf "  ${WHITE}9)${RST} Start server\n"
+        printf "  ${WHITE}10)${RST} Stop server\n"
+        printf "  ${WHITE}11)${RST} Restart server\n"
+        printf "  ${WHITE}12)${RST} View logs\n"
+        printf "  ${WHITE}13)${RST} Attach to console\n"
+        printf "  ${WHITE}14)${RST} Server maintenance\n"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
         printf "  ${GOLD} Q)${RST} Quit\n"
 
@@ -5102,14 +5103,15 @@ main_menu() {
             3)  menu_sql_mods ;;
             4)  configure_ahbot; press_enter ;;
             5)  configure_ale; press_enter ;;
-            6)  rebuild_worldserver; press_enter ;;
-            7)  server_status; press_enter ;;
-            8)  server_start; press_enter ;;
-            9)  server_stop; press_enter ;;
-            10) server_restart; press_enter ;;
-            11) with_full_screen server_logs ;;
-            12) with_full_screen server_attach ;;
-            13) menu_server_maintenance ;;
+            6)  menu_module_management ;;
+            7)  rebuild_worldserver; press_enter ;;
+            8)  server_status; press_enter ;;
+            9)  server_start; press_enter ;;
+            10) server_stop; press_enter ;;
+            11) server_restart; press_enter ;;
+            12) with_full_screen server_logs ;;
+            13) with_full_screen server_attach ;;
+            14) menu_server_maintenance ;;
             q)  echo ""; print_info "Goodbye!"; exit 0 ;;
         esac
     done

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -519,7 +519,7 @@ server_start() {
             print_info "Most common causes and fixes:"
             print_info ""
             print_info "  • ${CYAN}'Table X already exists' errors${RST}: a previous module install"
-            print_info "    corrupted update tracking. Use menu option 12 (Repair install state)."
+            print_info "    corrupted update tracking. Use option 13 → Server Maintenance → Repair install state."
             print_info ""
             print_info "  • ${CYAN}'Permission denied' errors${RST}: UID/GID mismatch on env/dist."
             print_info "    Run: sudo chown -R 1000:1000 env/dist/etc env/dist/logs"
@@ -2952,14 +2952,25 @@ _sqlmod_remove_npc_teleporter() {
 _sqlmod_remove_tweak() {
     local key="$1" name="$2"
     local marker_file="$SQLMOD_MARKER_DIR/$key.installed"
-    local h_mult=1 d_mult=1 a_mult=1 spd_mult=1
+
+    # Known defaults per tweak (fallback if marker lacks APPLIED_* values)
+    local def_h def_d def_a def_spd
+    case "$key" in
+        buff-mobs)  def_h=2;    def_d=1.5;  def_a=1.5;  def_spd=0.8 ;;
+        xbuff-mobs) def_h=4;    def_d=2;    def_a=2;    def_spd=0.5 ;;
+        nerf-mobs)  def_h=0.5;  def_d=0.75; def_a=0.75; def_spd=1.2 ;;
+        baby-mobs)  def_h=0.25; def_d=0.25; def_a=0.25; def_spd=1.5 ;;
+        *) def_h=1; def_d=1; def_a=1; def_spd=1 ;;
+    esac
+
+    local h_mult="$def_h" d_mult="$def_d" a_mult="$def_a" spd_mult="$def_spd"
     if [ -f "$marker_file" ]; then
         # shellcheck source=/dev/null
         source "$marker_file"
-        h_mult="${APPLIED_HP_MULT:-1}"
-        d_mult="${APPLIED_DMG_MULT:-1}"
-        a_mult="${APPLIED_ARM_MULT:-1}"
-        spd_mult="${APPLIED_SPD_MULT:-1}"
+        h_mult="${APPLIED_HP_MULT:-$def_h}"
+        d_mult="${APPLIED_DMG_MULT:-$def_d}"
+        a_mult="${APPLIED_ARM_MULT:-$def_a}"
+        spd_mult="${APPLIED_SPD_MULT:-$def_spd}"
     fi
 
     local inv_h inv_d inv_a inv_spd
@@ -3180,10 +3191,11 @@ configure_sqlmod_tweak() {
     [ -z "$new_a" ]   && new_a="$cur_a"
     [ -z "$new_spd" ] && new_spd="$cur_spd"
 
-    # Validate: must be positive numbers (required for safe reversal)
+    # Validate: must be positive numeric literals (regex + value check)
     local invalid=false
     for v in "$new_h" "$new_d" "$new_a" "$new_spd"; do
-        if ! awk "BEGIN{exit !($v > 0)}" 2>/dev/null; then invalid=true; fi
+        if ! [[ "$v" =~ ^[0-9]+([.][0-9]+)?$ ]] || \
+           ! awk "BEGIN{exit !($v > 0)}" 2>/dev/null; then invalid=true; fi
     done
     if $invalid; then
         print_error "All multipliers must be positive numbers greater than 0."
@@ -3224,10 +3236,11 @@ configure_sqlmod_xprates() {
     [ -z "$new_quest" ]   && new_quest="$cur_quest"
     [ -z "$new_explore" ] && new_explore="$cur_explore"
 
-    # Validate: must be positive numbers
+    # Validate: must be positive numeric literals (regex + value check)
     local invalid=false
     for v in "$new_kill" "$new_quest" "$new_explore"; do
-        if ! awk "BEGIN{exit !($v > 0)}" 2>/dev/null; then invalid=true; fi
+        if ! [[ "$v" =~ ^[0-9]+([.][0-9]+)?$ ]] || \
+           ! awk "BEGIN{exit !($v > 0)}" 2>/dev/null; then invalid=true; fi
     done
     if $invalid; then
         print_error "XP multipliers must be positive numbers greater than 0."
@@ -3979,7 +3992,7 @@ show_first_run_welcome() {
     echo -e "${WHITE}    On Steam Deck this takes 30-90 minutes. Plug in and${RST}"
     echo -e "${WHITE}    keep the device on a flat surface for airflow.${RST}"
     echo ""
-    echo -e "${GREEN}  ✓${RST} ${WHITE}The repair function (option 12) only clears SQL update${RST}"
+    echo -e "${GREEN}  ✓${RST} ${WHITE}The repair function (option 13 → Server Maintenance) only clears SQL update${RST}"
     echo -e "${WHITE}    tracking rows. It never drops database tables.${RST}"
     echo ""
     if [ "$user_module_count" -eq 0 ]; then
@@ -4132,6 +4145,158 @@ menu_sql_mods() {
     done
 }
 
+# ── Server Maintenance submenu ───────────────────────────────
+menu_server_maintenance() {
+    while true; do
+        printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+        printf "  ${GOLD}${BOLD}Server Maintenance${RST}\n"
+        printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
+        printf "  ${WHITE}1)${RST} Repair install state\n"
+        printf "  ${WHITE}2)${RST} Backup databases\n"
+        printf "  ${WHITE}3)${RST} Restore / import a backup\n"
+        printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
+        printf "  ${DIM}  [ENTER] Back${RST}\n"
+
+        local _tlines; _tlines=$(tput lines 2>/dev/null || echo 24)
+        _read_menu_input "$(( _tlines - 1 ))"
+        local choice="${_MENU_INPUT,,}"
+
+        case "$choice" in
+            1) repair_install_state; press_enter ;;
+            2) _maintenance_backup_all; press_enter ;;
+            3) _maintenance_import ;;
+            "") return ;;
+            *) print_warning "Enter 1–3 or ENTER to go back."; press_enter ;;
+        esac
+    done
+}
+
+_maintenance_backup_all() {
+    sqlmod_init
+    if ! container_running "$DB_CONTAINER"; then
+        print_error "Database container is not running."
+        return 1
+    fi
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    printf "  ${GOLD}── Database Backup ──${RST}\n\n"
+    local ts; ts=$(date +%Y%m%d_%H%M%S)
+    local failed=0
+    for db in acore_world acore_characters acore_auth; do
+        local bfile="$SQLMOD_BACKUP_DIR/${ts}_${db}.sql.gz"
+        print_info "Backing up ${db} → $(basename "$bfile") ..."
+        if docker exec "$DB_CONTAINER" mysqldump -uroot -p"$DB_ROOT_PASSWORD" "$db" \
+           2>/dev/null | gzip > "$bfile"; then
+            print_success "  ✓ $db"
+        else
+            rm -f "$bfile"
+            print_error "  ✗ $db backup failed"
+            failed=1
+        fi
+    done
+    printf "\n"
+    if [ "$failed" -eq 0 ]; then
+        print_success "All databases backed up to: $SQLMOD_BACKUP_DIR"
+    else
+        print_warning "Some backups failed. Check that the DB container is healthy."
+    fi
+    printf "\n  ${DIM}Backups are .sql.gz files — restore via option 3 in this menu.${RST}\n"
+}
+
+_maintenance_import() {
+    sqlmod_init
+    if ! container_running "$DB_CONTAINER"; then
+        print_error "Database container is not running."
+        press_enter; return
+    fi
+
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    printf "  ${GOLD}── Restore / Import Backup ──${RST}\n\n"
+
+    # List available backups sorted newest-first
+    local -a files=()
+    while IFS= read -r f; do files+=("$f"); done < <(
+        ls -t "$SQLMOD_BACKUP_DIR"/*.sql.gz 2>/dev/null
+    )
+
+    if [ "${#files[@]}" -eq 0 ]; then
+        print_warning "No backups found in $SQLMOD_BACKUP_DIR"
+        print_info "Run option 2 first to create a backup."
+        press_enter; return
+    fi
+
+    printf "  ${DIM}Available backups (newest first):${RST}\n\n"
+    local i=1
+    for f in "${files[@]}"; do
+        local sz; sz=$(du -h "$f" 2>/dev/null | awk '{print $1}')
+        printf "  ${WHITE}%2d)${RST} %s  ${DIM}(%s)${RST}\n" "$i" "$(basename "$f")" "$sz"
+        (( i++ ))
+    done
+    printf "\n  ${DIM}Or enter a full path to a .sql or .sql.gz file.${RST}\n"
+    printf "\n  ${WHITE}Select [1-%d] or path (B to cancel): ${RST}" "${#files[@]}"
+    local sel; read -r sel
+    [ "${sel,,}" = "b" ] || [ -z "$sel" ] && return
+
+    local chosen_file
+    if [[ "$sel" =~ ^[0-9]+$ ]] && [ "$sel" -ge 1 ] && [ "$sel" -le "${#files[@]}" ]; then
+        chosen_file="${files[$((sel - 1))]}"
+    elif [ -f "$sel" ]; then
+        chosen_file="$sel"
+    else
+        print_error "Invalid selection."; press_enter; return
+    fi
+
+    # Determine target database from filename
+    local target_db=""
+    local fname; fname="$(basename "$chosen_file")"
+    if [[ "$fname" == *acore_world* ]];      then target_db="acore_world"
+    elif [[ "$fname" == *acore_characters* ]]; then target_db="acore_characters"
+    elif [[ "$fname" == *acore_auth* ]];       then target_db="acore_auth"
+    fi
+
+    if [ -z "$target_db" ]; then
+        printf "\n  ${WHITE}Target database (acore_world / acore_characters / acore_auth): ${RST}"
+        read -r target_db
+        if [[ ! "$target_db" =~ ^acore_(world|characters|auth)$ ]]; then
+            print_error "Invalid database name."; press_enter; return
+        fi
+    fi
+
+    printf "\n"
+    print_warning "This will OVERWRITE ${target_db} with data from: $(basename "$chosen_file")"
+    print_warning "Make sure you have a fresh backup before restoring!"
+    if ! ask_yes_no "Restore ${target_db} from this backup?"; then return; fi
+
+    # Take a safety backup before overwriting
+    print_info "Taking safety backup of current ${target_db} before restore..."
+    local ts; ts=$(date +%Y%m%d_%H%M%S)
+    local safefile="$SQLMOD_BACKUP_DIR/${ts}_pre_restore_${target_db}.sql.gz"
+    if docker exec "$DB_CONTAINER" mysqldump -uroot -p"$DB_ROOT_PASSWORD" "$target_db" \
+       2>/dev/null | gzip > "$safefile"; then
+        print_success "Safety backup: $(basename "$safefile")"
+    else
+        rm -f "$safefile"
+        print_warning "Safety backup failed — proceeding anyway (you accepted the risk)."
+    fi
+
+    print_info "Restoring ${target_db} from $(basename "$chosen_file")..."
+    if [[ "$chosen_file" == *.gz ]]; then
+        if gzip -dc "$chosen_file" | docker exec -i "$DB_CONTAINER" \
+           mysql -uroot -p"$DB_ROOT_PASSWORD" "$target_db" 2>&1; then
+            print_success "Restore complete!"
+        else
+            print_error "Restore failed. Check the file and try again."
+        fi
+    else
+        if docker exec -i "$DB_CONTAINER" \
+           mysql -uroot -p"$DB_ROOT_PASSWORD" "$target_db" < "$chosen_file" 2>&1; then
+            print_success "Restore complete!"
+        else
+            print_error "Restore failed. Check the file and try again."
+        fi
+    fi
+    press_enter
+}
+
 main_menu() {
     while true; do
         refresh_container_names
@@ -4168,7 +4333,7 @@ main_menu() {
         printf "  ${WHITE}10)${RST} Restart server\n"
         printf "  ${WHITE}11)${RST} View logs\n"
         printf "  ${WHITE}12)${RST} Attach to console\n"
-        printf "  ${WHITE}13)${RST} Repair install state\n"
+        printf "  ${WHITE}13)${RST} Server maintenance\n"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
         printf "  ${GOLD} Q)${RST} Quit\n"
 
@@ -4191,7 +4356,7 @@ main_menu() {
             10) server_restart; press_enter ;;
             11) with_full_screen server_logs ;;
             12) with_full_screen server_attach ;;
-            13) repair_install_state; press_enter ;;
+            13) menu_server_maintenance ;;
             q)  echo ""; print_info "Goodbye!"; exit 0 ;;
         esac
     done

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -232,6 +232,68 @@ press_enter() {
 }
 
 # ─────────────────────────────────────────────────────────────
+# _offer_npc_in_capitals  npc_entry  npc_name  [timing_note]
+#   Shows GM commands (in-game and console forms) to spawn an NPC
+#   in Stormwind and Orgrimmar.  Uses per-entry deterministic offsets
+#   so repeated calls never stack NPCs on the same coordinates.
+#   Optionally appends commands to $SERVER_DIR/npc_spawn_commands.txt.
+#   timing_note: extra line shown before coordinates (e.g. "run after rebuild")
+# ─────────────────────────────────────────────────────────────
+_offer_npc_in_capitals() {
+    local npc_entry="$1"
+    local npc_name="$2"
+    local timing_note="${3:-}"
+
+    # Deterministic slot per known entry; unknown entries use session counter
+    local slot
+    case "$npc_entry" in
+        190010)  slot=0 ;;
+        999991)  slot=1 ;;
+        601026)  slot=2 ;;
+        1116001) slot=3 ;;
+        *)       slot="${_NPC_SPAWN_IDX:-0}" ;;
+    esac
+    _NPC_SPAWN_IDX=$((_NPC_SPAWN_IDX + 1))
+
+    # Offset x by +3 and y by +2 per slot to prevent NPC overlap
+    local sw_x sw_y og_x og_y
+    sw_x=$(LC_ALL=C awk -v s="$slot" 'BEGIN{printf "%.1f", -8831.3 + s*3}')
+    sw_y=$(LC_ALL=C awk -v s="$slot" 'BEGIN{printf "%.1f",   628.2 + s*2}')
+    og_x=$(LC_ALL=C awk -v s="$slot" 'BEGIN{printf "%.1f",  1597.2 + s*3}')
+    og_y=$(LC_ALL=C awk -v s="$slot" 'BEGIN{printf "%.1f", -4415.7 + s*2}')
+
+    echo ""
+    print_info "📍 $npc_name (entry $npc_entry) is in the database but not yet placed in the world."
+    [ -n "$timing_note" ] && print_info "   $timing_note"
+    echo ""
+    echo -e "  ${GOLD}Stormwind, Alliance (map 0):${RST}"
+    echo -e "  ${WHITE}In-game GM:${RST}  ${CYAN}.npc add $npc_entry 0 $sw_x $sw_y 94.1 3.7${RST}"
+    echo -e "  ${WHITE}WS console:${RST}  ${CYAN}npc add $npc_entry 0 $sw_x $sw_y 94.1 3.7${RST}"
+    echo ""
+    echo -e "  ${GOLD}Orgrimmar, Horde (map 1):${RST}"
+    echo -e "  ${WHITE}In-game GM:${RST}  ${CYAN}.npc add $npc_entry 1 $og_x $og_y 17.5 4.5${RST}"
+    echo -e "  ${WHITE}WS console:${RST}  ${CYAN}npc add $npc_entry 1 $og_x $og_y 17.5 4.5${RST}"
+    echo ""
+    print_info "Access the worldserver console via option 12 from the main menu."
+    print_info "If the NPC lands in a bad spot, use .npc delete (in-game) or"
+    print_info "npc delete (console) then re-place with your own coordinates."
+    echo ""
+
+    if ask_yes_no "Save these spawn commands to a reference file?"; then
+        local outfile="$SERVER_DIR/npc_spawn_commands.txt"
+        {
+            printf '# %s (entry %s) — %s\n' "$npc_name" "$npc_entry" "$(date '+%Y-%m-%d %H:%M')"
+            printf '# Stormwind (Alliance, map 0)\n'
+            printf 'npc add %s 0 %s %s 94.1 3.7\n' "$npc_entry" "$sw_x" "$sw_y"
+            printf '# Orgrimmar (Horde, map 1)\n'
+            printf 'npc add %s 1 %s %s 17.5 4.5\n' "$npc_entry" "$og_x" "$og_y"
+            printf '\n'
+        } >> "$outfile"
+        print_success "Commands saved to: $outfile"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────
 # CONFIG — populated by detect_install
 # ─────────────────────────────────────────────────────────────
 SERVER_DIR=""
@@ -241,6 +303,9 @@ WORLD_CONTAINER=""
 DB_CONTAINER=""
 AUTH_CONTAINER=""
 DB_ROOT_PASSWORD="password"   # acore-docker default
+
+# Session counter for NPC spawn coordinate staggering (deterministic per known entry)
+_NPC_SPAWN_IDX=0
 
 # Module registry: key|name|repo url|sql dirs (comma-sep)
 declare -a MODULE_REGISTRY=(
@@ -2461,6 +2526,7 @@ ale_script_install() {
         exchangenpc)
             echo ""
             print_info "Exchange NPC requires a world SQL file to be applied."
+            local _exchangenpc_sql_ok=false
             if ask_yes_no "Apply Exchange NPC world SQL now?"; then
                 if ensure_db_running; then
                     # Prefer the *_Up.sql (install) variant; avoid Down/Revert scripts
@@ -2472,7 +2538,9 @@ ale_script_install() {
                             | grep -v -i "down\|revert" | head -1)
                     fi
                     if [ -n "$sql_file" ]; then
-                        ale_run_sql_file "acore_world" "$sql_file"
+                        if ale_run_sql_file "acore_world" "$sql_file"; then
+                            _exchangenpc_sql_ok=true
+                        fi
                     else
                         print_warning "No install SQL file found in $clone_dir"
                         print_info "Manually apply the *_Up.sql file from the repo."
@@ -2480,7 +2548,15 @@ ale_script_install() {
                 fi
             fi
             echo ""
-            print_info "After restart, teleport to the NPC: ${CYAN}.go zonexy 51.1 27.7 976${RST}"
+            print_info "Exchange NPC (Roboto, entry 1116001) is in the database but has no spawn point."
+            if [ "$_exchangenpc_sql_ok" = true ]; then
+                _offer_npc_in_capitals 1116001 "Roboto (Exchange NPC)" \
+                    "The NPC template was just applied — restart the server, then run these commands."
+            else
+                print_info "Apply the world SQL first (re-install or run manually), then spawn the NPC:"
+                print_info "  In-game:  ${CYAN}.npc add 1116001 0 -8831.3 628.2 94.1 3.7${RST}  (Stormwind)"
+                print_info "  In-game:  ${CYAN}.npc add 1116001 1  1597.2 -4415.7 17.5 4.5${RST}  (Orgrimmar)"
+            fi
             ;;
         battlepass)
             echo ""
@@ -3435,15 +3511,18 @@ _get_about_text() {
             printf '%s\n' \
                 'Adds a Transmogrification NPC (entry 190010) letting players' \
                 'change the visual appearance of their gear. Based on the' \
-                'Rochet2 transmog script. Spawn the NPC anywhere with' \
-                '.npc add 190010.'
+                'Rochet2 transmog script. After installing and rebuilding,' \
+                'spawn the NPC in-game or via console: .npc add 190010.' \
+                'The install flow will offer to provide capital-city coordinates.'
             ;;
         mod-1v1-arena)
             printf '%s\n' \
                 'Introduces solo 1v1 arena brackets so players can queue for' \
                 'ranked matches without needing a partner. Adds its own arena' \
                 'season structure and rating/reward system alongside the' \
-                'standard 2v2, 3v3, and 5v5 brackets.'
+                'standard 2v2, 3v3, and 5v5 brackets. Requires NPC entry' \
+                '999991 (Arena Battlemaster 1v1) to be manually spawned in' \
+                'the world after rebuilding — install flow provides coordinates.'
             ;;
         mod-ale)
             printf '%s\n' \
@@ -3484,8 +3563,9 @@ _get_about_text() {
                 'special NPC. Provides pet adoption (normal, rare, exotic), Hunter' \
                 'skills for non-hunters, a pet food vendor, stables, and a tracked-pets' \
                 'system (summon, rename, delete). Players summon the NPC anywhere via' \
-                '.beastmaster. NPC entry: 601026 (White Fang). Add 601026 to' \
-                'Creatures.CustomIDs in worldserver.conf to silence a harmless warning.'
+                '.beastmaster. NPC entry: 601026 (White Fang). You can also place it' \
+                'permanently in capitals — install flow provides coordinates. Add 601026' \
+                'to Creatures.CustomIDs in worldserver.conf to silence a harmless warning.'
             ;;
         accountwide)
             printf '%s\n' \
@@ -3505,10 +3585,11 @@ _get_about_text() {
             ;;
         exchangenpc)
             printf '%s\n' \
-                'Spawns a configurable NPC that swaps items for other items --' \
-                'a custom material-exchange vendor. Define exchange pairs in' \
-                'the Lua config, run the world SQL to place the NPC, and' \
-                'players interact with it directly to trade materials.'
+                'Spawns a configurable NPC (Roboto, entry 1116001) that swaps' \
+                'items for other items -- a custom material-exchange vendor.' \
+                'Define exchange pairs in the Lua config, apply the world SQL' \
+                'during install, then manually spawn the NPC in the world.' \
+                'The install flow offers capital-city spawn coordinates.'
             ;;
         activechat)
             printf '%s\n' \
@@ -4058,6 +4139,23 @@ menu_modules() {
                         print_info "NPC Beastmaster has a conf file and SQL in db-world and db-characters."
                         print_info "Note: rebuild the worldserver first if the conf.dist is not yet present."
                         if ask_yes_no "Configure NPC Beastmaster now?"; then configure_module_npc_beastmaster; fi
+                        echo ""
+                        print_info "Players can summon the Beastmaster NPC anywhere via .beastmaster."
+                        print_info "You can also permanently place it in capital cities."
+                        _offer_npc_in_capitals 601026 "White Fang (Beastmaster NPC)" \
+                            "Run these commands after rebuilding and starting the worldserver."
+                    fi
+                    if [ "$key" = "mod-transmog" ]; then
+                        echo ""
+                        print_info "Transmogrification adds NPC entry 190010 — it must be manually placed in the world."
+                        _offer_npc_in_capitals 190010 "Transmogrifier NPC" \
+                            "Run these commands after rebuilding and starting the worldserver."
+                    fi
+                    if [ "$key" = "mod-1v1-arena" ]; then
+                        echo ""
+                        print_info "1v1 Arena adds a Battlemaster NPC (entry 999991) — it must be manually placed in the world."
+                        _offer_npc_in_capitals 999991 "Arena Battlemaster 1v1" \
+                            "Run these commands after rebuilding and starting the worldserver."
                     fi
                 done
                 press_enter

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -702,6 +702,30 @@ declare -a ALE_SCRIPT_REGISTRY=(
     "unlimitedammo|Unlimited Ammo (auto-refills Hunter arrows/bullets)|https://github.com/Day36512/Acore_Lua_Unlimited_Ammo.git"
 )
 
+# SQL Mod registry — key|name|github_url|install_type
+# install_type values:
+#   clone_sql         — clone repo, run up.sql / down.sql via docker exec
+#   clone_sql_norevert— clone_sql but no down.sql exists
+#   clone_sql_pick    — clone repo, user picks which SQL variant to apply
+#   clone_dist        — clone repo, .dist files → .sql, apply with optional config
+#   conf_module       — C++ module: clone to modules/, copy .conf.dist; needs rebuild
+#   tweak_world       — inline SQL tweaks on acore_world (no clone needed)
+#   conf_xp           — edits worldserver.conf XP rate settings (no DB change)
+declare -a SQL_MOD_REGISTRY=(
+    "portals-capitals|Portals in All Capitals|https://github.com/azerothcore/portals-in-all-capitals.git|clone_sql"
+    "rare-drops|Rare Drops (450 Classic rares loot)|https://github.com/StraysFromPath/mod-rare-drops.git|clone_sql_norevert"
+    "lvl1-mounts|Level One Mounts (ride at level 1)|https://github.com/tomcoffingiii/mod-level-one-mounts.git|clone_sql"
+    "all-stackables|All Stackables to 200|https://github.com/AsgavinYT/azerothcore-all-stackables-200.git|clone_sql"
+    "custom-login|Custom Login (starter gear + rep on first login)|https://github.com/azerothcore/mod-custom-login.git|conf_module"
+    "npc-teleporter|NPC Teleporter (capital + starting zones)|https://github.com/Zoidwaffle/sql-npc-teleporter.git|clone_dist"
+    "hearthstone-cd|Hearthstone Cooldown Tweaks|https://github.com/AsgavinYT/hearthstone-cooldowns.git|clone_sql_pick"
+    "buff-mobs|Buff Mobs (HP×2 / DMG×1.5 / ARM×1.5)||tweak_world"
+    "xbuff-mobs|Extreme Buff Mobs (HP×4 / DMG×2 / ARM×2)||tweak_world"
+    "nerf-mobs|Nerf Mobs (HP×0.5 / DMG×0.75 / ARM×0.75)||tweak_world"
+    "baby-mobs|Baby Mobs (HP×0.25 / DMG×0.25 / ARM×0.25)||tweak_world"
+    "xp-rates|XP Rate Customization (Kill/Quest/Explore)||conf_xp"
+)
+
 # Discover the actual SQL filenames in a module's sql dir.
 # This is what AC's auto-update will use as the `updates.name` value.
 # Returns space-separated filenames, or empty if dir doesn't exist.
@@ -2457,6 +2481,760 @@ ale_script_remove() {
 }
 
 # ─────────────────────────────────────────────────────────────
+# SQL MODS — helpers
+# ─────────────────────────────────────────────────────────────
+
+SQLMOD_BASE_DIR=""
+SQLMOD_MARKER_DIR=""
+SQLMOD_CLONE_DIR=""
+SQLMOD_CONFIG_DIR=""
+SQLMOD_BACKUP_DIR=""
+
+sqlmod_init() {
+    [ -n "$SQLMOD_BASE_DIR" ] && return 0   # already initialised
+    SQLMOD_BASE_DIR="$SERVER_DIR/.sqlmods"
+    SQLMOD_MARKER_DIR="$SQLMOD_BASE_DIR/installed"
+    SQLMOD_CLONE_DIR="$SQLMOD_BASE_DIR/clones"
+    SQLMOD_CONFIG_DIR="$SQLMOD_BASE_DIR/config"
+    SQLMOD_BACKUP_DIR="$SQLMOD_BASE_DIR/backups"
+    mkdir -p "$SQLMOD_MARKER_DIR" "$SQLMOD_CLONE_DIR" "$SQLMOD_CONFIG_DIR" "$SQLMOD_BACKUP_DIR"
+}
+
+sqlmod_is_installed() {
+    local key="$1"
+    sqlmod_init
+    local entry t
+    for entry in "${SQL_MOD_REGISTRY[@]}"; do
+        IFS='|' read -r k _ _ t <<< "$entry"
+        if [ "$k" = "$key" ] && [ "$t" = "conf_module" ]; then
+            [ -d "$SERVER_DIR/modules/$key" ] && return 0 || return 1
+        fi
+    done
+    [ -f "$SQLMOD_MARKER_DIR/$key.installed" ]
+}
+
+sqlmod_backup_world() {
+    sqlmod_init
+    if ! container_running "$DB_CONTAINER"; then
+        print_error "Database container is not running. Cannot back up."
+        return 1
+    fi
+    local ts; ts=$(date +%Y%m%d_%H%M%S)
+    local bfile="$SQLMOD_BACKUP_DIR/${ts}_acore_world.sql.gz"
+    print_info "Backing up acore_world → $(basename "$bfile") ..."
+    if docker exec "$DB_CONTAINER" mysqldump -uroot -p"$DB_ROOT_PASSWORD" acore_world \
+       2>/dev/null | gzip > "$bfile"; then
+        print_success "Backup saved: $bfile"
+        return 0
+    else
+        rm -f "$bfile"
+        print_error "Backup failed! Aborting."
+        return 1
+    fi
+}
+
+sqlmod_run_sql() {
+    local db="$1" sql="$2"
+    docker exec "$DB_CONTAINER" mysql -uroot -p"$DB_ROOT_PASSWORD" "$db" -e "$sql" 2>&1
+}
+
+sqlmod_run_sql_file() {
+    local db="$1" filepath="$2"
+    docker exec -i "$DB_CONTAINER" mysql -uroot -p"$DB_ROOT_PASSWORD" "$db" \
+        < "$filepath" 2>&1
+}
+
+# ── Clone helper ──────────────────────────────────────────────
+_sqlmod_clone_or_update() {
+    local key="$1" url="$2"
+    local target="$SQLMOD_CLONE_DIR/$key"
+    if [ -d "$target/.git" ]; then
+        print_info "Updating $key..."
+        git -C "$target" pull --ff-only -q 2>&1 || true
+    else
+        print_info "Cloning $key..."
+        git clone --depth=1 -q "$url" "$target" 2>&1 || {
+            print_error "Clone failed for $url"
+            return 1
+        }
+    fi
+}
+
+# ── Install dispatcher ────────────────────────────────────────
+sqlmod_install() {
+    local key="$1" name="$2" url="$3" type="$4"
+    sqlmod_init
+
+    # These types don't touch the DB — handle separately
+    case "$type" in
+        conf_xp)     configure_sqlmod_xprates; return 0 ;;
+        conf_module) _sqlmod_install_conf_module "$key" "$name" "$url"; return ;;
+    esac
+
+    if sqlmod_is_installed "$key"; then
+        print_warning "$name is already installed."
+        return 0
+    fi
+
+    if ! container_running "$DB_CONTAINER"; then
+        print_error "Database container ($DB_CONTAINER) is not running."
+        print_info "Start the server first, then retry."
+        return 1
+    fi
+
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    printf "  ${YELLOW}⚠  WARNING: SQL Mods modify the world database.${RST}\n"
+    printf "  ${DIM}These changes are unlikely to corrupt the server, but a backup${RST}\n"
+    printf "  ${DIM}will be taken automatically before proceeding.${RST}\n\n"
+
+    if ! ask_yes_no "Install $name?"; then return 0; fi
+
+    sqlmod_backup_world || return 1
+    echo ""
+
+    case "$type" in
+        clone_sql|clone_sql_norevert) _sqlmod_install_clone_sql "$key" "$name" "$url" ;;
+        clone_sql_pick)               _sqlmod_install_hearthstone "$key" "$name" "$url" ;;
+        clone_dist)                   _sqlmod_install_clone_dist "$key" "$name" "$url" ;;
+        tweak_world)                  _sqlmod_install_tweak "$key" "$name" ;;
+    esac
+}
+
+_sqlmod_install_clone_sql() {
+    local key="$1" name="$2" url="$3"
+    _sqlmod_clone_or_update "$key" "$url" || return 1
+    local clone_dir="$SQLMOD_CLONE_DIR/$key"
+    local up_sql="" tmp_sql
+
+    case "$key" in
+        portals-capitals)
+            up_sql="$clone_dir/portals-in-all-capitals.up.sql"
+            local cfg_file="$SQLMOD_CONFIG_DIR/portals-capitals.conf"
+            if [ -f "$cfg_file" ]; then
+                # shellcheck source=/dev/null
+                source "$cfg_file"
+                local go_tpl="${PORTALS_GO_TEMPLATE:-500000}"
+                local go_spn="${PORTALS_GO_SPAWN:-2000000}"
+                tmp_sql="$SQLMOD_CLONE_DIR/${key}_configured.sql"
+                sed \
+                    -e "s/SET @GO_TEMPLATE = [0-9]*/SET @GO_TEMPLATE = $go_tpl/" \
+                    -e "s/SET @GO_SPAWN = [0-9]*/SET @GO_SPAWN = $go_spn/" \
+                    "$up_sql" > "$tmp_sql"
+                up_sql="$tmp_sql"
+            fi
+            ;;
+        rare-drops)
+            up_sql="$clone_dir/data/sql/db-world/updates/mod rare drops final.sql"
+            ;;
+        lvl1-mounts)
+            up_sql="$clone_dir/level-one-mounts.sql"
+            ;;
+        all-stackables)
+            up_sql="$clone_dir/All_Stackables_200_Up.sql"
+            local cfg_file="$SQLMOD_CONFIG_DIR/all-stackables.conf"
+            if [ -f "$cfg_file" ]; then
+                # shellcheck source=/dev/null
+                source "$cfg_file"
+                local stack="${STACKABLES_SIZE:-200}"
+                tmp_sql="$SQLMOD_CLONE_DIR/${key}_configured.sql"
+                sed \
+                    -e "s/stackable=[0-9]*/stackable=$stack/g" \
+                    -e "s/maxcount=[0-9]*/maxcount=$stack/g" \
+                    "$up_sql" > "$tmp_sql"
+                up_sql="$tmp_sql"
+            fi
+            ;;
+    esac
+
+    if [ -z "$up_sql" ] || [ ! -f "$up_sql" ]; then
+        print_error "Could not find install SQL for $name"
+        return 1
+    fi
+
+    print_info "Applying SQL to acore_world..."
+    if sqlmod_run_sql_file "acore_world" "$up_sql"; then
+        touch "$SQLMOD_MARKER_DIR/$key.installed"
+        print_success "$name installed successfully!"
+    else
+        print_error "SQL apply failed for $name"
+        return 1
+    fi
+}
+
+_sqlmod_install_hearthstone() {
+    local key="$1" name="$2" url="$3"
+    _sqlmod_clone_or_update "$key" "$url" || return 1
+    local clone_dir="$SQLMOD_CLONE_DIR/$key"
+
+    local cfg_file="$SQLMOD_CONFIG_DIR/hearthstone-cd.conf"
+    local cooldown_choice="30min"
+    if [ -f "$cfg_file" ]; then
+        # shellcheck source=/dev/null
+        source "$cfg_file"
+        cooldown_choice="${HEARTHSTONE_COOLDOWN:-30min}"
+    fi
+
+    local sql_file
+    case "$cooldown_choice" in
+        1sec|1s)   sql_file="$clone_dir/Hearthstone_1_Sec.sql" ;;
+        1min)      sql_file="$clone_dir/Hearthstone_1_Min.sql" ;;
+        5min)      sql_file="$clone_dir/Hearthstone_5_Min.sql" ;;
+        15min)     sql_file="$clone_dir/Hearthstone_15_Min.sql" ;;
+        30min|*)   sql_file="$clone_dir/Hearthstone_30_Min.sql" ;;
+    esac
+
+    print_info "Applying Hearthstone cooldown ($cooldown_choice) to acore_world..."
+    if sqlmod_run_sql_file "acore_world" "$sql_file"; then
+        echo "HEARTHSTONE_COOLDOWN=$cooldown_choice" > "$SQLMOD_MARKER_DIR/$key.installed"
+        print_success "$name installed ($cooldown_choice)!"
+    else
+        print_error "SQL apply failed"
+        return 1
+    fi
+}
+
+_sqlmod_install_clone_dist() {
+    local key="$1" name="$2" url="$3"
+    _sqlmod_clone_or_update "$key" "$url" || return 1
+    local clone_dir="$SQLMOD_CLONE_DIR/$key"
+
+    local cfg_file="$SQLMOD_CONFIG_DIR/npc-teleporter.conf"
+    local ony_level=60 install_capital=true install_startzone=true
+    if [ -f "$cfg_file" ]; then
+        # shellcheck source=/dev/null
+        source "$cfg_file"
+        ony_level="${NPC_TELEPORTER_ONY_LEVEL:-60}"
+        install_capital="${NPC_TELEPORTER_CAPITAL:-true}"
+        install_startzone="${NPC_TELEPORTER_STARTZONE:-true}"
+    fi
+
+    local dist_dir="$clone_dir/data/sql/db-world"
+    local applied=false
+    if [ "$install_capital" = "true" ] && [ -f "$dist_dir/teleporter_capital.dist" ]; then
+        local cap_sql="$SQLMOD_CLONE_DIR/${key}_capital.sql"
+        sed "s/@ONY_LEVEL := [0-9]*/@ONY_LEVEL := $ony_level/" \
+            "$dist_dir/teleporter_capital.dist" > "$cap_sql"
+        print_info "Applying capital teleporter SQL (ONY_LEVEL=$ony_level)..."
+        sqlmod_run_sql_file "acore_world" "$cap_sql" || {
+            print_error "Capital teleporter SQL failed"; return 1
+        }
+        applied=true
+    fi
+
+    if [ "$install_startzone" = "true" ] && [ -f "$dist_dir/teleporter_starting_zone.dist" ]; then
+        local sz_sql="$SQLMOD_CLONE_DIR/${key}_startzone.sql"
+        sed "s/@ONY_LEVEL := [0-9]*/@ONY_LEVEL := $ony_level/" \
+            "$dist_dir/teleporter_starting_zone.dist" > "$sz_sql"
+        print_info "Applying starting zone teleporter SQL..."
+        sqlmod_run_sql_file "acore_world" "$sz_sql" || {
+            print_error "Starting zone teleporter SQL failed"; return 1
+        }
+        applied=true
+    fi
+
+    if ! $applied; then
+        print_warning "No SQL was applied — both capital and starting zone NPCs are disabled in config."
+        return 1
+    fi
+
+    touch "$SQLMOD_MARKER_DIR/$key.installed"
+    print_success "$name installed successfully!"
+}
+
+_sqlmod_install_conf_module() {
+    local key="$1" name="$2" url="$3"
+    local module_dir="$SERVER_DIR/modules/$key"
+    if [ -d "$module_dir/.git" ]; then
+        print_info "Updating $key module..."
+        git -C "$module_dir" pull --ff-only -q 2>&1 || true
+    else
+        print_info "Cloning $key into modules/..."
+        git clone --depth=1 -q "$url" "$module_dir" 2>&1 || {
+            print_error "Clone failed"; return 1
+        }
+    fi
+
+    local conf_dist="$module_dir/conf/mod_customlogin.conf.dist"
+    local conf_dest="$SERVER_DIR/env/docker/etc/modules/mod_customlogin.conf"
+    if [ -f "$conf_dist" ] && [ ! -f "$conf_dest" ]; then
+        mkdir -p "$(dirname "$conf_dest")"
+        cp "$conf_dist" "$conf_dest"
+        print_success "Created default config: $conf_dest"
+    fi
+
+    print_success "$name cloned to modules/!"
+    print_warning "A worldserver rebuild is required to activate this module."
+    print_info "Use 'Rebuild worldserver' from the main menu to compile."
+}
+
+_sqlmod_install_tweak() {
+    local key="$1" name="$2"
+    local cfg_file="$SQLMOD_CONFIG_DIR/${key}.conf"
+    local h_mult d_mult a_mult spd_mult
+
+    case "$key" in
+        buff-mobs)  h_mult=2;    d_mult=1.5;  a_mult=1.5;  spd_mult=0.8 ;;
+        xbuff-mobs) h_mult=4;    d_mult=2;    a_mult=2;    spd_mult=0.5 ;;
+        nerf-mobs)  h_mult=0.5;  d_mult=0.75; a_mult=0.75; spd_mult=1.2 ;;
+        baby-mobs)  h_mult=0.25; d_mult=0.25; a_mult=0.25; spd_mult=1.5 ;;
+    esac
+
+    if [ -f "$cfg_file" ]; then
+        # shellcheck source=/dev/null
+        source "$cfg_file"
+        h_mult="${TWEAK_HP_MULT:-$h_mult}"
+        d_mult="${TWEAK_DMG_MULT:-$d_mult}"
+        a_mult="${TWEAK_ARM_MULT:-$a_mult}"
+        spd_mult="${TWEAK_SPD_MULT:-$spd_mult}"
+    fi
+
+    print_info "Applying $name (HP×${h_mult} / DMG×${d_mult} / ARM×${a_mult} / SPD×${spd_mult})..."
+    local sql
+    sql="UPDATE creature_template SET HealthModifier = HealthModifier * ${h_mult};"
+    sql+=" UPDATE creature_template SET DamageModifier = DamageModifier * ${d_mult};"
+    sql+=" UPDATE creature_template SET BaseAttackTime = BaseAttackTime * ${spd_mult}, RangeAttackTime = RangeAttackTime * ${spd_mult};"
+    sql+=" UPDATE creature_template SET ArmorModifier = ArmorModifier * ${a_mult};"
+
+    if sqlmod_run_sql "acore_world" "$sql"; then
+        printf 'APPLIED_HP_MULT=%s\nAPPLIED_DMG_MULT=%s\nAPPLIED_ARM_MULT=%s\nAPPLIED_SPD_MULT=%s\n' \
+            "$h_mult" "$d_mult" "$a_mult" "$spd_mult" > "$SQLMOD_MARKER_DIR/$key.installed"
+        print_success "$name applied!"
+        print_warning "Applying again stacks multipliers. Use Remove to reverse."
+    else
+        print_error "SQL failed for $name"
+        return 1
+    fi
+}
+
+# ── Remove dispatcher ─────────────────────────────────────────
+sqlmod_remove() {
+    local key="$1" name="$2" url="$3" type="$4"
+    sqlmod_init
+
+    case "$type" in
+        conf_module)
+            if ! sqlmod_is_installed "$key"; then
+                print_warning "$name is not installed."; return 0
+            fi
+            if ! ask_yes_no "Remove $name module directory? A rebuild will be required."; then return 0; fi
+            rm -rf "$SERVER_DIR/modules/$key"
+            print_success "$name removed. Rebuild worldserver to deactivate."
+            return 0
+            ;;
+        conf_xp)
+            if ! sqlmod_is_installed "$key"; then
+                print_warning "No XP rate customization is applied."; return 0
+            fi
+            if ! ask_yes_no "Reset XP rates to 1.0 (server default)?"; then return 0; fi
+            _sqlmod_remove_xprates
+            return 0
+            ;;
+    esac
+
+    if ! sqlmod_is_installed "$key"; then
+        print_warning "$name is not installed."; return 0
+    fi
+    if ! container_running "$DB_CONTAINER"; then
+        print_error "Database container ($DB_CONTAINER) is not running."
+        return 1
+    fi
+
+    case "$type" in
+        clone_sql)
+            if ! ask_yes_no "Remove $name? (runs down.sql)"; then return 0; fi
+            sqlmod_backup_world || return 1
+            _sqlmod_remove_clone_sql "$key" "$name"
+            ;;
+        clone_sql_norevert)
+            print_warning "$name has no automated reversal SQL."
+            print_info "To undo: restore a backup from: $SQLMOD_BACKUP_DIR"
+            press_enter; return 0
+            ;;
+        clone_sql_pick)
+            if ! ask_yes_no "Remove $name? (Hearthstone resets to 30-min WotLK default)"; then return 0; fi
+            sqlmod_backup_world || return 1
+            _sqlmod_remove_hearthstone "$key" "$name"
+            ;;
+        clone_dist)
+            if ! ask_yes_no "Remove $name? (NPC deleted from world)"; then return 0; fi
+            sqlmod_backup_world || return 1
+            _sqlmod_remove_npc_teleporter "$key" "$name"
+            ;;
+        tweak_world)
+            if ! ask_yes_no "Reverse $name? (applies inverse multipliers to creature_template)"; then return 0; fi
+            sqlmod_backup_world || return 1
+            _sqlmod_remove_tweak "$key" "$name"
+            ;;
+    esac
+}
+
+_sqlmod_remove_clone_sql() {
+    local key="$1" name="$2"
+    local clone_dir="$SQLMOD_CLONE_DIR/$key"
+    local down_sql="" tmp_sql
+
+    case "$key" in
+        portals-capitals)
+            down_sql="$clone_dir/portals-in-all-capitals.down.sql"
+            # Apply same config substitution used at install time
+            local cfg_file="$SQLMOD_CONFIG_DIR/portals-capitals.conf"
+            if [ -f "$cfg_file" ] && [ -f "$down_sql" ]; then
+                # shellcheck source=/dev/null
+                source "$cfg_file"
+                local go_tpl="${PORTALS_GO_TEMPLATE:-500000}"
+                local go_spn="${PORTALS_GO_SPAWN:-2000000}"
+                tmp_sql="$SQLMOD_CLONE_DIR/${key}_down_configured.sql"
+                sed \
+                    -e "s/SET @GO_TEMPLATE = [0-9]*/SET @GO_TEMPLATE = $go_tpl/" \
+                    -e "s/SET @GO_SPAWN = [0-9]*/SET @GO_SPAWN = $go_spn/" \
+                    "$down_sql" > "$tmp_sql"
+                down_sql="$tmp_sql"
+            fi
+            ;;
+        lvl1-mounts)  down_sql="$clone_dir/level-twenty-mounts.sql" ;;
+        all-stackables) down_sql="$clone_dir/All_Stackables_200_Down.sql" ;;
+    esac
+
+    if [ -z "$down_sql" ] || [ ! -f "$down_sql" ]; then
+        print_error "Remove SQL not found for $name (missing clone?)"
+        return 1
+    fi
+
+    print_info "Applying down.sql for $name..."
+    if sqlmod_run_sql_file "acore_world" "$down_sql"; then
+        rm -f "$SQLMOD_MARKER_DIR/$key.installed"
+        print_success "$name removed!"
+    else
+        print_error "SQL remove failed"
+        return 1
+    fi
+}
+
+_sqlmod_remove_hearthstone() {
+    local key="$1" name="$2"
+    # Reset to WotLK default: 30 minutes (1800000 ms)
+    local sql="UPDATE spell_dbc SET RecoveryTime = 1800000, CategoryRecoveryTime = 1800000 WHERE Id = 8690;"
+    print_info "Resetting Hearthstone to 30-minute cooldown..."
+    if sqlmod_run_sql "acore_world" "$sql"; then
+        rm -f "$SQLMOD_MARKER_DIR/$key.installed"
+        print_success "$name removed (30-min cooldown restored)!"
+    else
+        print_error "SQL reset failed"; return 1
+    fi
+}
+
+_sqlmod_remove_npc_teleporter() {
+    local key="$1" name="$2"
+    local sql
+    sql="DELETE FROM creature WHERE id1 IN (190000, 190001);"
+    sql+=" DELETE FROM creature_template WHERE entry IN (190000, 190001);"
+    print_info "Removing NPC Teleporter from world..."
+    if sqlmod_run_sql "acore_world" "$sql"; then
+        rm -f "$SQLMOD_MARKER_DIR/$key.installed"
+        print_success "$name removed!"
+    else
+        print_error "SQL removal failed"; return 1
+    fi
+}
+
+_sqlmod_remove_tweak() {
+    local key="$1" name="$2"
+    local marker_file="$SQLMOD_MARKER_DIR/$key.installed"
+    local h_mult=1 d_mult=1 a_mult=1 spd_mult=1
+    if [ -f "$marker_file" ]; then
+        # shellcheck source=/dev/null
+        source "$marker_file"
+        h_mult="${APPLIED_HP_MULT:-1}"
+        d_mult="${APPLIED_DMG_MULT:-1}"
+        a_mult="${APPLIED_ARM_MULT:-1}"
+        spd_mult="${APPLIED_SPD_MULT:-1}"
+    fi
+
+    local inv_h inv_d inv_a inv_spd
+    inv_h=$(awk   "BEGIN{printf \"%.6f\", 1/$h_mult}")
+    inv_d=$(awk   "BEGIN{printf \"%.6f\", 1/$d_mult}")
+    inv_a=$(awk   "BEGIN{printf \"%.6f\", 1/$a_mult}")
+    inv_spd=$(awk "BEGIN{printf \"%.6f\", 1/$spd_mult}")
+
+    print_info "Reversing $name (HP×${inv_h} / DMG×${inv_d} / ARM×${inv_a})..."
+    local sql
+    sql="UPDATE creature_template SET HealthModifier = HealthModifier * ${inv_h};"
+    sql+=" UPDATE creature_template SET DamageModifier = DamageModifier * ${inv_d};"
+    sql+=" UPDATE creature_template SET BaseAttackTime = BaseAttackTime * ${inv_spd}, RangeAttackTime = RangeAttackTime * ${inv_spd};"
+    sql+=" UPDATE creature_template SET ArmorModifier = ArmorModifier * ${inv_a};"
+
+    if sqlmod_run_sql "acore_world" "$sql"; then
+        rm -f "$SQLMOD_MARKER_DIR/$key.installed"
+        print_success "$name reversed!"
+    else
+        print_error "SQL failed"; return 1
+    fi
+}
+
+_sqlmod_remove_xprates() {
+    local conf_path="$SERVER_DIR/env/docker/etc/worldserver.conf"
+    if [ ! -f "$conf_path" ]; then
+        print_error "worldserver.conf not found at $conf_path"; return 1
+    fi
+    local tmpf; tmpf=$(mktemp)
+    sed \
+        -e 's/^Rate\.XP\.Kill *= *[0-9.]*/Rate.XP.Kill = 1/' \
+        -e 's/^Rate\.XP\.Quest *= *[0-9.]*/Rate.XP.Quest = 1/' \
+        -e 's/^Rate\.XP\.Explore *= *[0-9.]*/Rate.XP.Explore = 1/' \
+        "$conf_path" > "$tmpf" && mv "$tmpf" "$conf_path"
+    rm -f "$SQLMOD_MARKER_DIR/xp-rates.installed" 2>/dev/null
+    print_success "XP rates reset to 1.0 in worldserver.conf"
+    print_info "Run '.reload config' in-game or restart the world server to apply."
+}
+
+# ── Configure dispatcher ──────────────────────────────────────
+sqlmod_configure() {
+    local key="$1" name="$2"
+    sqlmod_init
+    case "$key" in
+        portals-capitals) configure_sqlmod_portals ;;
+        all-stackables)   configure_sqlmod_stackables ;;
+        npc-teleporter)   configure_sqlmod_npc_teleporter ;;
+        hearthstone-cd)   configure_sqlmod_hearthstone ;;
+        custom-login)     configure_sqlmod_custom_login ;;
+        buff-mobs|xbuff-mobs|nerf-mobs|baby-mobs)
+                          configure_sqlmod_tweak "$key" "$name" ;;
+        xp-rates)         configure_sqlmod_xprates ;;
+        *)  print_info "No dedicated configuration for $name." ;;
+    esac
+}
+
+configure_sqlmod_portals() {
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    printf "  ${GOLD}── Configure: Portals in All Capitals ──${RST}\n\n"
+    printf "  ${DIM}Adjust GO_TEMPLATE/GO_SPAWN base IDs if they conflict with other mods.${RST}\n"
+    printf "  ${DIM}Changes apply on next (re)install.${RST}\n\n"
+
+    local cfg_file="$SQLMOD_CONFIG_DIR/portals-capitals.conf"
+    local cur_tpl=500000 cur_spn=2000000
+    if [ -f "$cfg_file" ]; then
+        # shellcheck source=/dev/null
+        source "$cfg_file"
+        cur_tpl="${PORTALS_GO_TEMPLATE:-500000}"
+        cur_spn="${PORTALS_GO_SPAWN:-2000000}"
+    fi
+
+    printf "  GO_TEMPLATE base ID (current: %s): " "$cur_tpl"; local new_tpl; read -r new_tpl
+    printf "  GO_SPAWN base ID    (current: %s): " "$cur_spn"; local new_spn; read -r new_spn
+    [ -z "$new_tpl" ] && new_tpl="$cur_tpl"
+    [ -z "$new_spn" ] && new_spn="$cur_spn"
+
+    if ! [[ "$new_tpl" =~ ^[0-9]+$ ]] || ! [[ "$new_spn" =~ ^[0-9]+$ ]]; then
+        print_error "ID values must be positive integers."; press_enter; return
+    fi
+
+    printf 'PORTALS_GO_TEMPLATE=%s\nPORTALS_GO_SPAWN=%s\n' "$new_tpl" "$new_spn" > "$cfg_file"
+    print_success "Config saved. Remove + reinstall Portals to apply new IDs."
+    press_enter
+}
+
+configure_sqlmod_stackables() {
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    printf "  ${GOLD}── Configure: All Stackables ──${RST}\n\n"
+    printf "  ${DIM}Set the maximum stack size. Default is 200.${RST}\n"
+    printf "  ${DIM}Changes apply on next (re)install.${RST}\n\n"
+
+    local cfg_file="$SQLMOD_CONFIG_DIR/all-stackables.conf"
+    local cur_size=200
+    if [ -f "$cfg_file" ]; then
+        # shellcheck source=/dev/null
+        source "$cfg_file"; cur_size="${STACKABLES_SIZE:-200}"
+    fi
+
+    printf "  Max stack size (current: %s): " "$cur_size"; local new_size; read -r new_size
+    [ -z "$new_size" ] && new_size="$cur_size"
+    if ! [[ "$new_size" =~ ^[0-9]+$ ]]; then print_error "Invalid value."; press_enter; return; fi
+
+    printf 'STACKABLES_SIZE=%s\n' "$new_size" > "$cfg_file"
+    print_success "Config saved (stack size = $new_size). Remove + reinstall to apply."
+    press_enter
+}
+
+configure_sqlmod_npc_teleporter() {
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    printf "  ${GOLD}── Configure: NPC Teleporter ──${RST}\n\n"
+
+    local cfg_file="$SQLMOD_CONFIG_DIR/npc-teleporter.conf"
+    local cur_ony=60 cur_capital=true cur_startzone=true
+    if [ -f "$cfg_file" ]; then
+        # shellcheck source=/dev/null
+        source "$cfg_file"
+        cur_ony="${NPC_TELEPORTER_ONY_LEVEL:-60}"
+        cur_capital="${NPC_TELEPORTER_CAPITAL:-true}"
+        cur_startzone="${NPC_TELEPORTER_STARTZONE:-true}"
+    fi
+
+    printf "  Onyxia Level (60 = Vanilla, 80 = WotLK) [current: %s]: " "$cur_ony"
+    local new_ony; read -r new_ony
+    [ -z "$new_ony" ] && new_ony="$cur_ony"
+    ( [ "$new_ony" = "60" ] || [ "$new_ony" = "80" ] ) || {
+        print_error "Must be 60 or 80."; press_enter; return
+    }
+    printf "  Install Capital Teleporter NPC?      (true/false) [current: %s]: " "$cur_capital"
+    local new_capital; read -r new_capital
+    [ -z "$new_capital" ] && new_capital="$cur_capital"
+    printf "  Install Starting Zone Teleporter NPC? (true/false) [current: %s]: " "$cur_startzone"
+    local new_startzone; read -r new_startzone
+    [ -z "$new_startzone" ] && new_startzone="$cur_startzone"
+
+    printf 'NPC_TELEPORTER_ONY_LEVEL=%s\nNPC_TELEPORTER_CAPITAL=%s\nNPC_TELEPORTER_STARTZONE=%s\n' \
+        "$new_ony" "$new_capital" "$new_startzone" > "$cfg_file"
+    print_success "Config saved. Remove + reinstall to apply."
+    press_enter
+}
+
+configure_sqlmod_hearthstone() {
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    printf "  ${GOLD}── Configure: Hearthstone Cooldowns ──${RST}\n\n"
+    printf "  ${DIM}Select the Hearthstone cooldown. Remove + reinstall to apply.${RST}\n\n"
+    printf "  1) 30 minutes (WotLK default)\n"
+    printf "  2) 15 minutes\n"
+    printf "  3) 5 minutes\n"
+    printf "  4) 1 minute\n"
+    printf "  5) 1 second (instant)\n\n"
+
+    local cfg_file="$SQLMOD_CONFIG_DIR/hearthstone-cd.conf"
+    local cur="30min"
+    if [ -f "$cfg_file" ]; then
+        # shellcheck source=/dev/null
+        source "$cfg_file"; cur="${HEARTHSTONE_COOLDOWN:-30min}"
+    fi
+
+    printf "  Your choice [current: %s]: " "$cur"; local ans; read -r ans
+    local sel
+    case "$ans" in
+        1) sel="30min" ;; 2) sel="15min" ;; 3) sel="5min" ;;
+        4) sel="1min"  ;; 5) sel="1sec"  ;; *) sel="$cur" ;;
+    esac
+    printf 'HEARTHSTONE_COOLDOWN=%s\n' "$sel" > "$cfg_file"
+    print_success "Config saved ($sel). Remove + reinstall to apply."
+    press_enter
+}
+
+configure_sqlmod_custom_login() {
+    sqlmod_init
+    local conf_dest="$SERVER_DIR/env/docker/etc/modules/mod_customlogin.conf"
+    if [ ! -f "$conf_dest" ]; then
+        local module_dir="$SERVER_DIR/modules/custom-login"
+        local conf_dist="$module_dir/conf/mod_customlogin.conf.dist"
+        if [ -f "$conf_dist" ]; then
+            mkdir -p "$(dirname "$conf_dest")"
+            cp "$conf_dist" "$conf_dest"
+            print_success "Created $conf_dest"
+        else
+            print_error "Config not found. Install mod first."; press_enter; return
+        fi
+    fi
+    print_info "Opening mod_customlogin.conf in ${EDITOR:-vi}..."
+    "${EDITOR:-vi}" "$conf_dest"
+}
+
+configure_sqlmod_tweak() {
+    local key="$1" name="$2"
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    printf "  ${GOLD}── Configure: %s ──${RST}\n\n" "$name"
+    printf "  ${DIM}Adjust creature_template multipliers. Leave blank to keep current.${RST}\n"
+    printf "  ${DIM}Values must be positive numbers > 0 (used for reversal on remove).${RST}\n\n"
+
+    local def_h def_d def_a def_spd
+    case "$key" in
+        buff-mobs)  def_h=2;    def_d=1.5;  def_a=1.5;  def_spd=0.8 ;;
+        xbuff-mobs) def_h=4;    def_d=2;    def_a=2;    def_spd=0.5 ;;
+        nerf-mobs)  def_h=0.5;  def_d=0.75; def_a=0.75; def_spd=1.2 ;;
+        baby-mobs)  def_h=0.25; def_d=0.25; def_a=0.25; def_spd=1.5 ;;
+    esac
+
+    local cfg_file="$SQLMOD_CONFIG_DIR/${key}.conf"
+    local cur_h="$def_h" cur_d="$def_d" cur_a="$def_a" cur_spd="$def_spd"
+    if [ -f "$cfg_file" ]; then
+        # shellcheck source=/dev/null
+        source "$cfg_file"
+        cur_h="${TWEAK_HP_MULT:-$def_h}"; cur_d="${TWEAK_DMG_MULT:-$def_d}"
+        cur_a="${TWEAK_ARM_MULT:-$def_a}"; cur_spd="${TWEAK_SPD_MULT:-$def_spd}"
+    fi
+
+    local new_h new_d new_a new_spd
+    printf "  HP multiplier     [current: %s]: " "$cur_h";   read -r new_h
+    printf "  Damage multiplier [current: %s]: " "$cur_d";   read -r new_d
+    printf "  Armor multiplier  [current: %s]: " "$cur_a";   read -r new_a
+    printf "  Attack speed mult [current: %s]: " "$cur_spd"; read -r new_spd
+    [ -z "$new_h" ]   && new_h="$cur_h"
+    [ -z "$new_d" ]   && new_d="$cur_d"
+    [ -z "$new_a" ]   && new_a="$cur_a"
+    [ -z "$new_spd" ] && new_spd="$cur_spd"
+
+    # Validate: must be positive numbers (required for safe reversal)
+    local invalid=false
+    for v in "$new_h" "$new_d" "$new_a" "$new_spd"; do
+        if ! awk "BEGIN{exit !($v > 0)}" 2>/dev/null; then invalid=true; fi
+    done
+    if $invalid; then
+        print_error "All multipliers must be positive numbers greater than 0."
+        press_enter; return
+    fi
+
+    printf 'TWEAK_HP_MULT=%s\nTWEAK_DMG_MULT=%s\nTWEAK_ARM_MULT=%s\nTWEAK_SPD_MULT=%s\n' \
+        "$new_h" "$new_d" "$new_a" "$new_spd" > "$cfg_file"
+    print_success "Config saved. Install (or remove + reinstall) to apply."
+    press_enter
+}
+
+configure_sqlmod_xprates() {
+    sqlmod_init
+    printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+    printf "  ${GOLD}── Configure: XP Rates ──${RST}\n\n"
+
+    local conf_path="$SERVER_DIR/env/docker/etc/worldserver.conf"
+    if [ ! -f "$conf_path" ]; then
+        print_error "worldserver.conf not found at $conf_path"
+        print_info "Make sure your AzerothCore install is complete."
+        press_enter; return
+    fi
+
+    local cur_kill cur_quest cur_explore
+    cur_kill=$(grep -m1 '^Rate\.XP\.Kill' "$conf_path" | awk -F'=' '{print $2}' | tr -d ' ' 2>/dev/null)
+    cur_quest=$(grep -m1 '^Rate\.XP\.Quest' "$conf_path" | awk -F'=' '{print $2}' | tr -d ' ' 2>/dev/null)
+    cur_explore=$(grep -m1 '^Rate\.XP\.Explore' "$conf_path" | awk -F'=' '{print $2}' | tr -d ' ' 2>/dev/null)
+    [ -z "$cur_kill" ]    && cur_kill="1"
+    [ -z "$cur_quest" ]   && cur_quest="1"
+    [ -z "$cur_explore" ] && cur_explore="1"
+
+    printf "  ${DIM}File: %s${RST}\n\n" "$conf_path"
+    printf "  Kill XP multiplier    [current: %s]: " "$cur_kill";    local new_kill;    read -r new_kill
+    printf "  Quest XP multiplier   [current: %s]: " "$cur_quest";   local new_quest;   read -r new_quest
+    printf "  Explore XP multiplier [current: %s]: " "$cur_explore"; local new_explore; read -r new_explore
+    [ -z "$new_kill" ]    && new_kill="$cur_kill"
+    [ -z "$new_quest" ]   && new_quest="$cur_quest"
+    [ -z "$new_explore" ] && new_explore="$cur_explore"
+
+    # Validate: must be positive numbers
+    local invalid=false
+    for v in "$new_kill" "$new_quest" "$new_explore"; do
+        if ! awk "BEGIN{exit !($v > 0)}" 2>/dev/null; then invalid=true; fi
+    done
+    if $invalid; then
+        print_error "XP multipliers must be positive numbers greater than 0."
+        press_enter; return
+    fi
+
+    local tmpf; tmpf=$(mktemp)
+    sed \
+        -e "s/^Rate\.XP\.Kill *= *[0-9.]*/Rate.XP.Kill = $new_kill/" \
+        -e "s/^Rate\.XP\.Quest *= *[0-9.]*/Rate.XP.Quest = $new_quest/" \
+        -e "s/^Rate\.XP\.Explore *= *[0-9.]*/Rate.XP.Explore = $new_explore/" \
+        "$conf_path" > "$tmpf" && mv "$tmpf" "$conf_path"
+    touch "$SQLMOD_MARKER_DIR/xp-rates.installed" 2>/dev/null
+    print_success "XP rates saved: Kill=$new_kill  Quest=$new_quest  Explore=$new_explore"
+    print_info "Run '.reload config' in-game or restart the world server to apply."
+    press_enter
+}
+
+# ─────────────────────────────────────────────────────────────
 # ABOUT PANELS
 # ─────────────────────────────────────────────────────────────
 
@@ -2515,8 +3293,7 @@ _get_about_text() {
                 'Adds a Transmogrification NPC (entry 190010) letting players' \
                 'change the visual appearance of their gear. Based on the' \
                 'Rochet2 transmog script. Spawn the NPC anywhere with' \
-                '.npc add 190010. An optional TransmogPlus variant is' \
-                'available via mod-acore-subscriptions.'
+                '.npc add 190010.'
             ;;
         mod-1v1-arena)
             printf '%s\n' \
@@ -2621,6 +3398,98 @@ _get_about_text() {
                 'mid-fight. Enable via the ENABLED flag in config, or use' \
                 'the .ua GM command for runtime-only toggling.'
             ;;
+        # ── SQL Mods ──────────────────────────────────────────
+        portals-capitals)
+            printf '%s\n' \
+                'Capitalizes portal and interactable object labels in every' \
+                'major city (Stormwind, Orgrimmar, etc.). Pure cosmetic SQL' \
+                'change to gameobject_template display names -- no client mod' \
+                'needed. GO_TEMPLATE and GO_SPAWN base IDs are configurable to' \
+                'avoid conflicts with other SQL mods that add game objects.'
+            ;;
+        rare-drops)
+            printf '%s\n' \
+                'Adds hand-picked, level-appropriate loot to 450+ Classic rare' \
+                'and rare-elite mobs that previously had no special drops. Each' \
+                'item was thematically chosen for its specific mob across 100+' \
+                'hours of curation. Note: no down.sql exists -- removing requires' \
+                'restoring from the automatic backup taken at install time.'
+            ;;
+        lvl1-mounts)
+            printf '%s\n' \
+                'Modifies mount skill requirements so characters can ride at' \
+                'level 1 instead of the default 20. A minimal SQL change to' \
+                'skill line abilities. Revert SQL (level-twenty-mounts.sql)' \
+                'is included to restore the original level-20 requirement.'
+            ;;
+        all-stackables)
+            printf '%s\n' \
+                'Updates all stackable items in item_template to a configurable' \
+                'max stack size (default 200). Dramatically reduces bag clutter' \
+                'for consumables, reagents, and materials. Stack size can be set' \
+                'in Config before installing. Down.sql reverts to original sizes.'
+            ;;
+        custom-login)
+            printf '%s\n' \
+                'Grants configurable starter items, bags, heirlooms, skills,' \
+                'and faction reputation to characters on their very first login.' \
+                'Toggle each category in mod_customlogin.conf. Ideal for fresh' \
+                'realms or starter-pack servers. NOTE: C++ module -- requires' \
+                'a worldserver rebuild after install to activate.'
+            ;;
+        npc-teleporter)
+            printf '%s\n' \
+                'Spawns a Portal Master NPC with a gossip menu teleporting' \
+                'players to all major zones, dungeons, raids, and battlegrounds.' \
+                'Two NPC variants: capital city hub and starting zone hub.' \
+                'Onyxia Level (60 or 80) is configurable. Pure SQL -- no' \
+                'client modification required. Originally by Rochet2.'
+            ;;
+        hearthstone-cd)
+            printf '%s\n' \
+                'Changes the Hearthstone cooldown from 30 minutes to your' \
+                'preferred duration: 30 min, 15 min, 5 min, 1 min, or 1 sec.' \
+                'Updates spell_dbc via a simple UPDATE statement. Select the' \
+                'variant in Config before installing. Remove resets to the' \
+                'WotLK default of 30 minutes automatically.'
+            ;;
+        buff-mobs)
+            printf '%s\n' \
+                'Multiplies all creature HP (×2), damage (×1.5), armor (×1.5),' \
+                'and attack speed (×0.8 interval = faster). Makes open-world' \
+                'mobs noticeably harder without touching dungeon scripting.' \
+                'Multipliers are configurable. Remove applies the exact inverse' \
+                'to restore original values (floating-point accuracy may vary).'
+            ;;
+        xbuff-mobs)
+            printf '%s\n' \
+                'Extreme buff: creature HP×4, damage×2, armor×2, attack speed' \
+                '×0.5 (double attack rate). Designed for hardcore or challenge' \
+                'servers where trash mobs are genuinely dangerous. Multipliers' \
+                'are configurable. Remove applies the inverse multipliers.'
+            ;;
+        nerf-mobs)
+            printf '%s\n' \
+                'Reduces creature HP (×0.5), damage (×0.75), armor (×0.75),' \
+                'and slows attacks (×1.2 interval). Makes open-world content' \
+                'more accessible for casual players or fast leveling servers.' \
+                'Multipliers are configurable. Remove applies the inverse.'
+            ;;
+        baby-mobs)
+            printf '%s\n' \
+                'Sets creatures to baby difficulty: HP×0.25, damage×0.25,' \
+                'armor×0.25, very slow attacks (×1.5 interval). Ideal for' \
+                'families, new players, or near-trivial open-world combat.' \
+                'Multipliers are configurable. Remove applies the exact inverse.'
+            ;;
+        xp-rates)
+            printf '%s\n' \
+                'Edits Rate.XP.Kill, Rate.XP.Quest, and Rate.XP.Explore in' \
+                'worldserver.conf to custom multiplier values (e.g. 2 = double' \
+                'XP). Changes take effect after .reload config in-game or a' \
+                'world server restart. Remove resets all three rates to 1.0' \
+                '(the AzerothCore default). Install and Config do the same thing.'
+            ;;
         *)
             printf '%s\n' 'No description available. See the GitHub link below.'
             ;;
@@ -2632,7 +3501,7 @@ show_about() {
     printf '\033[%d;1H\033[J' "$MENU_START_ROW"
     printf "  ${GOLD}── About: %s ──${RST}\n\n" "$name"
     _get_about_text "$key" | sed 's/^/  /'
-    printf "\n  ${DIM}Source: %s${RST}\n" "$url"
+    [ -n "$url" ] && printf "\n  ${DIM}Source: %s${RST}\n" "$url"
     printf "\n  ${DIM}Press ENTER to return...${RST}\n"
     read -r _
 }
@@ -3124,6 +3993,133 @@ show_first_run_welcome() {
     printf '\033[%d;1H\033[J' "$MENU_START_ROW"
 }
 
+# ── SQL Mods submenu ──────────────────────────────────────────
+menu_sql_mods() {
+    sqlmod_init
+    local page_start=0
+    while true; do
+        local tlines; tlines=$(tput lines 2>/dev/null || echo 24)
+        printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+
+        local -a available_entries=()
+        local -a markers=()
+        local entry key name url type
+
+        for entry in "${SQL_MOD_REGISTRY[@]}"; do
+            IFS='|' read -r key name url type <<< "$entry"
+            if sqlmod_is_installed "$key"; then
+                markers+=("${GREEN}✓ Installed${RST}")
+            else
+                markers+=("${DIM}○ Not installed${RST}")
+            fi
+            available_entries+=("$entry")
+        done
+
+        local total=${#available_entries[@]}
+        local avail=$(( tlines - MENU_START_ROW - 1 ))
+        local page_size=$(( avail - 7 ))
+        [ "$page_size" -lt 3 ] && page_size=3
+
+        local max_start=$(( total - page_size ))
+        [ "$max_start" -lt 0 ] && max_start=0
+        [ "$page_start" -gt "$max_start" ] && page_start=$max_start
+        [ "$page_start" -lt 0 ] && page_start=0
+
+        local page_end=$(( page_start + page_size ))
+        [ "$page_end" -gt "$total" ] && page_end=$total
+        local total_pages=$(( (total + page_size - 1) / page_size ))
+        local current_page=$(( page_start / page_size + 1 ))
+
+        printf "  ${GOLD}── SQL Mods ──────────────────────────────────────${RST}\n"
+        printf "  ${YELLOW}⚠  Edits the world DB — auto-backup runs before each install${RST}\n"
+        printf "  ${DIM}%-4s %-40s %s${RST}\n" "Num" "Mod" "Status"
+        printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
+
+        local idx
+        for (( idx=page_start; idx<page_end; idx++ )); do
+            IFS='|' read -r key name url type <<< "${available_entries[$idx]}"
+            printf "  ${WHITE}%2d)${RST} %-40s %b\n" "$(( idx + 1 ))" "$name" "${markers[$idx]}"
+        done
+
+        printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
+        if [ "$total_pages" -gt 1 ]; then
+            local nav="  ${DIM}Page $current_page/$total_pages${RST}"
+            [ "$current_page" -gt 1 ]              && nav+="   ${WHITE}< prev${RST}"
+            [ "$current_page" -lt "$total_pages" ]  && nav+="   ${WHITE}> next${RST}"
+            printf "%b\n" "$nav"
+        fi
+        printf "  ${WHITE}i<num>${RST} Install   ${WHITE}r<num>${RST} Remove   ${WHITE}c<num>${RST} Config   ${WHITE}?<num>${RST} About   ${WHITE}ENTER${RST} Back\n"
+
+        _read_menu_input "$(( tlines - 1 ))"
+        local raw_choice="$_MENU_INPUT"
+        [ -z "$raw_choice" ] && return
+
+        local action nums
+        action="${raw_choice:0:1}"
+        nums="${raw_choice:1}"
+
+        case "${action,,}" in
+            '<')
+                page_start=$(( page_start - page_size ))
+                [ "$page_start" -lt 0 ] && page_start=0
+                ;;
+            '>')
+                page_start=$(( page_start + page_size ))
+                [ "$page_start" -gt "$max_start" ] && page_start=$max_start
+                ;;
+            i)
+                local inum; inum="${nums//[[:space:]]/}"
+                if ! [[ "$inum" =~ ^[0-9]+$ ]] || \
+                   [ "$inum" -lt 1 ] || [ "$inum" -gt "$total" ]; then
+                    print_warning "Invalid mod number — e.g. i3"
+                    press_enter; continue
+                fi
+                IFS='|' read -r key name url type <<< "${available_entries[$((inum - 1))]}"
+                printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                sqlmod_install "$key" "$name" "$url" "$type" || true
+                press_enter
+                ;;
+            r)
+                local rnum; rnum="${nums//[[:space:]]/}"
+                if ! [[ "$rnum" =~ ^[0-9]+$ ]] || \
+                   [ "$rnum" -lt 1 ] || [ "$rnum" -gt "$total" ]; then
+                    print_warning "Invalid mod number — e.g. r3"
+                    press_enter; continue
+                fi
+                IFS='|' read -r key name url type <<< "${available_entries[$((rnum - 1))]}"
+                printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                sqlmod_remove "$key" "$name" "$url" "$type" || true
+                press_enter
+                ;;
+            c)
+                local cnum; cnum="${nums//[[:space:]]/}"
+                if ! [[ "$cnum" =~ ^[0-9]+$ ]] || \
+                   [ "$cnum" -lt 1 ] || [ "$cnum" -gt "$total" ]; then
+                    print_warning "Invalid mod number — e.g. c5"
+                    press_enter; continue
+                fi
+                IFS='|' read -r key name url type <<< "${available_entries[$((cnum - 1))]}"
+                printf '\033[%d;1H\033[J' "$MENU_START_ROW"
+                sqlmod_configure "$key" "$name"
+                ;;
+            [?])
+                local anum; anum="${nums//[[:space:]]/}"
+                if ! [[ "$anum" =~ ^[0-9]+$ ]] || \
+                   [ "$anum" -lt 1 ] || [ "$anum" -gt "$total" ]; then
+                    print_warning "Invalid mod number -- e.g. ?3"
+                    press_enter; continue
+                fi
+                IFS='|' read -r key name url type <<< "${available_entries[$((anum - 1))]}"
+                show_about "$key" "$name" "$url"
+                ;;
+            *)
+                print_warning "Unknown command. Use i<num>, r<num>, c<num>, ?<num>, or ENTER."
+                press_enter
+                ;;
+        esac
+    done
+}
+
 main_menu() {
     while true; do
         refresh_container_names
@@ -3148,18 +4144,19 @@ main_menu() {
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
         printf "  ${WHITE}1)${RST} Manage AzerothCore Modules\n"
         printf "  ${WHITE}2)${RST} Manage ALE Lua Mods\n"
-        printf "  ${WHITE}3)${RST} Configure AH Bot\n"
-        printf "  ${WHITE}4)${RST} Configure ALE\n"
-        printf "  ${WHITE}5)${RST} Rebuild worldserver\n"
+        printf "  ${WHITE}3)${RST} Manage SQL Mods\n"
+        printf "  ${WHITE}4)${RST} Configure AH Bot\n"
+        printf "  ${WHITE}5)${RST} Configure ALE\n"
+        printf "  ${WHITE}6)${RST} Rebuild worldserver\n"
         printf "\n  ${GOLD}${BOLD}Server Controls${RST}\n"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
-        printf "  ${WHITE}6)${RST} Server status\n"
-        printf "  ${WHITE}7)${RST} Start server\n"
-        printf "  ${WHITE}8)${RST} Stop server\n"
-        printf "  ${WHITE}9)${RST} Restart server\n"
-        printf "  ${WHITE}10)${RST} View logs\n"
-        printf "  ${WHITE}11)${RST} Attach to console\n"
-        printf "  ${WHITE}12)${RST} Repair install state\n"
+        printf "  ${WHITE}7)${RST} Server status\n"
+        printf "  ${WHITE}8)${RST} Start server\n"
+        printf "  ${WHITE}9)${RST} Stop server\n"
+        printf "  ${WHITE}10)${RST} Restart server\n"
+        printf "  ${WHITE}11)${RST} View logs\n"
+        printf "  ${WHITE}12)${RST} Attach to console\n"
+        printf "  ${WHITE}13)${RST} Repair install state\n"
         printf "  ${GOLD}──────────────────────────────────────────────────${RST}\n"
         printf "  ${GOLD} Q)${RST} Quit\n"
 
@@ -3172,16 +4169,17 @@ main_menu() {
         case "$choice" in
             1)  menu_modules ;;
             2)  menu_ale_scripts ;;
-            3)  configure_ahbot; press_enter ;;
-            4)  configure_ale; press_enter ;;
-            5)  rebuild_worldserver; press_enter ;;
-            6)  server_status; press_enter ;;
-            7)  server_start; press_enter ;;
-            8)  server_stop; press_enter ;;
-            9)  server_restart; press_enter ;;
-            10) with_full_screen server_logs ;;
-            11) with_full_screen server_attach ;;
-            12) repair_install_state; press_enter ;;
+            3)  menu_sql_mods ;;
+            4)  configure_ahbot; press_enter ;;
+            5)  configure_ale; press_enter ;;
+            6)  rebuild_worldserver; press_enter ;;
+            7)  server_status; press_enter ;;
+            8)  server_start; press_enter ;;
+            9)  server_stop; press_enter ;;
+            10) server_restart; press_enter ;;
+            11) with_full_screen server_logs ;;
+            12) with_full_screen server_attach ;;
+            13) repair_install_state; press_enter ;;
             q)  echo ""; print_info "Goodbye!"; exit 0 ;;
         esac
     done

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -2517,15 +2517,8 @@ configure_ale_bmah() {
     local deployed_file="$lua_dir/bmah_server.lua"
 
     # Parallel arrays — index-aligned (Bash 3 compatible; no associative arrays).
-    local -a BNPC_IDS=(   45281   2496  11183   8921   3162  14740  11504  10834)
-    local -a BNPC_NAMES=( "Slytter"
-                        "Krazek"
-                        "Dirge Quikcleave"
-                        "Ravenholdt Guards"
-                        "Slyres Notrash"
-                        "Stonard Smuggler"
-                        "Baron Vardus"
-                        "Count Remo" )
+    local -a BNPC_IDS=(   2494              7164    )
+    local -a BNPC_NAMES=( "Privateer Bloads" "Krazek" )
 
 
     print_step "Black Market AH — NPC Vendor Configuration"
@@ -2572,28 +2565,15 @@ configure_ale_bmah() {
     fi
 
     # ── NPC selection menu ────────────────────────────────────
-    echo -e "  ${GOLD}──  Suggested Vendor NPCs  ──────────────────────────────────────────────${RST}"
+    echo -e "  ${GOLD}──  Suggested Vendor NPCs (Booty Bay)  ─────────────────────────────────${RST}"
     echo ""
-    echo -e "  ${DIM}Shady / Neutral Factions${RST}"
-    printf "  ${WHITE}%2s)${RST} %-20s ${CYAN}(%5s)${RST}  %s\n" \
-        1 "Slytter"          45281 "Goblin rogue in Booty Bay; coastal smuggler theme" \
-        2 "Krazek"            2496 "Booty Bay goblin with shady business connections" \
-        3 "Dirge Quikcleave" 11183 "Gadgetzan butcher; deals in rare exotic goods"
-    echo ""
-    echo -e "  ${DIM}Criminal Underworld / Rogue Themes${RST}"
-    printf "  ${WHITE}%2s)${RST} %-20s ${CYAN}(%5s)${RST}  %s\n" \
-        4 "Ravenholdt Guards"  8921 "Ravenholdt Manor; gate BMAH behind rogue faction" \
-        5 "Slyres Notrash"     3162 "Dalaran Underbelly; illicit underground zone" \
-        6 "Stonard Smuggler"  14740 "Out-of-the-way NPC; hidden underground trade network"
-    echo ""
-    echo -e "  ${DIM}High Society / Wealthy Elites${RST}"
-    printf "  ${WHITE}%2s)${RST} %-20s ${CYAN}(%5s)${RST}  %s\n" \
-        7 "Baron Vardus"      11504 "Corrupt noble; wealthy elites buying illegal artifacts" \
-        8 "Count Remo"        10834 "High-standing noble; hidden high-end auction ring"
+    printf "  ${WHITE}%2s)${RST} %-22s ${CYAN}(%5s)${RST}  %s\n" \
+        1 "Privateer Bloads" 2494 "Booty Bay; shady privateer with underworld connections" \
+        2 "Krazek"           7164 "Booty Bay goblin; deals in rare and illicit goods"
     echo ""
     echo -e "  ${GOLD}────────────────────────────────────────────────────────────────────────${RST}"
     echo ""
-    printf "${WHITE}Select NPCs by number (e.g. 1 3 7), or \"all\". Leave blank to keep current IDs: ${RST}"
+    printf "${WHITE}Select NPCs by number (e.g. 1 2), or \"all\". Leave blank to keep current IDs: ${RST}"
     read -r _bsel
 
     # ── Parse numbered selection ──────────────────────────────


### PR DESCRIPTION
## Overview

Full rebuild of the WotLK server management script, previously `manage-wow-modules.sh`,
now renamed to `wow-manage.sh`. This branch transforms a basic module-install helper into
a full interactive terminal manager for AzerothCore WotLK servers running on docker,
with dedicated support for Steam Deck sizing and usability constraints.

## What's New

### Script Rename & Structural Refactor
- Renamed `manage-wow-modules.sh` → `wow-manage.sh`
- Full code restructure: helpers at top, registries, install/configure/remove flows,
  menus, then entrypoint; consistent ordering throughout
- Dead code removed, stale comments cleaned, reusable helpers extracted

### Terminal UX — Steam Deck & Dynamic Resize
- Real-time `SIGWINCH` handling: menus and header redraw correctly on terminal resize
- Supports Steam Deck's common smaller terminal (launched via Konsole from Game Mode)
- Slim banner shown inside menus; full animated logo reserved for intro and first-run only
- Terminal cleared and header reprinted on every menu/scene transition
- `SIGTERM` handler added: always restores alt-screen and cursor before exit
- EOF/Ctrl-D on stdin now exits cleanly instead of infinite-redraw loop
- `_is_steam_deck` detection: on SteamOS, all config file opens show the file path
  and offer to launch **Kate** (graphical editor) instead of nano, which cannot be
  exited on the Steam Deck virtual keyboard (no Ctrl key)

### C++ Module Management
New modules added to registry:
- **Challenge Modes** (Hardcore, Iron Man, etc.)
- **Bot Level Brackets** (Playerbots XP distribution)
- **NPC Beastmaster** (multi-pet taming for all classes)
- **Sit Means Rest** (regen buff on sit)
- **Unlimited Ammo** (removes ammo requirement)

### All modules/Lua/SQL have:
- `install` / `remove` / `configure` flows with correct conf paths
- `About` panels with detailed descriptions
- NPC spawn commands for capital cities where applicable
- Post-install hooks for modules requiring world placement
- Prints of related commands at ingame-commands.txt
- Pagination (`<` / `>`) on all script lists with page indicator.

### Added SQL Mod Management
- Per-mod `install` / `remove` / `configure` / `reapply` flows
- Automatic `acore_world` backup before every install or remove
- **Backup rotation**: keeps last 2 backups per database; pre-restore safety copies
  are never pruned
- Full backup/restore under Server Maintenance menu (option 14)
- Pipelines use `set -o pipefail` to correctly propagate mysqldump/gzip failures
- Clone failure cleanup before retry; installed-state checks require `.git` presence

### In-Game Commands Reference System
- Auto-generated `ingame-commands.txt` in `$SERVER_DIR`
- NPC Spawn Quick Reference header rebuilt from all installed mods
- NPC spawn commands listed first within each mod's section
- Blank line after each mod's section for readability
- Page change hint (`< / >`) shown on paginated lists
- Kate offer (Steam Deck)

### Server Maintenance Menu
New menu (option 14):
- Back up / restore all databases
- Repair: pull latest Docker images, recreate containers, reset permissions

### Input & Menu Hardening
- `_parse_single_index`: regex capture rejects embedded spaces — `i1 2` no longer
  silently collapses to `i12` targeting the wrong item
- All install/remove prompts accept **one number at a time** (no multi-digit ambiguity)
- `_read_menu_input` distinguishes resize events (redraw) from EOF/broken stdin (exit)