### PR TITLE
fix(DML Launcher): Win11 tray, WSL RAM release, and Extras menu

### DIFF
--- a/guides/DML-Windows/DML-Launcher.cs
+++ b/guides/DML-Windows/DML-Launcher.cs
@@ -1,0 +1,995 @@
+// DML-Launcher.cs -- Dad's MMO Lab system tray launcher
+// Compiled at install time: csc.exe /target:winexe /r:System.Windows.Forms.dll /r:System.Drawing.dll
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+
+class DmlLauncherEntry
+{
+    [STAThread]
+    static void Main()
+    {
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+        Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
+        Application.ThreadException += delegate(object s, ThreadExceptionEventArgs e) { };
+        SynchronizationContext.SetSynchronizationContext(new WindowsFormsSynchronizationContext());
+        Application.Run(new TrayApp());
+    }
+}
+
+class TrayApp : ApplicationContext
+{
+    const string DISTRO   = "dml-arch";
+    const string VERSION  = "2.1.1";
+
+    enum ServerDisplayState { Stopped, Running, Loading }
+
+    string TrayTooltip(bool serverActive)
+    {
+        return serverActive
+            ? "DML Launcher v" + VERSION + " — Server Active"
+            : "DML Launcher v" + VERSION;
+    }
+
+    string TitlesCachePath {
+        get {
+            return System.IO.Path.Combine(
+                System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location),
+                "dml-titles.cache");
+        }
+    }
+
+    string StoppedMarkerPath {
+        get {
+            return System.IO.Path.Combine(
+                System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location),
+                ".dml-servers-stopped");
+        }
+    }
+
+    bool ServersIntentionallyStopped()
+    {
+        try { return System.IO.File.Exists(StoppedMarkerPath); }
+        catch { return false; }
+    }
+
+    // After stop, tray/doctor must not boot WSL for status — that leaves VmmemWSL ~2 GB idle.
+    string GetStatusOutput()
+    {
+        if (ServersIntentionallyStopped() || !IsDistroRunning())
+            return BuildStoppedStatusOutput();
+        return WslRun("dml status");
+    }
+
+    void MaybeReReleaseWsl()
+    {
+        if (ServersIntentionallyStopped() && IsDistroRunning())
+            TriggerReleaseWsl(0);
+    }
+
+    // True only when dml-arch is Running — wsl -l -v does NOT boot the distro.
+    static bool IsDistroRunning()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo();
+            psi.FileName               = "wsl.exe";
+            psi.Arguments              = "-l -v";
+            psi.UseShellExecute        = false;
+            psi.RedirectStandardOutput = true;
+            psi.CreateNoWindow         = true;
+            // wsl -l -v emits UTF-16 LE; UTF-8 decoding breaks "Running" matching
+            psi.StandardOutputEncoding = Encoding.Unicode;
+            using (var p = Process.Start(psi))
+            {
+                string output = p.StandardOutput.ReadToEnd();
+                p.WaitForExit(5000);
+                foreach (var line in output.Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    string trimmed = line.Trim();
+                    if (trimmed.StartsWith(DISTRO, StringComparison.OrdinalIgnoreCase)
+                        || trimmed.StartsWith("* " + DISTRO, StringComparison.OrdinalIgnoreCase))
+                        return trimmed.IndexOf("Running", StringComparison.OrdinalIgnoreCase) >= 0;
+                }
+            }
+        }
+        catch { }
+        return false;
+    }
+
+    void SaveTitleCache(System.Collections.Generic.IEnumerable<string> titles)
+    {
+        try
+        {
+            System.IO.File.WriteAllLines(TitlesCachePath, titles);
+        }
+        catch { }
+    }
+
+    string[] LoadTitleCache()
+    {
+        try
+        {
+            if (System.IO.File.Exists(TitlesCachePath))
+                return System.IO.File.ReadAllLines(TitlesCachePath);
+        }
+        catch { }
+        return new string[0];
+    }
+
+    string BuildStoppedStatusOutput()
+    {
+        var titles = LoadTitleCache();
+        if (titles.Length == 0) return "";
+        var lines = new System.Collections.Generic.List<string>();
+        foreach (var t in titles)
+        {
+            string title = (t ?? "").Trim();
+            if (title.Length > 0) lines.Add(title + ":stopped");
+        }
+        return string.Join("\n", lines);
+    }
+
+    // Prevents Windows from sleeping while a server is running.
+    // ES_CONTINUOUS makes the state persist until explicitly released.
+    // ES_SYSTEM_REQUIRED blocks sleep without requiring the display to stay on.
+    [DllImport("kernel32.dll")] static extern uint SetThreadExecutionState(uint esFlags);
+    const uint ES_CONTINUOUS      = 0x80000000;
+    const uint ES_SYSTEM_REQUIRED = 0x00000001;
+
+    NotifyIcon _tray;
+    ContextMenuStrip _menu;
+    System.Windows.Forms.Timer _menuTimer;
+    System.Windows.Forms.Timer _loadingAnimTimer;
+    Form _syncForm;
+    string _lastStatusOut = "";
+    int _loadingDotFrame;
+    readonly Dictionary<string, string> _pendingTitleStatus =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    const int WslQuickTimeoutMs = 15000;
+    const int WslLongTimeoutMs  = 600000;
+
+    static readonly Color ColorRunning = Color.FromArgb(30, 160, 60);
+    static readonly Color ColorStopped = Color.FromArgb(110, 110, 110);
+    static readonly Color ColorLoading = Color.FromArgb(200, 150, 0);
+
+    public TrayApp()
+    {
+        // Hidden form gives a stable UI thread marshal target (ApplicationContext alone can leave _uiSync null).
+        _syncForm = new Form();
+        _syncForm.FormBorderStyle = FormBorderStyle.None;
+        _syncForm.ShowInTaskbar   = false;
+        _syncForm.StartPosition   = FormStartPosition.Manual;
+        _syncForm.Size            = new Size(0, 0);
+        _syncForm.Opacity         = 0;
+        _syncForm.Show();
+
+        _tray = new NotifyIcon();
+        string icoPath = System.IO.Path.Combine(
+            System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location),
+            "dml.ico");
+        _tray.Icon = System.IO.File.Exists(icoPath) ? new Icon(icoPath) : SystemIcons.Application;
+        _tray.Text    = TrayTooltip(false);
+        _tray.Visible = true;
+
+        _menu = new ContextMenuStrip();
+        _menu.Closed += OnMenuClosed;
+        // Win11: show menu only on right-click (not ContextMenuStrip — avoids left-click open)
+        _tray.MouseUp += OnTrayMouseUp;
+
+        // Re-release if something woke WSL after an intentional stop (doctor, old tray poll).
+        MaybeReReleaseWsl();
+
+        // Check server state at startup so sleep is blocked immediately
+        // if a server is already running when the tray loads.
+        var startupTimer = new System.Windows.Forms.Timer { Interval = 3000 };
+        startupTimer.Tick += delegate {
+            startupTimer.Stop(); startupTimer.Dispose();
+            string[] r = { null };
+            var pollTimer = new System.Windows.Forms.Timer { Interval = 150 };
+            pollTimer.Tick += delegate {
+                if (r[0] == null) return;
+                pollTimer.Stop(); pollTimer.Dispose();
+                ApplyStatusResult(r[0]);
+            };
+            pollTimer.Start();
+            System.Threading.ThreadPool.QueueUserWorkItem(_ => {
+                try { r[0] = GetStatusOutput(); }
+                catch { r[0] = BuildStoppedStatusOutput(); }
+            });
+        };
+        startupTimer.Start();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            try { if (_syncForm != null) { _syncForm.Close(); _syncForm.Dispose(); } } catch { }
+        }
+        base.Dispose(disposing);
+    }
+
+    void PostToUi(Action action)
+    {
+        if (action == null) return;
+        try
+        {
+            if (_syncForm != null && !_syncForm.IsDisposed)
+            {
+                if (_syncForm.InvokeRequired)
+                    _syncForm.BeginInvoke(action);
+                else
+                    action();
+                return;
+            }
+        }
+        catch { }
+        try { action(); } catch { }
+    }
+
+    void DeferCloseMenu()
+    {
+        PostToUi(delegate {
+            try { if (_menu != null && _menu.Visible) _menu.Close(); } catch { }
+        });
+    }
+
+    // Blocks or releases Windows sleep based on how many servers are running.
+    void UpdateSleepLock(int runningCount)
+    {
+        if (runningCount > 0)
+        {
+            SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
+            _tray.Text = TrayTooltip(true);
+        }
+        else
+        {
+            SetThreadExecutionState(ES_CONTINUOUS);  // release
+            _tray.Text = TrayTooltip(false);
+        }
+    }
+
+    static int CountRunning(string statusOut)
+    {
+        int count = 0;
+        foreach (var line in statusOut.Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            int colon = line.Trim().IndexOf(':');
+            if (colon > 0 && line.Trim().Substring(colon + 1).Trim()
+                    .Equals("running", StringComparison.OrdinalIgnoreCase))
+                count++;
+        }
+        return count;
+    }
+
+    void OnTrayMouseUp(object sender, MouseEventArgs e)
+    {
+        if (e.Button != MouseButtons.Right) return;
+        try
+        {
+            if (_menu == null || _menu.IsDisposed) return;
+            if (_menu.Visible)
+            {
+                _menu.Close();
+                return;
+            }
+            try
+            {
+                PopulateMenu(_menu);
+            }
+            catch
+            {
+                _menu.Items.Clear();
+                var err = new ToolStripMenuItem("DML Launcher");
+                err.Enabled = false;
+                _menu.Items.Add(err);
+                _menu.Items.Add(new ToolStripSeparator());
+                AddStaticItems(_menu);
+            }
+            _menu.Show(Cursor.Position);
+        }
+        catch { }
+    }
+
+    void OnMenuClosed(object sender, ToolStripDropDownClosedEventArgs e)
+    {
+        if (_menuTimer != null)
+        {
+            _menuTimer.Stop();
+            _menuTimer.Dispose();
+            _menuTimer = null;
+        }
+        if (_loadingAnimTimer != null && _pendingTitleStatus.Count == 0)
+        {
+            _loadingAnimTimer.Stop();
+            _loadingAnimTimer.Dispose();
+            _loadingAnimTimer = null;
+        }
+    }
+
+    string LoadingDots()
+    {
+        int n = (_loadingDotFrame % 3) + 1;
+        return new string('.', n);
+    }
+
+    string FormatTitleText(string title, ServerDisplayState state)
+    {
+        switch (state)
+        {
+            case ServerDisplayState.Running:
+                return title + "  \u25cf Running";
+            case ServerDisplayState.Loading:
+                return title + "  \u25cc Loading" + LoadingDots();
+            default:
+                return title + "  \u25cb Stopped";
+        }
+    }
+
+    Color ColorForState(ServerDisplayState state)
+    {
+        switch (state)
+        {
+            case ServerDisplayState.Running: return ColorRunning;
+            case ServerDisplayState.Loading: return ColorLoading;
+            default: return ColorStopped;
+        }
+    }
+
+    ServerDisplayState GetDisplayState(string title, string reportedStatus)
+    {
+        string expected;
+        if (_pendingTitleStatus.TryGetValue(title, out expected))
+        {
+            if (!string.Equals(reportedStatus, expected, StringComparison.OrdinalIgnoreCase))
+                return ServerDisplayState.Loading;
+        }
+        return string.Equals(reportedStatus, "running", StringComparison.OrdinalIgnoreCase)
+            ? ServerDisplayState.Running : ServerDisplayState.Stopped;
+    }
+
+    void SyncPendingWithStatus(string statusOut)
+    {
+        var map = ParseStatusMap(statusOut);
+        var done = new System.Collections.Generic.List<string>();
+        foreach (var kv in _pendingTitleStatus)
+        {
+            string reported;
+            if (map.TryGetValue(kv.Key, out reported)
+                && string.Equals(reported, kv.Value, StringComparison.OrdinalIgnoreCase))
+                done.Add(kv.Key);
+        }
+        foreach (var t in done) _pendingTitleStatus.Remove(t);
+        if (_pendingTitleStatus.Count == 0 && _loadingAnimTimer != null)
+        {
+            _loadingAnimTimer.Stop();
+            _loadingAnimTimer.Dispose();
+            _loadingAnimTimer = null;
+        }
+    }
+
+    void MarkTitlePending(string title, string expectedStatus)
+    {
+        _pendingTitleStatus[title] = expectedStatus;
+        EnsureLoadingAnimTimer();
+    }
+
+    void MarkAllTitlesPending(string expectedStatus)
+    {
+        foreach (var line in _lastStatusOut.Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            string trimmed = line.Trim();
+            int colon = trimmed.IndexOf(':');
+            if (colon > 0)
+                _pendingTitleStatus[trimmed.Substring(0, colon)] = expectedStatus;
+        }
+        if (_pendingTitleStatus.Count == 0)
+        {
+            foreach (var t in LoadTitleCache())
+            {
+                string title = (t ?? "").Trim();
+                if (title.Length > 0) _pendingTitleStatus[title] = expectedStatus;
+            }
+        }
+        EnsureLoadingAnimTimer();
+    }
+
+    void EnsureLoadingAnimTimer()
+    {
+        if (_loadingAnimTimer != null) return;
+        _loadingAnimTimer = new System.Windows.Forms.Timer { Interval = 450 };
+        _loadingAnimTimer.Tick += delegate {
+            _loadingDotFrame++;
+            if (_menu != null && _menu.Visible && _pendingTitleStatus.Count > 0)
+                UpdateTitleRowsInOpenMenu(_lastStatusOut);
+        };
+        _loadingAnimTimer.Start();
+    }
+
+    void UpdateTitleRowsInOpenMenu(string statusOut)
+    {
+        if (_menu == null || _menu.IsDisposed || !_menu.Visible) return;
+        var statusMap = ParseStatusMap(statusOut);
+        PostToUi(delegate {
+            try
+            {
+                if (_menu == null || _menu.IsDisposed || !_menu.Visible) return;
+                foreach (ToolStripItem item in _menu.Items)
+                {
+                    string title = item.Tag as string;
+                    if (string.IsNullOrEmpty(title)) continue;
+                    string reported;
+                    if (!statusMap.TryGetValue(title, out reported)) reported = "stopped";
+                    var state = GetDisplayState(title, reported);
+                    item.Text = FormatTitleText(title, state);
+                    item.ForeColor = ColorForState(state);
+                }
+            }
+            catch { }
+        });
+    }
+
+    Dictionary<string, string> ParseStatusMap(string statusOut)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in statusOut.Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            string trimmed = line.Trim();
+            int colon = trimmed.IndexOf(':');
+            if (colon > 0)
+                map[trimmed.Substring(0, colon)] = trimmed.Substring(colon + 1).Trim();
+        }
+        return map;
+    }
+
+    void ApplyStatusResult(string statusOut)
+    {
+        _lastStatusOut = statusOut ?? "";
+        SyncPendingWithStatus(_lastStatusOut);
+        UpdateSleepLock(CountRunning(_lastStatusOut));
+        UpdateTitleRowsInOpenMenu(_lastStatusOut);
+    }
+
+    void PopulateMenu(ContextMenuStrip menu)
+    {
+        if (_menuTimer != null)
+        {
+            _menuTimer.Stop();
+            _menuTimer.Dispose();
+            _menuTimer = null;
+        }
+
+        menu.Items.Clear();
+
+        var header = new ToolStripMenuItem("DML Launcher v" + VERSION);
+        header.Enabled = false;
+        try { header.Font = new Font(SystemFonts.MenuFont, FontStyle.Bold); }
+        catch { }
+        menu.Items.Add(header);
+        menu.Items.Add(new ToolStripSeparator());
+
+        var placeholder = new ToolStripMenuItem("Checking servers...");
+        placeholder.Enabled = false;
+        placeholder.Tag = "placeholder";
+        menu.Items.Add(placeholder);
+
+        menu.Items.Add(new ToolStripSeparator());
+        AddStaticItems(menu);
+
+        string[] result = new string[1];
+
+        _menuTimer = new System.Windows.Forms.Timer();
+        _menuTimer.Interval = 150;
+        _menuTimer.Tick += delegate
+        {
+            if (result[0] == null) return;
+            _menuTimer.Stop();
+            _menuTimer.Dispose();
+            _menuTimer = null;
+            if (menu.IsDisposed) return;
+
+            int idx = -1;
+            for (int i = 0; i < menu.Items.Count; i++)
+                if ("placeholder".Equals(menu.Items[i].Tag as string)) { idx = i; break; }
+            if (idx < 0) return;
+
+            menu.Items.RemoveAt(idx);
+            ApplyStatusResult(result[0]);
+            var items = BuildTitleItems(result[0]);
+            for (int i = items.Count - 1; i >= 0; i--)
+                menu.Items.Insert(idx, items[i]);
+        };
+        _menuTimer.Start();
+
+        System.Threading.ThreadPool.QueueUserWorkItem(delegate
+        {
+            try { result[0] = GetStatusOutput(); }
+            catch { result[0] = BuildStoppedStatusOutput(); }
+        });
+    }
+
+    System.Collections.Generic.List<ToolStripItem> BuildTitleItems(string statusOut)
+    {
+        var items     = new System.Collections.Generic.List<ToolStripItem>();
+        var statusMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        int runningCount = 0;
+
+        foreach (var line in statusOut.Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            string trimmed = line.Trim();
+            int colon = trimmed.IndexOf(':');
+            if (colon > 0)
+                statusMap[trimmed.Substring(0, colon)] = trimmed.Substring(colon + 1);
+        }
+
+        if (statusMap.Count == 0)
+        {
+            var empty = new ToolStripMenuItem("No titles installed");
+            empty.Enabled = false;
+            items.Add(empty);
+            UpdateSleepLock(0);
+            return items;
+        }
+
+        foreach (var kv in statusMap)
+        {
+            string title   = kv.Key;
+            string reported = kv.Value;
+            var displayState = GetDisplayState(title, reported);
+            bool running = displayState == ServerDisplayState.Running;
+            bool loading = displayState == ServerDisplayState.Loading;
+            if (running) runningCount++;
+
+            var gameMenu = new ToolStripMenuItem(FormatTitleText(title, displayState));
+            gameMenu.Tag = title;
+            gameMenu.ForeColor = ColorForState(displayState);
+
+            var startItem   = new ToolStripMenuItem("Start");
+            var restartItem = new ToolStripMenuItem("Restart");
+            var stopItem    = new ToolStripMenuItem("Stop");
+            startItem.Enabled   = !running && !loading;
+            restartItem.Enabled =  running && !loading;
+            stopItem.Enabled    =  running && !loading;
+
+            string captured = title;
+            startItem.Click   += delegate { RunAndReport("start",   captured); };
+            restartItem.Click += delegate { RunAndReport("restart", captured); };
+            stopItem.Click    += delegate { RunAndReport("stop",    captured); };
+
+            gameMenu.DropDownItems.Add(startItem);
+            gameMenu.DropDownItems.Add(restartItem);
+            gameMenu.DropDownItems.Add(stopItem);
+            items.Add(gameMenu);
+        }
+
+        SaveTitleCache(statusMap.Keys);
+        UpdateSleepLock(runningCount);
+        return items;
+    }
+
+    void AddStaticItems(ContextMenuStrip menu)
+    {
+        var installItem = new ToolStripMenuItem("Install New Title...");
+        installItem.Click += delegate { ShowInstallDialog(); };
+        menu.Items.Add(installItem);
+
+        var shellItem = new ToolStripMenuItem("Open DML Shell");
+        shellItem.Click += delegate { OpenTerminal("-d " + DISTRO); };
+        menu.Items.Add(shellItem);
+
+        var doctorItem = new ToolStripMenuItem("Run DML Doctor");
+        doctorItem.Click += delegate
+        {
+            DeferCloseMenu();
+            SetTrayProgress("Running doctor...");
+            System.Threading.ThreadPool.QueueUserWorkItem(_ => {
+                try {
+                    string result = WslRun("dml doctor", WslLongTimeoutMs);
+                    MaybeReReleaseWsl();
+                    bool warn = result.Contains("[WARN]");
+                    PostToUi(delegate {
+                        RefreshTrayFromStatus();
+                        MessageBoxIcon icon = warn ? MessageBoxIcon.Warning : MessageBoxIcon.Information;
+                        MessageBox.Show(result, "DML Doctor", MessageBoxButtons.OK, icon);
+                    });
+                } catch (Exception ex) {
+                    PostToUi(delegate {
+                        MessageBox.Show("[error] " + ex.Message, "DML Doctor", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    });
+                }
+            });
+        };
+        menu.Items.Add(doctorItem);
+
+        menu.Items.Add(new ToolStripSeparator());
+
+        var minimizeItem = new ToolStripMenuItem("Minimize");
+        minimizeItem.Click += delegate { if (_menu != null && _menu.Visible) _menu.Close(); };
+        menu.Items.Add(minimizeItem);
+
+        var extrasMenu = new ToolStripMenuItem("Extras");
+        var restartActiveItem = new ToolStripMenuItem("Restart active server/s");
+        restartActiveItem.Click += delegate { RestartActiveServers(); };
+        extrasMenu.DropDownItems.Add(restartActiveItem);
+
+        var releaseItem = new ToolStripMenuItem("Stop WSL (release RAM)");
+        releaseItem.Click += delegate { ConfirmAndReleaseWsl(); };
+        extrasMenu.DropDownItems.Add(releaseItem);
+        menu.Items.Add(extrasMenu);
+
+        var exitItem = new ToolStripMenuItem("Exit");
+        exitItem.Click += delegate {
+            SetThreadExecutionState(ES_CONTINUOUS);  // always release before exit
+            _tray.Visible = false;
+            _tray.Dispose();
+            Application.Exit();
+        };
+        menu.Items.Add(exitItem);
+    }
+
+    void RestartActiveServers()
+    {
+        if (!IsDistroRunning())
+        {
+            MessageBox.Show(
+                "WSL is not running.\n\nUse Start on a title to boot the server first.",
+                "Restart active server/s", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        int running = 0;
+        try { running = CountRunning(WslRun("dml status")); } catch { }
+
+        if (running == 0)
+        {
+            MessageBox.Show(
+                "No active servers to restart.",
+                "Restart active server/s", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        string msg = running == 1
+            ? "Restart the 1 active server now?"
+            : "Restart all " + running + " active servers now?";
+
+        if (MessageBox.Show(msg, "Restart active server/s",
+                MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+            return;
+
+        DeferCloseMenu();
+        MarkAllTitlesPending("running");
+        SetTrayProgress("Restarting active server(s) — see console");
+        OpenLiveConsole("dml restart-active", "Restart active server/s");
+        StartStatusPolling(900);
+    }
+
+    void ConfirmAndReleaseWsl()
+    {
+        int running = 0;
+        try {
+            if (IsDistroRunning())
+                running = CountRunning(WslRun("dml status"));
+        } catch { }
+
+        string msg =
+            "This will stop any running game servers cleanly (docker compose down), "
+            + "then shut down WSL and return RAM to Windows.\n\n"
+            + "• Running titles are stopped with docker compose down\n"
+            + "• Docker and DML services are then stopped\n"
+            + "• Vmmem RAM should drop within a few seconds\n\n"
+            + "Use Start on a title when you want to play again.";
+
+        if (running > 0)
+            msg += "\n\n" + running + " server(s) will be stopped gracefully first.";
+
+        if (MessageBox.Show(msg, "Stop WSL", MessageBoxButtons.YesNo, MessageBoxIcon.Warning)
+                != DialogResult.Yes)
+            return;
+
+        try { System.IO.File.WriteAllText(StoppedMarkerPath, DateTime.Now.ToString("o")); }
+        catch { }
+
+        MarkAllTitlesPending("stopped");
+        UpdateSleepLock(0);
+        DeferCloseMenu();
+
+        if (IsDistroRunning())
+        {
+            SetTrayProgress("Stopping servers + releasing WSL...");
+            System.Threading.ThreadPool.QueueUserWorkItem(_ => {
+                try {
+                    string result = WslRun("dml release-wsl", WslLongTimeoutMs);
+                    bool warn = result.Contains("[WARN]") || result.ToLower().Contains("error");
+                    PostToUi(delegate {
+                        UpdateSleepLock(0);
+                        _tray.Text = TrayTooltip(false);
+                        MessageBoxIcon icon = warn ? MessageBoxIcon.Warning : MessageBoxIcon.Information;
+                        MessageBox.Show(result, "Stop WSL", MessageBoxButtons.OK, icon);
+                    });
+                } catch (Exception ex) {
+                    PostToUi(delegate {
+                        MessageBox.Show("[error] " + ex.Message, "Stop WSL", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    });
+                }
+            });
+        }
+        else
+        {
+            TriggerReleaseWsl(0);
+            MessageBox.Show(
+                "WSL is shutting down — RAM should free in a few seconds.\n"
+                + "Use Start when you want to bring the server back.",
+                "Stop WSL", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+    }
+
+    void TriggerReleaseWsl(int delaySeconds)
+    {
+        try
+        {
+            string ps1 = System.IO.Path.Combine(
+                System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location),
+                "DML-Release-WSL.ps1");
+            if (!System.IO.File.Exists(ps1)) return;
+            var psi = new ProcessStartInfo();
+            psi.FileName = "powershell.exe";
+            psi.Arguments = "-NoProfile -WindowStyle Hidden -File \"" + ps1 + "\" -DelaySeconds " + delaySeconds;
+            psi.UseShellExecute = false;
+            psi.CreateNoWindow = true;
+            psi.WindowStyle = ProcessWindowStyle.Hidden;
+            Process.Start(psi);
+        }
+        catch { }
+    }
+
+    void CloseMenuIfOpen()
+    {
+        try { if (_menu != null && _menu.Visible) _menu.Close(); } catch { }
+    }
+
+    void SetTrayProgress(string detail)
+    {
+        try { _tray.Text = "DML Launcher v" + VERSION + " — " + detail; } catch { }
+    }
+
+    void ShowTrayBalloon(string title, string text, ToolTipIcon icon)
+    {
+        try
+        {
+            _tray.BalloonTipTitle = title;
+            _tray.BalloonTipText  = TruncateForBalloon(text);
+            _tray.BalloonTipIcon  = icon;
+            _tray.ShowBalloonTip(5000);
+        }
+        catch { }
+    }
+
+    string TruncateForBalloon(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return "";
+        text = text.Trim();
+        return text.Length <= 240 ? text : text.Substring(0, 237) + "...";
+    }
+
+    void RefreshTrayFromStatus()
+    {
+        string[] r = { null };
+        var pollTimer = new System.Windows.Forms.Timer { Interval = 150 };
+        pollTimer.Tick += delegate {
+            if (r[0] == null) return;
+            pollTimer.Stop(); pollTimer.Dispose();
+            ApplyStatusResult(r[0]);
+        };
+        pollTimer.Start();
+        System.Threading.ThreadPool.QueueUserWorkItem(_ => {
+            try { r[0] = GetStatusOutput(); }
+            catch { r[0] = BuildStoppedStatusOutput(); }
+        });
+    }
+
+    void StartStatusPolling(int durationSeconds)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(durationSeconds);
+        var timer = new System.Windows.Forms.Timer { Interval = 3000 };
+        timer.Tick += delegate {
+            RefreshTrayFromStatus();
+            if (DateTime.UtcNow >= deadline) {
+                timer.Stop();
+                timer.Dispose();
+            }
+        };
+        timer.Start();
+        RefreshTrayFromStatus();
+    }
+
+    // Same terminal + dml-arch path as "Open DML Shell" (wt → cmd → PowerShell).
+    bool OpenShell(string wslArguments, string errorTitle)
+    {
+        try {
+            // wt.exe treats ';' as a command separator — use 'new-tab --' so the
+            // remainder is passed intact to wsl (live-console scripts use '&&' not ';').
+            var psi = new ProcessStartInfo("wt.exe", "new-tab -- wsl " + wslArguments);
+            psi.UseShellExecute = true;
+            Process.Start(psi);
+            return true;
+        }
+        catch { }
+        try {
+            var psi = new ProcessStartInfo("cmd.exe", "/k wsl " + wslArguments);
+            psi.UseShellExecute = true;
+            Process.Start(psi);
+            return true;
+        }
+        catch { }
+        try {
+            var psi = new ProcessStartInfo("powershell.exe",
+                "-NoExit -Command \"wsl " + wslArguments + "\"");
+            psi.UseShellExecute = true;
+            Process.Start(psi);
+            return true;
+        }
+        catch (Exception ex) {
+            MessageBox.Show("[error] Could not open console: " + ex.Message, errorTitle,
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return false;
+        }
+    }
+
+    void OpenLiveConsole(string wslInnerCmd, string windowTitle)
+    {
+        // wow-server-playerbots: dml-start/stop.sh handle shell + close prompt.
+        // Other commands: land in login bash when done.
+        string bashScript = wslInnerCmd;
+        if (wslInnerCmd.IndexOf("wow-server-playerbots", StringComparison.OrdinalIgnoreCase) < 0)
+            bashScript = wslInnerCmd + " && exec bash -l";
+        string wslArgs = "-d " + DISTRO + " -e bash -lic \"" + bashScript.Replace("\"", "\\\"") + "\"";
+        OpenShell(wslArgs, windowTitle);
+    }
+
+    void RunAndReport(string cmd, string title)
+    {
+        DeferCloseMenu();
+        string expected = (cmd == "stop") ? "stopped" : "running";
+        MarkTitlePending(title, expected);
+        try { System.IO.File.Delete(StoppedMarkerPath); } catch { }
+        string caption = (cmd == "start" ? "Start " : cmd == "restart" ? "Restart " : "Stop ") + title;
+        string verb = cmd == "start" ? "Starting" : cmd == "restart" ? "Restarting" : "Stopping";
+        SetTrayProgress(verb + " " + title + " — see console");
+        OpenLiveConsole("dml " + cmd + " " + title, caption);
+        StartStatusPolling(900);
+    }
+
+    string WslRun(string wslCmd)
+    {
+        return WslRun(wslCmd, WslQuickTimeoutMs);
+    }
+
+    string WslRun(string wslCmd, int timeoutMs)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo();
+            psi.FileName               = "wsl.exe";
+            psi.Arguments              = "-d " + DISTRO + " -- " + wslCmd;
+            psi.UseShellExecute        = false;
+            psi.RedirectStandardOutput = true;
+            psi.RedirectStandardError  = true;
+            psi.CreateNoWindow         = true;
+            psi.StandardOutputEncoding = Encoding.UTF8;
+            psi.StandardErrorEncoding  = Encoding.UTF8;
+            using (var p = Process.Start(psi))
+            {
+                var stdout = new System.Text.StringBuilder();
+                var stderr = new System.Text.StringBuilder();
+                p.OutputDataReceived += delegate(object s, DataReceivedEventArgs e) {
+                    if (e.Data != null) stdout.AppendLine(e.Data);
+                };
+                p.ErrorDataReceived += delegate(object s, DataReceivedEventArgs e) {
+                    if (e.Data != null) stderr.AppendLine(e.Data);
+                };
+                p.BeginOutputReadLine();
+                p.BeginErrorReadLine();
+                if (!p.WaitForExit(timeoutMs))
+                {
+                    string partial = stdout.ToString().Trim();
+                    if (string.IsNullOrEmpty(partial)) partial = stderr.ToString().Trim();
+                    if (!string.IsNullOrEmpty(partial)) partial += "\n";
+                    return partial + "[WARN] Still running — use Open DML Shell to monitor progress.";
+                }
+                p.WaitForExit();
+                string output = stdout.ToString().Trim();
+                if (string.IsNullOrEmpty(output)) output = stderr.ToString().Trim();
+                return output;
+            }
+        }
+        catch (Exception ex)
+        {
+            return "[error] Could not run WSL: " + ex.Message;
+        }
+    }
+
+    void OpenTerminal(string wslArgs)
+    {
+        OpenShell(wslArgs, "Open DML Shell");
+    }
+
+    void ShowInstallDialog()
+    {
+        using (var form = new Form())
+        {
+            form.Text            = "Install New DML Title";
+            form.Size            = new Size(520, 210);
+            form.StartPosition   = FormStartPosition.CenterScreen;
+            form.FormBorderStyle = FormBorderStyle.FixedDialog;
+            form.MaximizeBox     = false;
+            form.MinimizeBox     = false;
+
+            var lbl = new Label();
+            lbl.Text   = "GitHub URL, local .sh installer, or folder:";
+            lbl.Left   = 10; lbl.Top = 15; lbl.Width = 490; lbl.Height = 20;
+
+            var box = new TextBox();
+            box.Left = 10; box.Top = 42; box.Width = 380;
+
+            var btnBrowse = new Button();
+            btnBrowse.Text  = "Browse...";
+            btnBrowse.Left  = 398; btnBrowse.Top = 40;
+            btnBrowse.Width = 100;
+            btnBrowse.Click += delegate {
+                using (var ofd = new OpenFileDialog())
+                {
+                    ofd.Title       = "Select a DML installer script";
+                    ofd.Filter      = "Shell scripts (*.sh)|*.sh|All files (*.*)|*.*";
+                    ofd.FilterIndex = 1;
+                    if (ofd.ShowDialog() == DialogResult.OK)
+                        box.Text = ofd.FileName;
+                }
+            };
+
+            var btnOk = new Button();
+            btnOk.Text   = "Install"; btnOk.Left = 320; btnOk.Top = 100;
+            btnOk.Width  = 85; btnOk.DialogResult = DialogResult.OK;
+
+            var btnCancel = new Button();
+            btnCancel.Text   = "Cancel"; btnCancel.Left = 415; btnCancel.Top = 100;
+            btnCancel.Width  = 85; btnCancel.DialogResult = DialogResult.Cancel;
+
+            form.Controls.Add(lbl);
+            form.Controls.Add(box);
+            form.Controls.Add(btnBrowse);
+            form.Controls.Add(btnOk);
+            form.Controls.Add(btnCancel);
+            form.AcceptButton = btnOk;
+            form.CancelButton = btnCancel;
+
+            if (form.ShowDialog() == DialogResult.OK)
+            {
+                string input = box.Text.Trim();
+                if (string.IsNullOrEmpty(input)) return;
+                string wslPath = ToWslPath(input);
+                // .sh file -> run directly with bash; directory or URL -> dml run
+                string wslArgs = wslPath.EndsWith(".sh")
+                    ? "-d " + DISTRO + " -- bash \"" + wslPath + "\""
+                    : "-d " + DISTRO + " -- dml run \"" + wslPath + "\"";
+                OpenTerminal(wslArgs);
+            }
+        }
+    }
+
+    static string ToWslPath(string input)
+    {
+        // Convert C:\path\to\folder -> /mnt/c/path/to/folder
+        if (input.Length >= 3 && input[1] == ':' && (input[2] == '\\' || input[2] == '/'))
+            return "/mnt/" + input.Substring(0, 1).ToLower() + "/" + input.Substring(3).Replace('\\', '/');
+        return input;
+    }
+}
+

--- a/guides/DML-Windows/Install-DML.ps1
+++ b/guides/DML-Windows/Install-DML.ps1
@@ -40,7 +40,7 @@ if (-not $ScriptPath) { $ScriptPath = $PSCommandPath }
 $DiskNeededBytes = 30GB
 $DmlDistroName   = 'dml-arch'
 $DmlLinuxUser    = 'dml'
-$DmlCliVersion   = '2.1.0'   # bundled dml CLI + launcher tooltip (keep in sync)
+$DmlCliVersion   = '2.1.1'   # bundled dml CLI + launcher tooltip (keep in sync)
 $TaskName        = 'DadsMmoLab-Phase2'
 
 $Script:FailReported = $false
@@ -799,6 +799,194 @@ _compose_running() {
     { docker compose -f "$compose_file" ps --status running -q 2>/dev/null || true; } | wc -l | tr -d '[:space:]'
 }
 
+_title_lifecycle_busy() {
+    local compose_dir="${1%/}"
+    [[ -f "${compose_dir}/.dml-lifecycle-busy" ]] && return 0
+    pgrep -f "${compose_dir}/dml-start\\.sh" >/dev/null 2>&1 \
+        || pgrep -f "${compose_dir}/dml-stop\\.sh" >/dev/null 2>&1
+}
+
+_title_reported_status() {
+    local compose_dir="$1" count
+    if _title_lifecycle_busy "$compose_dir"; then
+        echo "loading"
+        return
+    fi
+    count=$(_compose_running "$compose_dir")
+    if [[ "$count" -gt 0 ]]; then echo "running"; else echo "stopped"; fi
+}
+
+_stop_title_graceful() {
+    local title="$1" dir="$GAMES_DIR/$title" compose_dir="$GAMES_DIR/$title"
+    if [[ ! -d "$dir" ]]; then
+        echo "[dml] ERROR: Title not found: $title" >&2
+        return 1
+    fi
+    if [[ -x "$dir/dml-stop.sh" ]]; then
+        bash "$dir/dml-stop.sh"
+        return
+    fi
+    if ! _has_compose "$dir"; then
+        for subdir in "$dir"*/; do
+            if [[ -d "$subdir" ]] && _has_compose "$subdir"; then
+                compose_dir="$subdir"; break
+            fi
+        done
+    fi
+    if ! _has_compose "$compose_dir"; then
+        echo "[dml] ERROR: No compose file found in $title or its subdirectories." >&2
+        return 1
+    fi
+    _require_docker
+    cd "$compose_dir" || return 1
+    echo "[dml] Stopping $title (containers only — data volumes are preserved)..."
+    docker compose down >"$compose_dir/.dml-stop.log" 2>&1 \
+        || { echo "[dml] ERROR: Stop failed — see $compose_dir/.dml-stop.log" >&2; return 1; }
+    echo "[dml] $title stopped — progress saved on disk"
+}
+
+_stop_all_running_titles() {
+    command -v docker &>/dev/null || { echo "[dml] Docker not available — skipping server stop"; return 0; }
+    if ! systemctl is-active --quiet docker 2>/dev/null; then
+        echo "[dml] Docker not running — no servers to stop"
+        return 0
+    fi
+
+    local -A _seen=()
+    local -a titles=()
+    local dir title compose_dir count subdir project
+
+    if [[ -d "$GAMES_DIR" ]]; then
+        for dir in "$GAMES_DIR"/*/; do
+            [[ -d "$dir" ]] || continue
+            title=$(basename "$dir")
+            compose_dir="$dir"
+            if ! _has_compose "$dir"; then
+                for subdir in "$dir"*/; do
+                    if [[ -d "$subdir" ]] && _has_compose "$subdir"; then
+                        compose_dir="$subdir"; break
+                    fi
+                done
+            fi
+            if _has_compose "$compose_dir"; then
+                count=$(_compose_running "$compose_dir")
+                if [[ "$count" -gt 0 ]]; then
+                    titles+=("$title")
+                    _seen["$title"]=1
+                fi
+            fi
+        done
+    fi
+
+    while IFS= read -r project; do
+        [[ -z "$project" ]] || [[ -n "${_seen[$project]:-}" ]] && continue
+        if docker ps -q --filter "label=com.docker.compose.project=$project" 2>/dev/null | grep -q .; then
+            titles+=("$project")
+            _seen["$project"]=1
+        fi
+    done < <(docker ps --format '{{index .Labels "com.docker.compose.project"}}' 2>/dev/null | sort -u | grep -v '^$')
+
+    if [[ ${#titles[@]} -eq 0 ]]; then
+        echo "[dml] No running game servers to stop"
+        return 0
+    fi
+
+    for title in "${titles[@]}"; do
+        compose_dir=""
+        if [[ -d "$GAMES_DIR/$title" ]]; then
+            compose_dir="$GAMES_DIR/$title"
+            if ! _has_compose "$compose_dir"; then
+                for subdir in "$GAMES_DIR/$title"*/; do
+                    if [[ -d "$subdir" ]] && _has_compose "$subdir"; then
+                        compose_dir="$subdir"; break
+                    fi
+                done
+            fi
+        fi
+        if [[ -n "$compose_dir" ]] && _has_compose "$compose_dir"; then
+            echo "[dml] Stopping $title..."
+            ( cd "$compose_dir" && docker compose down ) \
+                || echo "[WARN] Failed to stop $title" >&2
+            echo "[dml] $title stopped"
+        else
+            echo "[dml] Stopping compose project $title..."
+            docker compose -p "$title" down 2>/dev/null \
+                || echo "[WARN] Failed to stop project $title" >&2
+        fi
+    done
+    _update_titles_cache
+}
+
+_restart_all_running_titles() {
+    command -v docker &>/dev/null || { echo "[dml] Docker not available"; return 1; }
+    if ! systemctl is-active --quiet docker 2>/dev/null; then
+        echo "[dml] Docker not running — no servers to restart"
+        return 1
+    fi
+
+    local -A _seen=()
+    local -a titles=()
+    local dir title compose_dir count subdir project
+
+    if [[ -d "$GAMES_DIR" ]]; then
+        for dir in "$GAMES_DIR"/*/; do
+            [[ -d "$dir" ]] || continue
+            title=$(basename "$dir")
+            compose_dir="$dir"
+            if ! _has_compose "$dir"; then
+                for subdir in "$dir"*/; do
+                    if [[ -d "$subdir" ]] && _has_compose "$subdir"; then
+                        compose_dir="$subdir"; break
+                    fi
+                done
+            fi
+            if _has_compose "$compose_dir"; then
+                count=$(_compose_running "$compose_dir")
+                if [[ "$count" -gt 0 ]]; then
+                    titles+=("$title")
+                    _seen["$title"]=1
+                fi
+            fi
+        done
+    fi
+
+    while IFS= read -r project; do
+        [[ -z "$project" ]] || [[ -n "${_seen[$project]:-}" ]] && continue
+        if docker ps -q --filter "label=com.docker.compose.project=$project" 2>/dev/null | grep -q .; then
+            titles+=("$project")
+            _seen["$project"]=1
+        fi
+    done < <(docker ps --format '{{index .Labels "com.docker.compose.project"}}' 2>/dev/null | sort -u | grep -v '^$')
+
+    if [[ ${#titles[@]} -eq 0 ]]; then
+        echo "[dml] No active servers to restart"
+        return 1
+    fi
+
+    for title in "${titles[@]}"; do
+        compose_dir=""
+        if [[ -d "$GAMES_DIR/$title" ]]; then
+            compose_dir="$GAMES_DIR/$title"
+            if ! _has_compose "$compose_dir"; then
+                for subdir in "$GAMES_DIR/$title"*/; do
+                    if [[ -d "$subdir" ]] && _has_compose "$subdir"; then
+                        compose_dir="$subdir"; break
+                    fi
+                done
+            fi
+        fi
+        if [[ -n "$compose_dir" ]] && _has_compose "$compose_dir"; then
+            _start_title "$title" restart || echo "[WARN] Failed to restart $title" >&2
+        else
+            echo "[dml] Restarting compose project $title..."
+            docker compose -p "$title" down 2>/dev/null || true
+            docker compose -p "$title" up -d 2>/dev/null \
+                || echo "[WARN] Failed to restart project $title" >&2
+        fi
+    done
+    _update_titles_cache
+}
+
 # Windows-side helpers (paths written at install time)
 DML_WIN_ROOT='__DML_INSTALL_ROOT__'
 
@@ -1029,6 +1217,8 @@ case "$cmd" in
 
     if command -v powershell.exe &>/dev/null; then
         _doctor_section "Windows host + WSL"
+        win_root_mnt=$(_win_to_mnt "$DML_WIN_ROOT")
+        stopped_marker="$win_root_mnt/.dml-servers-stopped"
         # wsl.exe stdout is UTF-16 when piped; strip NULs before text tools
         wsl_ver=$(wsl.exe --version 2>&1 | tr -d '\0' | grep -i 'WSL version' | head -1 | sed 's/.*:[[:space:]]*//' | tr -d '\r' || true)
         if [[ -n "$wsl_ver" ]]; then
@@ -1062,8 +1252,12 @@ case "$cmd" in
                 warns=$((warns + 1))
             elif docker ps -q 2>/dev/null | grep -q .; then
                 echo "[ok]  Vmmem RAM: ${vmmem_mb} MB (servers running)"
+            elif [[ -f "$stopped_marker" ]] && (( vmmem_mb > 500 )); then
+                echo "[WARN] Vmmem ${vmmem_mb} MB after intentional stop -- WSL woke (doctor/tray) -- re-releasing RAM..."
+                warns=$((warns + 1))
+                _release_wsl
             elif (( vmmem_mb > 500 )); then
-                echo "[WARN] Vmmem ${vmmem_mb} MB with no containers -- Stop from tray to release RAM"
+                echo "[WARN] Vmmem ${vmmem_mb} MB with no containers -- tray: Stop WSL (release RAM), or: dml release-wsl"
                 warns=$((warns + 1))
             else
                 echo "[ok]  Vmmem RAM: ${vmmem_mb} MB"
@@ -1071,7 +1265,6 @@ case "$cmd" in
         fi
 
         _doctor_section "Windows DML install ($DML_WIN_ROOT)"
-        win_root_mnt=$(_win_to_mnt "$DML_WIN_ROOT")
         for script in WSL-Keepalive.ps1 DML-Ensure-Keepalive.ps1 DML-Release-WSL.ps1 DML-Launcher.exe dml-titles.cache; do
             if [[ -f "$win_root_mnt/$script" ]]; then
                 echo "[ok]  $script present"
@@ -1116,7 +1309,6 @@ case "$cmd" in
         else
             echo "[ok]  Windows keepalive off (no game servers running)"
         fi
-        stopped_marker="$win_root_mnt/.dml-servers-stopped"
         if [[ -f "$stopped_marker" ]] && docker ps -q 2>/dev/null | grep -q .; then
             echo "[WARN] .dml-servers-stopped marker exists but containers are running -- tray may show Stopped"
             warns=$((warns + 1))
@@ -1262,8 +1454,7 @@ case "$cmd" in
             done
         fi
         if _has_compose "$compose_dir"; then
-            count=$(_compose_running "$compose_dir")
-            if [[ "$count" -gt 0 ]]; then echo "running"; else echo "stopped"; fi
+            _title_reported_status "$compose_dir"
         else
             echo "stopped"
         fi
@@ -1274,8 +1465,7 @@ case "$cmd" in
             [[ -d "$dir" ]] || continue
             title=$(basename "$dir")
             if _has_compose "$dir"; then
-                count=$(_compose_running "$dir")
-                if [[ "$count" -gt 0 ]]; then echo "$title:running"; else echo "$title:stopped"; fi
+                echo "$title:$(_title_reported_status "$dir")"
                 _seen["$title"]=1
             else
                 # One level deeper -- catches repos with compose file in a subdirectory
@@ -1283,8 +1473,7 @@ case "$cmd" in
                     [[ -d "$subdir" ]] || continue
                     _has_compose "$subdir" || continue
                     [[ -n "${_seen[$title]:-}" ]] && continue
-                    count=$(_compose_running "$subdir")
-                    if [[ "$count" -gt 0 ]]; then echo "$title:running"; else echo "$title:stopped"; fi
+                    echo "$title:$(_title_reported_status "$subdir")"
                     _seen["$title"]=1
                     break
                 done
@@ -1310,31 +1499,37 @@ case "$cmd" in
     _start_title "$title" restart
     ;;
 
+  restart-active)
+    echo "[dml] Restarting active server(s)..."
+    _restart_all_running_titles || exit 1
+    ;;
+
   stop)
     title="${1:?Usage: dml stop <title>}"
-    dir="$GAMES_DIR/$title"
-    if [[ ! -d "$dir" ]]; then echo "[dml] ERROR: Title not found: $title" >&2; exit 1; fi
-    compose_dir="$dir"
-    if ! _has_compose "$dir"; then
-        for subdir in "$dir"*/; do
-            if [[ -d "$subdir" ]] && _has_compose "$subdir"; then
-                compose_dir="$subdir"; break
-            fi
-        done
+    if [[ -x "$GAMES_DIR/$title/dml-stop.sh" ]]; then
+      bash "$GAMES_DIR/$title/dml-stop.sh"
+    else
+      _stop_title_graceful "$title" || exit 1
+      running=$(docker ps -q 2>/dev/null | wc -l | tr -d '[:space:]')
+      if [[ "$running" -eq 0 ]]; then
+        echo "[dml] No servers running — releasing WSL memory to Windows..."
+        _release_wsl
+      fi
     fi
-    if ! _has_compose "$compose_dir"; then
-        echo "[dml] ERROR: No compose file found in $title or its subdirectories." >&2; exit 1
+    ;;
+
+  release-wsl)
+    echo "[dml] Stopping any running game servers cleanly..."
+    _stop_all_running_titles
+    remaining=$(docker ps -q 2>/dev/null | wc -l | tr -d '[:space:]')
+    if [[ "$remaining" -gt 0 ]]; then
+        echo "[WARN] $remaining container(s) still running — stopping..."
+        docker ps -q 2>/dev/null | xargs docker stop 2>/dev/null || true
     fi
-    _require_docker
-    cd "$compose_dir"
-    echo "[dml] Stopping $title..."
-    docker compose down
-    echo "[dml] $title stopped"
-    running=$(docker ps -q 2>/dev/null | wc -l | tr -d '[:space:]')
-    if [[ "$running" -eq 0 ]]; then
-      echo "[dml] No servers running — releasing WSL memory to Windows..."
-      _release_wsl
-    fi
+    echo "[dml] Shutting down WSL and returning RAM to Windows..."
+    _release_wsl
+    echo "[dml] Scheduled — Vmmem should drop in a few seconds."
+    echo "[dml] Use 'dml start <title>' when you want to play again."
     ;;
 
   scan)
@@ -1581,7 +1776,9 @@ case "$cmd" in
     echo "  status [<title>]      show running/stopped status (all titles if no arg)"
     echo "  start <title>         start a title's Docker server"
     echo "  restart <title>       restart a title (uses dml-start.sh if present)"
+    echo "  restart-active        restart all currently running titles"
     echo "  stop <title>          stop a title; releases WSL RAM if no servers left"
+    echo "  release-wsl           compose-down all titles, then shut down WSL (frees Vmmem RAM)"
     echo "  scan                  show all running containers and which game ports they hold"
     echo "  kill <name|--all>     force-stop by project name (no directory needed)"
     echo "  clean [--yes]         stop stuck containers, remove incomplete installs, prune Docker"
@@ -1676,8 +1873,7 @@ echo "[phase3] Done"
             $LauncherCs  = "$LauncherDir\DML-Launcher.cs"
             $LauncherExe = "$LauncherDir\DML-Launcher.exe"
 
-            $LauncherSource = @'
-// DML-Launcher.cs -- Dad's MMO Lab system tray launcher
+            $LauncherSource = @'// DML-Launcher.cs -- Dad's MMO Lab system tray launcher
 // Compiled at install time: csc.exe /target:winexe /r:System.Windows.Forms.dll /r:System.Drawing.dll
 
 using System;
@@ -1686,6 +1882,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Windows.Forms;
 
 class DmlLauncherEntry
@@ -1695,6 +1892,9 @@ class DmlLauncherEntry
     {
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
+        Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
+        Application.ThreadException += delegate(object s, ThreadExceptionEventArgs e) { };
+        SynchronizationContext.SetSynchronizationContext(new WindowsFormsSynchronizationContext());
         Application.Run(new TrayApp());
     }
 }
@@ -1702,7 +1902,9 @@ class DmlLauncherEntry
 class TrayApp : ApplicationContext
 {
     const string DISTRO   = "dml-arch";
-    const string VERSION  = "__DML_CLI_VERSION__";
+    const string VERSION  = "2.1.1";
+
+    enum ServerDisplayState { Stopped, Running, Loading }
 
     string TrayTooltip(bool serverActive)
     {
@@ -1717,6 +1919,34 @@ class TrayApp : ApplicationContext
                 System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location),
                 "dml-titles.cache");
         }
+    }
+
+    string StoppedMarkerPath {
+        get {
+            return System.IO.Path.Combine(
+                System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location),
+                ".dml-servers-stopped");
+        }
+    }
+
+    bool ServersIntentionallyStopped()
+    {
+        try { return System.IO.File.Exists(StoppedMarkerPath); }
+        catch { return false; }
+    }
+
+    // After stop, tray/doctor must not boot WSL for status — that leaves VmmemWSL ~2 GB idle.
+    string GetStatusOutput()
+    {
+        if (ServersIntentionallyStopped() || !IsDistroRunning())
+            return BuildStoppedStatusOutput();
+        return WslRun("dml status");
+    }
+
+    void MaybeReReleaseWsl()
+    {
+        if (ServersIntentionallyStopped() && IsDistroRunning())
+            TriggerReleaseWsl(0);
     }
 
     // True only when dml-arch is Running — wsl -l -v does NOT boot the distro.
@@ -1790,9 +2020,32 @@ class TrayApp : ApplicationContext
     const uint ES_SYSTEM_REQUIRED = 0x00000001;
 
     NotifyIcon _tray;
+    ContextMenuStrip _menu;
+    System.Windows.Forms.Timer _menuTimer;
+    System.Windows.Forms.Timer _loadingAnimTimer;
+    Form _syncForm;
+    string _lastStatusOut = "";
+    int _loadingDotFrame;
+    readonly Dictionary<string, string> _pendingTitleStatus =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    const int WslQuickTimeoutMs = 15000;
+    const int WslLongTimeoutMs  = 600000;
+
+    static readonly Color ColorRunning = Color.FromArgb(30, 160, 60);
+    static readonly Color ColorStopped = Color.FromArgb(110, 110, 110);
+    static readonly Color ColorLoading = Color.FromArgb(200, 150, 0);
 
     public TrayApp()
     {
+        // Hidden form gives a stable UI thread marshal target (ApplicationContext alone can leave _uiSync null).
+        _syncForm = new Form();
+        _syncForm.FormBorderStyle = FormBorderStyle.None;
+        _syncForm.ShowInTaskbar   = false;
+        _syncForm.StartPosition   = FormStartPosition.Manual;
+        _syncForm.Size            = new Size(0, 0);
+        _syncForm.Opacity         = 0;
+        _syncForm.Show();
+
         _tray = new NotifyIcon();
         string icoPath = System.IO.Path.Combine(
             System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location),
@@ -1801,9 +2054,13 @@ class TrayApp : ApplicationContext
         _tray.Text    = TrayTooltip(false);
         _tray.Visible = true;
 
-        var menu = new ContextMenuStrip();
-        menu.Opening += OnMenuOpening;
-        _tray.ContextMenuStrip = menu;
+        _menu = new ContextMenuStrip();
+        _menu.Closed += OnMenuClosed;
+        // Win11: show menu only on right-click (not ContextMenuStrip — avoids left-click open)
+        _tray.MouseUp += OnTrayMouseUp;
+
+        // Re-release if something woke WSL after an intentional stop (doctor, old tray poll).
+        MaybeReReleaseWsl();
 
         // Check server state at startup so sleep is blocked immediately
         // if a server is already running when the tray loads.
@@ -1815,16 +2072,49 @@ class TrayApp : ApplicationContext
             pollTimer.Tick += delegate {
                 if (r[0] == null) return;
                 pollTimer.Stop(); pollTimer.Dispose();
-                UpdateSleepLock(CountRunning(r[0]));
+                ApplyStatusResult(r[0]);
             };
             pollTimer.Start();
             System.Threading.ThreadPool.QueueUserWorkItem(_ => {
-                try {
-                    r[0] = IsDistroRunning() ? WslRun("dml status") : BuildStoppedStatusOutput();
-                } catch { r[0] = BuildStoppedStatusOutput(); }
+                try { r[0] = GetStatusOutput(); }
+                catch { r[0] = BuildStoppedStatusOutput(); }
             });
         };
         startupTimer.Start();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            try { if (_syncForm != null) { _syncForm.Close(); _syncForm.Dispose(); } } catch { }
+        }
+        base.Dispose(disposing);
+    }
+
+    void PostToUi(Action action)
+    {
+        if (action == null) return;
+        try
+        {
+            if (_syncForm != null && !_syncForm.IsDisposed)
+            {
+                if (_syncForm.InvokeRequired)
+                    _syncForm.BeginInvoke(action);
+                else
+                    action();
+                return;
+            }
+        }
+        catch { }
+        try { action(); } catch { }
+    }
+
+    void DeferCloseMenu()
+    {
+        PostToUi(delegate {
+            try { if (_menu != null && _menu.Visible) _menu.Close(); } catch { }
+        });
     }
 
     // Blocks or releases Windows sleep based on how many servers are running.
@@ -1848,25 +2138,225 @@ class TrayApp : ApplicationContext
         foreach (var line in statusOut.Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
         {
             int colon = line.Trim().IndexOf(':');
-            if (colon > 0 && line.Trim().Substring(colon + 1).Trim()
-                    .Equals("running", StringComparison.OrdinalIgnoreCase))
+            if (colon <= 0) continue;
+            string state = line.Trim().Substring(colon + 1).Trim();
+            if (state.Equals("running", StringComparison.OrdinalIgnoreCase)
+                || state.Equals("loading", StringComparison.OrdinalIgnoreCase))
                 count++;
         }
         return count;
     }
 
-    void OnMenuOpening(object sender, System.ComponentModel.CancelEventArgs e)
+    void OnTrayMouseUp(object sender, MouseEventArgs e)
     {
-        var menu = (ContextMenuStrip)sender;
+        if (e.Button != MouseButtons.Right) return;
+        try
+        {
+            if (_menu == null || _menu.IsDisposed) return;
+            if (_menu.Visible)
+            {
+                _menu.Close();
+                return;
+            }
+            try
+            {
+                PopulateMenu(_menu);
+            }
+            catch
+            {
+                _menu.Items.Clear();
+                var err = new ToolStripMenuItem("DML Launcher");
+                err.Enabled = false;
+                _menu.Items.Add(err);
+                _menu.Items.Add(new ToolStripSeparator());
+                AddStaticItems(_menu);
+            }
+            _menu.Show(Cursor.Position);
+        }
+        catch { }
+    }
+
+    void OnMenuClosed(object sender, ToolStripDropDownClosedEventArgs e)
+    {
+        if (_menuTimer != null)
+        {
+            _menuTimer.Stop();
+            _menuTimer.Dispose();
+            _menuTimer = null;
+        }
+        if (_loadingAnimTimer != null && _pendingTitleStatus.Count == 0)
+        {
+            _loadingAnimTimer.Stop();
+            _loadingAnimTimer.Dispose();
+            _loadingAnimTimer = null;
+        }
+    }
+
+    string LoadingDots()
+    {
+        int n = (_loadingDotFrame % 3) + 1;
+        return new string('.', n);
+    }
+
+    string FormatTitleText(string title, ServerDisplayState state)
+    {
+        switch (state)
+        {
+            case ServerDisplayState.Running:
+                return title + "  \u25cf Running";
+            case ServerDisplayState.Loading:
+                return title + "  \u25cc Loading" + LoadingDots();
+            default:
+                return title + "  \u25cb Stopped";
+        }
+    }
+
+    Color ColorForState(ServerDisplayState state)
+    {
+        switch (state)
+        {
+            case ServerDisplayState.Running: return ColorRunning;
+            case ServerDisplayState.Loading: return ColorLoading;
+            default: return ColorStopped;
+        }
+    }
+
+    ServerDisplayState GetDisplayState(string title, string reportedStatus)
+    {
+        if (string.Equals(reportedStatus, "loading", StringComparison.OrdinalIgnoreCase))
+            return ServerDisplayState.Loading;
+
+        string expected;
+        if (_pendingTitleStatus.TryGetValue(title, out expected))
+        {
+            if (!string.Equals(reportedStatus, expected, StringComparison.OrdinalIgnoreCase))
+                return ServerDisplayState.Loading;
+        }
+        return string.Equals(reportedStatus, "running", StringComparison.OrdinalIgnoreCase)
+            ? ServerDisplayState.Running : ServerDisplayState.Stopped;
+    }
+
+    void SyncPendingWithStatus(string statusOut)
+    {
+        var map = ParseStatusMap(statusOut);
+        var done = new System.Collections.Generic.List<string>();
+        foreach (var kv in _pendingTitleStatus)
+        {
+            string reported;
+            if (map.TryGetValue(kv.Key, out reported)
+                && string.Equals(reported, kv.Value, StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(reported, "loading", StringComparison.OrdinalIgnoreCase))
+                done.Add(kv.Key);
+        }
+        foreach (var t in done) _pendingTitleStatus.Remove(t);
+        if (_pendingTitleStatus.Count == 0 && _loadingAnimTimer != null)
+        {
+            _loadingAnimTimer.Stop();
+            _loadingAnimTimer.Dispose();
+            _loadingAnimTimer = null;
+        }
+    }
+
+    void MarkTitlePending(string title, string expectedStatus)
+    {
+        _pendingTitleStatus[title] = expectedStatus;
+        EnsureLoadingAnimTimer();
+    }
+
+    void MarkAllTitlesPending(string expectedStatus)
+    {
+        foreach (var line in _lastStatusOut.Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            string trimmed = line.Trim();
+            int colon = trimmed.IndexOf(':');
+            if (colon > 0)
+                _pendingTitleStatus[trimmed.Substring(0, colon)] = expectedStatus;
+        }
+        if (_pendingTitleStatus.Count == 0)
+        {
+            foreach (var t in LoadTitleCache())
+            {
+                string title = (t ?? "").Trim();
+                if (title.Length > 0) _pendingTitleStatus[title] = expectedStatus;
+            }
+        }
+        EnsureLoadingAnimTimer();
+    }
+
+    void EnsureLoadingAnimTimer()
+    {
+        if (_loadingAnimTimer != null) return;
+        _loadingAnimTimer = new System.Windows.Forms.Timer { Interval = 450 };
+        _loadingAnimTimer.Tick += delegate {
+            _loadingDotFrame++;
+            if (_menu != null && _menu.Visible && _pendingTitleStatus.Count > 0)
+                UpdateTitleRowsInOpenMenu(_lastStatusOut);
+        };
+        _loadingAnimTimer.Start();
+    }
+
+    void UpdateTitleRowsInOpenMenu(string statusOut)
+    {
+        if (_menu == null || _menu.IsDisposed || !_menu.Visible) return;
+        var statusMap = ParseStatusMap(statusOut);
+        PostToUi(delegate {
+            try
+            {
+                if (_menu == null || _menu.IsDisposed || !_menu.Visible) return;
+                foreach (ToolStripItem item in _menu.Items)
+                {
+                    string title = item.Tag as string;
+                    if (string.IsNullOrEmpty(title)) continue;
+                    string reported;
+                    if (!statusMap.TryGetValue(title, out reported)) reported = "stopped";
+                    var state = GetDisplayState(title, reported);
+                    item.Text = FormatTitleText(title, state);
+                    item.ForeColor = ColorForState(state);
+                }
+            }
+            catch { }
+        });
+    }
+
+    Dictionary<string, string> ParseStatusMap(string statusOut)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in statusOut.Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            string trimmed = line.Trim();
+            int colon = trimmed.IndexOf(':');
+            if (colon > 0)
+                map[trimmed.Substring(0, colon)] = trimmed.Substring(colon + 1).Trim();
+        }
+        return map;
+    }
+
+    void ApplyStatusResult(string statusOut)
+    {
+        _lastStatusOut = statusOut ?? "";
+        SyncPendingWithStatus(_lastStatusOut);
+        UpdateSleepLock(CountRunning(_lastStatusOut));
+        UpdateTitleRowsInOpenMenu(_lastStatusOut);
+    }
+
+    void PopulateMenu(ContextMenuStrip menu)
+    {
+        if (_menuTimer != null)
+        {
+            _menuTimer.Stop();
+            _menuTimer.Dispose();
+            _menuTimer = null;
+        }
+
         menu.Items.Clear();
 
         var header = new ToolStripMenuItem("DML Launcher v" + VERSION);
         header.Enabled = false;
-        header.Font = new Font(SystemFonts.MenuFont, FontStyle.Bold);
+        try { header.Font = new Font(SystemFonts.MenuFont, FontStyle.Bold); }
+        catch { }
         menu.Items.Add(header);
         menu.Items.Add(new ToolStripSeparator());
 
-        // Placeholder shown immediately — menu pops up with no delay
         var placeholder = new ToolStripMenuItem("Checking servers...");
         placeholder.Enabled = false;
         placeholder.Tag = "placeholder";
@@ -1875,17 +2365,16 @@ class TrayApp : ApplicationContext
         menu.Items.Add(new ToolStripSeparator());
         AddStaticItems(menu);
 
-        // Shared slot for background result
         string[] result = new string[1];
 
-        // Timer fires on the UI thread — no Invoke/handle needed
-        var timer = new System.Windows.Forms.Timer();
-        timer.Interval = 150;
-        timer.Tick += delegate
+        _menuTimer = new System.Windows.Forms.Timer();
+        _menuTimer.Interval = 150;
+        _menuTimer.Tick += delegate
         {
-            if (result[0] == null) return;   // not ready yet
-            timer.Stop();
-            timer.Dispose();
+            if (result[0] == null) return;
+            _menuTimer.Stop();
+            _menuTimer.Dispose();
+            _menuTimer = null;
             if (menu.IsDisposed) return;
 
             int idx = -1;
@@ -1894,24 +2383,17 @@ class TrayApp : ApplicationContext
             if (idx < 0) return;
 
             menu.Items.RemoveAt(idx);
+            ApplyStatusResult(result[0]);
             var items = BuildTitleItems(result[0]);
             for (int i = items.Count - 1; i >= 0; i--)
                 menu.Items.Insert(idx, items[i]);
         };
+        _menuTimer.Start();
 
-        // Clean up timer if the menu closes before the result arrives
-        menu.Closed += delegate { timer.Stop(); timer.Dispose(); };
-
-        timer.Start();
-
-        // Background thread — do NOT boot WSL just to check status (that auto-starts Docker).
         System.Threading.ThreadPool.QueueUserWorkItem(delegate
         {
-            try {
-                result[0] = IsDistroRunning() ? WslRun("dml status") : BuildStoppedStatusOutput();
-            } catch {
-                result[0] = BuildStoppedStatusOutput();
-            }
+            try { result[0] = GetStatusOutput(); }
+            catch { result[0] = BuildStoppedStatusOutput(); }
         });
     }
 
@@ -1941,21 +2423,22 @@ class TrayApp : ApplicationContext
         foreach (var kv in statusMap)
         {
             string title   = kv.Key;
-            bool   running = string.Equals(kv.Value, "running", StringComparison.OrdinalIgnoreCase);
+            string reported = kv.Value;
+            var displayState = GetDisplayState(title, reported);
+            bool running = displayState == ServerDisplayState.Running;
+            bool loading = displayState == ServerDisplayState.Loading;
             if (running) runningCount++;
 
-            var gameMenu  = new ToolStripMenuItem(title);
-            var statusLbl = new ToolStripMenuItem(running ? "● Running" : "○ Stopped");
-            statusLbl.Enabled = false;
-            gameMenu.DropDownItems.Add(statusLbl);
-            gameMenu.DropDownItems.Add(new ToolStripSeparator());
+            var gameMenu = new ToolStripMenuItem(FormatTitleText(title, displayState));
+            gameMenu.Tag = title;
+            gameMenu.ForeColor = ColorForState(displayState);
 
             var startItem   = new ToolStripMenuItem("Start");
             var restartItem = new ToolStripMenuItem("Restart");
             var stopItem    = new ToolStripMenuItem("Stop");
-            startItem.Enabled   = !running;
-            restartItem.Enabled =  running;
-            stopItem.Enabled    =  running;
+            startItem.Enabled   = !running && !loading;
+            restartItem.Enabled =  running && !loading;
+            stopItem.Enabled    =  running && !loading;
 
             string captured = title;
             startItem.Click   += delegate { RunAndReport("start",   captured); };
@@ -1983,16 +2466,45 @@ class TrayApp : ApplicationContext
         shellItem.Click += delegate { OpenTerminal("-d " + DISTRO); };
         menu.Items.Add(shellItem);
 
-        var doctorItem = new ToolStripMenuItem("Run dml doctor");
+        var doctorItem = new ToolStripMenuItem("Run DML Doctor");
         doctorItem.Click += delegate
         {
-            string result = WslRun("dml doctor");
-            MessageBoxIcon icon = result.Contains("[WARN]") ? MessageBoxIcon.Warning : MessageBoxIcon.Information;
-            MessageBox.Show(result, "DML Doctor", MessageBoxButtons.OK, icon);
+            DeferCloseMenu();
+            SetTrayProgress("Running doctor...");
+            System.Threading.ThreadPool.QueueUserWorkItem(_ => {
+                try {
+                    string result = WslRun("dml doctor", WslLongTimeoutMs);
+                    MaybeReReleaseWsl();
+                    bool warn = result.Contains("[WARN]");
+                    PostToUi(delegate {
+                        RefreshTrayFromStatus();
+                        MessageBoxIcon icon = warn ? MessageBoxIcon.Warning : MessageBoxIcon.Information;
+                        MessageBox.Show(result, "DML Doctor", MessageBoxButtons.OK, icon);
+                    });
+                } catch (Exception ex) {
+                    PostToUi(delegate {
+                        MessageBox.Show("[error] " + ex.Message, "DML Doctor", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    });
+                }
+            });
         };
         menu.Items.Add(doctorItem);
 
         menu.Items.Add(new ToolStripSeparator());
+
+        var minimizeItem = new ToolStripMenuItem("Minimize");
+        minimizeItem.Click += delegate { if (_menu != null && _menu.Visible) _menu.Close(); };
+        menu.Items.Add(minimizeItem);
+
+        var extrasMenu = new ToolStripMenuItem("Extras");
+        var restartActiveItem = new ToolStripMenuItem("Restart active server/s");
+        restartActiveItem.Click += delegate { RestartActiveServers(); };
+        extrasMenu.DropDownItems.Add(restartActiveItem);
+
+        var releaseItem = new ToolStripMenuItem("Stop WSL (release RAM)");
+        releaseItem.Click += delegate { ConfirmAndReleaseWsl(); };
+        extrasMenu.DropDownItems.Add(releaseItem);
+        menu.Items.Add(extrasMenu);
 
         var exitItem = new ToolStripMenuItem("Exit");
         exitItem.Click += delegate {
@@ -2004,7 +2516,103 @@ class TrayApp : ApplicationContext
         menu.Items.Add(exitItem);
     }
 
-    void TriggerReleaseWsl()
+    void RestartActiveServers()
+    {
+        if (!IsDistroRunning())
+        {
+            MessageBox.Show(
+                "WSL is not running.\n\nUse Start on a title to boot the server first.",
+                "Restart active server/s", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        int running = 0;
+        try { running = CountRunning(WslRun("dml status")); } catch { }
+
+        if (running == 0)
+        {
+            MessageBox.Show(
+                "No active servers to restart.",
+                "Restart active server/s", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        string msg = running == 1
+            ? "Restart the 1 active server now?"
+            : "Restart all " + running + " active servers now?";
+
+        if (MessageBox.Show(msg, "Restart active server/s",
+                MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+            return;
+
+        DeferCloseMenu();
+        MarkAllTitlesPending("running");
+        SetTrayProgress("Restarting active server(s) — see console");
+        OpenLiveConsole("dml restart-active", "Restart active server/s");
+        StartStatusPolling(900);
+    }
+
+    void ConfirmAndReleaseWsl()
+    {
+        int running = 0;
+        try {
+            if (IsDistroRunning())
+                running = CountRunning(WslRun("dml status"));
+        } catch { }
+
+        string msg =
+            "This will stop any running game servers cleanly (docker compose down), "
+            + "then shut down WSL and return RAM to Windows.\n\n"
+            + "• Running titles are stopped with docker compose down\n"
+            + "• Docker and DML services are then stopped\n"
+            + "• Vmmem RAM should drop within a few seconds\n\n"
+            + "Use Start on a title when you want to play again.";
+
+        if (running > 0)
+            msg += "\n\n" + running + " server(s) will be stopped gracefully first.";
+
+        if (MessageBox.Show(msg, "Stop WSL", MessageBoxButtons.YesNo, MessageBoxIcon.Warning)
+                != DialogResult.Yes)
+            return;
+
+        try { System.IO.File.WriteAllText(StoppedMarkerPath, DateTime.Now.ToString("o")); }
+        catch { }
+
+        MarkAllTitlesPending("stopped");
+        UpdateSleepLock(0);
+        DeferCloseMenu();
+
+        if (IsDistroRunning())
+        {
+            SetTrayProgress("Stopping servers + releasing WSL...");
+            System.Threading.ThreadPool.QueueUserWorkItem(_ => {
+                try {
+                    string result = WslRun("dml release-wsl", WslLongTimeoutMs);
+                    bool warn = result.Contains("[WARN]") || result.ToLower().Contains("error");
+                    PostToUi(delegate {
+                        UpdateSleepLock(0);
+                        _tray.Text = TrayTooltip(false);
+                        MessageBoxIcon icon = warn ? MessageBoxIcon.Warning : MessageBoxIcon.Information;
+                        MessageBox.Show(result, "Stop WSL", MessageBoxButtons.OK, icon);
+                    });
+                } catch (Exception ex) {
+                    PostToUi(delegate {
+                        MessageBox.Show("[error] " + ex.Message, "Stop WSL", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    });
+                }
+            });
+        }
+        else
+        {
+            TriggerReleaseWsl(0);
+            MessageBox.Show(
+                "WSL is shutting down — RAM should free in a few seconds.\n"
+                + "Use Start when you want to bring the server back.",
+                "Stop WSL", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+    }
+
+    void TriggerReleaseWsl(int delaySeconds)
     {
         try
         {
@@ -2014,7 +2622,7 @@ class TrayApp : ApplicationContext
             if (!System.IO.File.Exists(ps1)) return;
             var psi = new ProcessStartInfo();
             psi.FileName = "powershell.exe";
-            psi.Arguments = "-NoProfile -WindowStyle Hidden -File \"" + ps1 + "\"";
+            psi.Arguments = "-NoProfile -WindowStyle Hidden -File \"" + ps1 + "\" -DelaySeconds " + delaySeconds;
             psi.UseShellExecute = false;
             psi.CreateNoWindow = true;
             psi.WindowStyle = ProcessWindowStyle.Hidden;
@@ -2023,35 +2631,129 @@ class TrayApp : ApplicationContext
         catch { }
     }
 
-    void RunAndReport(string cmd, string title)
+    void CloseMenuIfOpen()
     {
-        string result  = WslRun("dml " + cmd + " " + title);
-        string caption = (cmd == "start" ? "Start " : cmd == "restart" ? "Restart " : "Stop ") + title;
-        MessageBoxIcon icon = (result.Contains("[error]") || result.ToLower().Contains("error"))
-            ? MessageBoxIcon.Warning : MessageBoxIcon.Information;
-        MessageBox.Show(result, caption, MessageBoxButtons.OK, icon);
+        try { if (_menu != null && _menu.Visible) _menu.Close(); } catch { }
+    }
 
-        if (cmd == "stop" && result.IndexOf("releasing WSL", StringComparison.OrdinalIgnoreCase) >= 0)
-            TriggerReleaseWsl();
+    void SetTrayProgress(string detail)
+    {
+        try { _tray.Text = "DML Launcher v" + VERSION + " — " + detail; } catch { }
+    }
 
-        // Re-check server state after start/stop so the sleep lock updates
-        // without requiring the user to reopen the menu.
+    void ShowTrayBalloon(string title, string text, ToolTipIcon icon)
+    {
+        try
+        {
+            _tray.BalloonTipTitle = title;
+            _tray.BalloonTipText  = TruncateForBalloon(text);
+            _tray.BalloonTipIcon  = icon;
+            _tray.ShowBalloonTip(5000);
+        }
+        catch { }
+    }
+
+    string TruncateForBalloon(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return "";
+        text = text.Trim();
+        return text.Length <= 240 ? text : text.Substring(0, 237) + "...";
+    }
+
+    void RefreshTrayFromStatus()
+    {
         string[] r = { null };
         var pollTimer = new System.Windows.Forms.Timer { Interval = 150 };
         pollTimer.Tick += delegate {
             if (r[0] == null) return;
             pollTimer.Stop(); pollTimer.Dispose();
-            UpdateSleepLock(CountRunning(r[0]));
+            ApplyStatusResult(r[0]);
         };
         pollTimer.Start();
         System.Threading.ThreadPool.QueueUserWorkItem(_ => {
-            try {
-                r[0] = IsDistroRunning() ? WslRun("dml status") : BuildStoppedStatusOutput();
-            } catch { r[0] = BuildStoppedStatusOutput(); }
+            try { r[0] = GetStatusOutput(); }
+            catch { r[0] = BuildStoppedStatusOutput(); }
         });
     }
 
+    void StartStatusPolling(int durationSeconds)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(durationSeconds);
+        var timer = new System.Windows.Forms.Timer { Interval = 3000 };
+        timer.Tick += delegate {
+            RefreshTrayFromStatus();
+            if (DateTime.UtcNow >= deadline) {
+                timer.Stop();
+                timer.Dispose();
+            }
+        };
+        timer.Start();
+        RefreshTrayFromStatus();
+    }
+
+    // Same terminal + dml-arch path as "Open DML Shell" (wt → cmd → PowerShell).
+    bool OpenShell(string wslArguments, string errorTitle)
+    {
+        try {
+            // wt.exe treats ';' as a command separator — use 'new-tab --' so the
+            // remainder is passed intact to wsl (live-console scripts use '&&' not ';').
+            var psi = new ProcessStartInfo("wt.exe", "new-tab -- wsl " + wslArguments);
+            psi.UseShellExecute = true;
+            Process.Start(psi);
+            return true;
+        }
+        catch { }
+        try {
+            var psi = new ProcessStartInfo("cmd.exe", "/k wsl " + wslArguments);
+            psi.UseShellExecute = true;
+            Process.Start(psi);
+            return true;
+        }
+        catch { }
+        try {
+            var psi = new ProcessStartInfo("powershell.exe",
+                "-NoExit -Command \"wsl " + wslArguments + "\"");
+            psi.UseShellExecute = true;
+            Process.Start(psi);
+            return true;
+        }
+        catch (Exception ex) {
+            MessageBox.Show("[error] Could not open console: " + ex.Message, errorTitle,
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return false;
+        }
+    }
+
+    void OpenLiveConsole(string wslInnerCmd, string windowTitle)
+    {
+        // wow-server-playerbots: dml-start/stop.sh handle shell + close prompt.
+        // Other commands: land in login bash when done.
+        string bashScript = wslInnerCmd;
+        if (wslInnerCmd.IndexOf("wow-server-playerbots", StringComparison.OrdinalIgnoreCase) < 0)
+            bashScript = wslInnerCmd + " && exec bash -l";
+        string wslArgs = "-d " + DISTRO + " -e bash -lic \"" + bashScript.Replace("\"", "\\\"") + "\"";
+        OpenShell(wslArgs, windowTitle);
+    }
+
+    void RunAndReport(string cmd, string title)
+    {
+        DeferCloseMenu();
+        string expected = (cmd == "stop") ? "stopped" : "running";
+        MarkTitlePending(title, expected);
+        try { System.IO.File.Delete(StoppedMarkerPath); } catch { }
+        string caption = (cmd == "start" ? "Start " : cmd == "restart" ? "Restart " : "Stop ") + title;
+        string verb = cmd == "start" ? "Starting" : cmd == "restart" ? "Restarting" : "Stopping";
+        SetTrayProgress(verb + " " + title + " — see console");
+        OpenLiveConsole("dml " + cmd + " " + title, caption);
+        StartStatusPolling(900);
+    }
+
     string WslRun(string wslCmd)
+    {
+        return WslRun(wslCmd, WslQuickTimeoutMs);
+    }
+
+    string WslRun(string wslCmd, int timeoutMs)
     {
         try
         {
@@ -2063,11 +2765,30 @@ class TrayApp : ApplicationContext
             psi.RedirectStandardError  = true;
             psi.CreateNoWindow         = true;
             psi.StandardOutputEncoding = Encoding.UTF8;
+            psi.StandardErrorEncoding  = Encoding.UTF8;
             using (var p = Process.Start(psi))
             {
-                string output = p.StandardOutput.ReadToEnd();
-                p.WaitForExit(15000);
-                return output.Trim();
+                var stdout = new System.Text.StringBuilder();
+                var stderr = new System.Text.StringBuilder();
+                p.OutputDataReceived += delegate(object s, DataReceivedEventArgs e) {
+                    if (e.Data != null) stdout.AppendLine(e.Data);
+                };
+                p.ErrorDataReceived += delegate(object s, DataReceivedEventArgs e) {
+                    if (e.Data != null) stderr.AppendLine(e.Data);
+                };
+                p.BeginOutputReadLine();
+                p.BeginErrorReadLine();
+                if (!p.WaitForExit(timeoutMs))
+                {
+                    string partial = stdout.ToString().Trim();
+                    if (string.IsNullOrEmpty(partial)) partial = stderr.ToString().Trim();
+                    if (!string.IsNullOrEmpty(partial)) partial += "\n";
+                    return partial + "[WARN] Still running — use Open DML Shell to monitor progress.";
+                }
+                p.WaitForExit();
+                string output = stdout.ToString().Trim();
+                if (string.IsNullOrEmpty(output)) output = stderr.ToString().Trim();
+                return output;
             }
         }
         catch (Exception ex)
@@ -2078,23 +2799,7 @@ class TrayApp : ApplicationContext
 
     void OpenTerminal(string wslArgs)
     {
-        try
-        {
-            var psi = new ProcessStartInfo("wt.exe", "wsl " + wslArgs);
-            psi.UseShellExecute = true;
-            Process.Start(psi);
-        }
-        catch
-        {
-            try
-            {
-                var psi = new ProcessStartInfo("powershell.exe",
-                    "-NoExit -Command \"wsl " + wslArgs + "\"");
-                psi.UseShellExecute = true;
-                Process.Start(psi);
-            }
-            catch { }
-        }
+        OpenShell(wslArgs, "Open DML Shell");
     }
 
     void ShowInstallDialog()

--- a/guides/wow-wotlk/dml-docker-entrypoint.sh
+++ b/guides/wow-wotlk/dml-docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# DML quiet entrypoint — same as AzerothCore entrypoint.sh but without cp -n portability warnings.
+set -euo pipefail
+
+CONF_DIR="${CONF_DIR:-/azerothcore/env/dist/etc}"
+LOGS_DIR="${LOGS_DIR:-/azerothcore/env/dist/logs}"
+
+if ! touch "$CONF_DIR/.write-test" 2>/dev/null || ! touch "$LOGS_DIR/.write-test" 2>/dev/null; then
+  cat <<EOF
+===== WARNING =====
+The current user doesn't have write permissions for
+the configuration dir ($CONF_DIR) or logs dir ($LOGS_DIR).
+It's likely that services will fail due to this.
+====================
+EOF
+fi
+
+[[ -f "$CONF_DIR/.write-test" ]] && rm -f "$CONF_DIR/.write-test"
+[[ -f "$LOGS_DIR/.write-test" ]] && rm -f "$LOGS_DIR/.write-test"
+
+if compgen -G "/azerothcore/env/ref/etc/*" >/dev/null; then
+  cp -ru --update=none /azerothcore/env/ref/etc/* "$CONF_DIR" 2>/dev/null \
+    || cp -ru /azerothcore/env/ref/etc/* "$CONF_DIR" 2>/dev/null \
+    || true
+fi
+
+CONF="$CONF_DIR/$ACORE_COMPONENT.conf"
+CONF_DIST="$CONF_DIR/$ACORE_COMPONENT.conf.dist"
+
+if [[ -f "$CONF_DIST" ]]; then
+  cp --update=none "$CONF_DIST" "$CONF" 2>/dev/null \
+    || cp -n "$CONF_DIST" "$CONF" 2>/dev/null \
+    || true
+else
+  touch "$CONF"
+fi
+
+echo "Starting $ACORE_COMPONENT..."
+
+exec "$@"

--- a/guides/wow-wotlk/dml-start.sh
+++ b/guides/wow-wotlk/dml-start.sh
@@ -12,6 +12,12 @@ DB_CONTAINER="${DML_DB_CONTAINER:-ac-database}"
 AUTH_CONTAINER="${DML_AUTH_CONTAINER:-ac-authserver}"
 WORLD_CONTAINER="${DML_WORLD_CONTAINER:-ac-worldserver}"
 DB_PASSWORD="${DOCKER_DB_ROOT_PASSWORD:-password}"
+COMPOSE_PROJECT="$(basename "$SERVER_DIR")"
+DB_VOLUME="${COMPOSE_PROJECT}_ac-database"
+DML_QUIET_COMPOSE="docker-compose.dml-quiet.yml"
+DML_ENTRYPOINT="dml-docker-entrypoint.sh"
+DML_QUIET_MARKER=".dml-quiet-applied"
+DML_BUSY_MARKER=".dml-lifecycle-busy"
 
 if [[ -f .env ]]; then
   # shellcheck disable=SC1091
@@ -20,6 +26,87 @@ if [[ -f .env ]]; then
 fi
 
 _log() { echo "[dml] $*"; }
+
+_log_ok() {
+  if [[ -t 1 ]]; then
+    echo -e "\033[32m[dml] $*\033[0m"
+  else
+    _log "$*"
+  fi
+}
+
+_log_tail_pid=""
+
+_stop_log_tail() {
+  if [[ -n "${_log_tail_pid:-}" ]] && kill -0 "$_log_tail_pid" 2>/dev/null; then
+    kill "$_log_tail_pid" 2>/dev/null || true
+    wait "$_log_tail_pid" 2>/dev/null || true
+  fi
+  _log_tail_pid=""
+}
+
+_dml_compose() {
+  local args=(-f docker-compose.yml)
+  [[ -f docker-compose.override.yml ]] && args+=(-f docker-compose.override.yml)
+  [[ -f "$DML_QUIET_COMPOSE" ]] && args+=(-f "$DML_QUIET_COMPOSE")
+  docker compose "${args[@]}" "$@"
+}
+
+_has_persisted_data() {
+  docker volume inspect "$DB_VOLUME" &>/dev/null
+}
+
+_ensure_quiet_startup() {
+  local bundled ep="$SERVER_DIR/$DML_ENTRYPOINT" qc="$SERVER_DIR/$DML_QUIET_COMPOSE"
+  bundled="$(dirname "${BASH_SOURCE[0]}")/$DML_ENTRYPOINT"
+
+  if [[ -f "$bundled" ]]; then
+    if [[ "$bundled" -ef "$ep" ]]; then
+      chmod +x "$ep"
+    else
+      cp "$bundled" "$ep"
+      chmod +x "$ep"
+    fi
+  fi
+
+  if [[ ! -f "$qc" ]]; then
+    cat > "$qc" << 'EOF'
+# DML overlay — quiet startup (no cp -n warnings). Merged by dml-start.sh.
+services:
+  ac-worldserver:
+    entrypoint: ["/bin/bash", "/azerothcore/dml-docker-entrypoint.sh"]
+    command: ["worldserver"]
+    volumes:
+      - ./dml-docker-entrypoint.sh:/azerothcore/dml-docker-entrypoint.sh:ro
+    environment:
+      AC_PROCESS_PRIORITY: "0"
+  ac-authserver:
+    entrypoint: ["/bin/bash", "/azerothcore/dml-docker-entrypoint.sh"]
+    command: ["authserver"]
+    volumes:
+      - ./dml-docker-entrypoint.sh:/azerothcore/dml-docker-entrypoint.sh:ro
+    environment:
+      AC_PROCESS_PRIORITY: "0"
+EOF
+  fi
+
+  local ws_conf="env/dist/etc/worldserver.conf"
+  if [[ -f "$ws_conf" ]] && grep -q '^ProcessPriority = 1' "$ws_conf"; then
+    sed -i 's/^ProcessPriority = 1/ProcessPriority = 0/' "$ws_conf"
+  fi
+
+  if [[ ! -f "$DML_QUIET_MARKER" && -f "$qc" && -f "$ep" ]]; then
+    touch "$DML_QUIET_MARKER"
+    export DML_QUIET_MIGRATE=1
+  fi
+}
+
+_filter_world_logs() {
+  grep --line-buffered -v -E \
+    '^cp: warning: behavior of -n is non-portable' \
+    | grep --line-buffered -v -E \
+    "Can't set process priority class|MoveSplineInitArgs::Validate|WaypointMovementGenerator::DoInitialize"
+}
 
 _ensure_playerbots_conf() {
   local conf="env/dist/etc/modules/playerbots.conf"
@@ -50,39 +137,135 @@ _wait_db_healthy() {
   return 1
 }
 
-_wait_ready() {
+_is_ready() {
+  local ok=1
+  docker ps --format '{{.Names}}' | grep -qx "$AUTH_CONTAINER" \
+    && docker ps --format '{{.Names}}' | grep -qx "$WORLD_CONTAINER" || return 1
+  set +o pipefail
+  docker logs "$AUTH_CONTAINER" 2>&1 | grep -m1 -q "${REALM_ADDRESS}:8085" \
+    && docker logs "$WORLD_CONTAINER" 2>&1 | grep -m1 -q 'ready\.\.\.' && ok=0
+  set -o pipefail
+  [[ "$ok" -eq 0 ]]
+}
+
+_start_world_log_tail() {
   local i
-  for i in $(seq 1 240); do
-    if docker ps --format '{{.Names}}' | grep -qx "$AUTH_CONTAINER" \
-       && docker ps --format '{{.Names}}' | grep -qx "$WORLD_CONTAINER"; then
-      if docker logs "$AUTH_CONTAINER" 2>&1 | grep -q "${REALM_ADDRESS}:8085"; then
-        if docker logs "$WORLD_CONTAINER" 2>&1 | grep -q 'ready\.\.\.'; then
-          return 0
-        fi
-      fi
+  for i in $(seq 1 30); do
+    if docker ps -a --format '{{.Names}}' | grep -qx "$WORLD_CONTAINER"; then
+      docker logs -f "$WORLD_CONTAINER" 2>&1 | _filter_world_logs &
+      _log_tail_pid=$!
+      return 0
     fi
-    sleep 2
+    sleep 1
   done
   return 1
 }
 
+_bots_are_done() {
+  local line cur total
+  set +o pipefail
+  if docker logs --tail 50 "$WORLD_CONTAINER" 2>&1 | grep -q 'Random Bots Stats:'; then
+    set -o pipefail
+    return 0
+  fi
+  line=$(docker logs --tail 20 "$WORLD_CONTAINER" 2>&1 \
+    | grep -E '[0-9]+/[0-9]+ Bot .+ logged in' | tail -1 || true)
+  set -o pipefail
+  if [[ "$line" =~ ^([0-9]+)/([0-9]+)\ Bot ]]; then
+    cur="${BASH_REMATCH[1]}"
+    total="${BASH_REMATCH[2]}"
+    [[ "$cur" == "$total" && "$total" -gt 0 ]]
+    return
+  fi
+  return 1
+}
+
+_wait_bots_populated() {
+  local i
+  _log "AzerothCore is ready — streaming playerbot logins until complete..."
+  for i in $(seq 1 300); do
+    if _bots_are_done; then
+      return 0
+    fi
+    sleep 2
+  done
+  _log "WARN: Timed out waiting for all bots — server is still playable"
+  return 0
+}
+
+_close_prompt() {
+  local ans
+  echo ""
+  if [[ -t 0 ]]; then
+    read -r -p "[dml] Close this window? [y/N]: " ans
+    case "${ans,,}" in
+      y|yes)
+        _log "Closing — server keeps running in the background."
+        exit 0
+        ;;
+    esac
+  fi
+  _log "Keeping window open — type 'exit' when you are done."
+  exec bash -l
+}
+
+_wait_ready() {
+  local i core_ok=0
+
+  if _has_persisted_data; then
+    _log "Waiting for AzerothCore ready (following worldserver logs; data volumes preserved)..."
+  else
+    _log "Waiting for AzerothCore ready (first boot — following worldserver logs; can take several minutes)..."
+  fi
+
+  _start_world_log_tail || _log "WARN: worldserver container not found yet — polling without live logs"
+
+  for i in $(seq 1 240); do
+    if _is_ready; then
+      core_ok=1
+      break
+    fi
+    sleep 2
+  done
+
+  if [[ "$core_ok" -ne 1 ]]; then
+    _stop_log_tail
+    return 1
+  fi
+
+  _wait_bots_populated
+  _stop_log_tail
+  return 0
+}
+
 _start_auth_world() {
-  # Use docker start (not compose up) so we do NOT re-trigger ac-db-import
-  # or ac-client-data-init on every restart — that was killing the database.
   if docker ps -a --format '{{.Names}}' | grep -qx "$AUTH_CONTAINER" \
      && docker ps -a --format '{{.Names}}' | grep -qx "$WORLD_CONTAINER"; then
     docker start "$DB_CONTAINER" 2>/dev/null || true
     _wait_db_healthy || { echo "[dml] ERROR: Database not healthy" >&2; exit 1; }
     _pin_realm_local
-    _log "Starting auth + world (direct)..."
-    docker start "$AUTH_CONTAINER" "$WORLD_CONTAINER"
+    if [[ -n "${DML_QUIET_MIGRATE:-}" ]]; then
+      _log "Refreshing auth + world for quiet startup (one-time)..."
+      _dml_compose up -d --force-recreate --no-deps "$AUTH_CONTAINER" "$WORLD_CONTAINER"
+    else
+      _log "Starting auth + world (direct)..."
+      docker start "$AUTH_CONTAINER" "$WORLD_CONTAINER"
+    fi
   else
-    _log "First boot — running docker compose up..."
-    docker compose up -d "$AUTH_CONTAINER" "$WORLD_CONTAINER"
+    if _has_persisted_data; then
+      _log "Recreating auth + world containers (compose up; database and client data preserved)..."
+    else
+      _log "First boot — running docker compose up..."
+    fi
+    _dml_compose up -d "$AUTH_CONTAINER" "$WORLD_CONTAINER"
   fi
 }
 
+_ensure_quiet_startup
 _ensure_playerbots_conf
+
+touch "$DML_BUSY_MARKER"
+trap 'rm -f "$DML_BUSY_MARKER"' EXIT
 
 if [[ "$MODE" == "restart" ]]; then
   _log "Restarting WoW server (staged)..."
@@ -96,8 +279,12 @@ if ! docker ps --format '{{.Names}}' | grep -qx "$DB_CONTAINER"; then
     _log "Starting existing database container..."
     docker start "$DB_CONTAINER"
   else
-    _log "Bringing up database (first install)..."
-    docker compose up -d "$DB_CONTAINER"
+    if _has_persisted_data; then
+      _log "Recreating database container (existing data volume preserved)..."
+    else
+      _log "Bringing up database (first install)..."
+    fi
+    _dml_compose up -d "$DB_CONTAINER"
   fi
 fi
 
@@ -109,13 +296,13 @@ fi
 
 _start_auth_world
 
-_log "Waiting for AzerothCore (playerbots first boot can take several minutes)..."
 if _wait_ready; then
-  _log "wow-server-playerbots is ready"
-  _log "Realm: AzerothCore at ${REALM_ADDRESS}:8085"
-  _log "Login: admin / admin"
+  echo ""
+  _log_ok "wow-server-playerbots is ready"
+  _log_ok "Realm: AzerothCore at ${REALM_ADDRESS}:8085"
+  _log_ok "Login: admin / admin"
   docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' | grep -E 'NAMES|ac-'
-  exit 0
+  _close_prompt
 fi
 
 echo "[dml] WARN: Timed out waiting for ready — server may still be starting" >&2

--- a/guides/wow-wotlk/dml-stop.sh
+++ b/guides/wow-wotlk/dml-stop.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Dad's MMO Lab — friendly stop for AzerothCore + Playerbots
+# Called by: dml stop wow-server-playerbots
+set -euo pipefail
+
+SERVER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SERVER_DIR"
+
+COMPOSE_PROJECT="$(basename "$SERVER_DIR")"
+DB_VOLUME="${COMPOSE_PROJECT}_ac-database"
+DML_QUIET_COMPOSE="docker-compose.dml-quiet.yml"
+DML_WIN_ROOT="${DML_WIN_ROOT:-/mnt/c/DML}"
+DML_BUSY_MARKER=".dml-lifecycle-busy"
+
+_log() { echo "[dml] $*"; }
+
+_log_ok() {
+  if [[ -t 1 ]]; then
+    echo -e "\033[32m[dml] $*\033[0m"
+  else
+    _log "$*"
+  fi
+}
+
+_dml_compose() {
+  local args=(-f docker-compose.yml)
+  [[ -f docker-compose.override.yml ]] && args+=(-f docker-compose.override.yml)
+  [[ -f "$DML_QUIET_COMPOSE" ]] && args+=(-f "$DML_QUIET_COMPOSE")
+  docker compose "${args[@]}" "$@"
+}
+
+_has_persisted_data() {
+  docker volume inspect "$DB_VOLUME" &>/dev/null
+}
+
+_release_wsl_windows() {
+  command -v powershell.exe &>/dev/null || return 0
+  local ps1="${DML_WIN_ROOT}/DML-Release-WSL.ps1"
+  local win_ps1="${ps1//\//\\}"
+  [[ -f "$ps1" ]] || return 0
+  powershell.exe -NoProfile -WindowStyle Hidden -Command \
+    "Start-Process -FilePath 'powershell.exe' -ArgumentList @('-NoProfile','-WindowStyle','Hidden','-File','${win_ps1}') -WindowStyle Hidden" \
+    2>/dev/null || true
+}
+
+_close_prompt() {
+  local ans release=0
+  echo ""
+  if [[ -t 0 ]]; then
+    read -r -p "[dml] Close this window? [y/N]: " ans
+    case "${ans,,}" in
+      y|yes) release=1 ;;
+    esac
+  fi
+
+  if [[ "$release" -eq 1 ]]; then
+    if [[ "$(docker ps -q 2>/dev/null | wc -l | tr -d '[:space:]')" -eq 0 ]]; then
+      _log "Releasing WSL memory to Windows..."
+      _release_wsl_windows
+    fi
+    _log "Closing — your server data is saved. Use Start when you want to play again."
+    exit 0
+  fi
+
+  _log "Keeping window open — server is stopped; data is on disk. Type 'exit' when done."
+  exec bash -l
+}
+
+touch "$DML_BUSY_MARKER"
+trap 'rm -f "$DML_BUSY_MARKER"' EXIT
+
+_log "Stopping wow-server-playerbots..."
+_log "This stops running containers only — your database, characters, and bot progress stay saved on disk."
+
+if _has_persisted_data; then
+  _log "Found existing data volume (${DB_VOLUME}) — nothing is being deleted."
+else
+  _log "No data volume yet (fresh install)."
+fi
+
+_log "Shutting down containers quietly..."
+if ! _dml_compose down >"$SERVER_DIR/.dml-stop.log" 2>&1; then
+  echo "[dml] ERROR: Stop failed — see $SERVER_DIR/.dml-stop.log" >&2
+  tail -20 "$SERVER_DIR/.dml-stop.log" >&2 || true
+  exit 1
+fi
+
+echo ""
+_log_ok "wow-server-playerbots stopped"
+_log_ok "All progress preserved — database and client data remain in Docker volumes"
+_log_ok "Next Start will bring everything back (no re-import needed)"
+
+_close_prompt

--- a/guides/wow-wotlk/docker-compose.dml-quiet.yml
+++ b/guides/wow-wotlk/docker-compose.dml-quiet.yml
@@ -1,0 +1,16 @@
+# DML overlay — quiet startup (no cp -n warnings). Merged by dml-start.sh / dml CLI.
+services:
+  ac-worldserver:
+    entrypoint: ["/bin/bash", "/azerothcore/dml-docker-entrypoint.sh"]
+    command: ["worldserver"]
+    volumes:
+      - ./dml-docker-entrypoint.sh:/azerothcore/dml-docker-entrypoint.sh:ro
+    environment:
+      AC_PROCESS_PRIORITY: "0"
+  ac-authserver:
+    entrypoint: ["/bin/bash", "/azerothcore/dml-docker-entrypoint.sh"]
+    command: ["authserver"]
+    volumes:
+      - ./dml-docker-entrypoint.sh:/azerothcore/dml-docker-entrypoint.sh:ro
+    environment:
+      AC_PROCESS_PRIORITY: "0"

--- a/guides/wow-wotlk/install-wow-wotlk.sh
+++ b/guides/wow-wotlk/install-wow-wotlk.sh
@@ -327,23 +327,32 @@ show_summary() {
 install_dml_start_hook() {
     print_info "Installing DML staged start/restart hook..."
 
-    local src dest="$SERVER_DIR/dml-start.sh"
-    src="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dml-start.sh"
+    local hook_dir dest file src
+    hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local ok=1
 
-    if [ -f "$src" ]; then
-        cp "$src" "$dest"
-    elif curl -fsSL \
-        "https://raw.githubusercontent.com/DadsMmoLab/dads-mmo-lab/main/guides/wow-wotlk/dml-start.sh" \
-        -o "$dest"; then
-        :
-    else
-        print_warning "Could not install dml-start.sh"
-        print_info "Restarts via 'dml restart' may re-import the DB until this file is present."
+    for file in dml-start.sh dml-stop.sh dml-docker-entrypoint.sh docker-compose.dml-quiet.yml; do
+        src="$hook_dir/$file"
+        dest="$SERVER_DIR/$file"
+        if [ -f "$src" ]; then
+            cp "$src" "$dest"
+            [[ "$file" == *.sh ]] && chmod +x "$dest"
+        elif [ "$file" = "dml-start.sh" ] && curl -fsSL \
+            "https://raw.githubusercontent.com/DadsMmoLab/dads-mmo-lab/main/guides/wow-wotlk/$file" \
+            -o "$dest"; then
+            chmod +x "$dest"
+        else
+            ok=0
+        fi
+    done
+
+    if [ "$ok" -eq 0 ]; then
+        print_warning "Could not install full DML start hook bundle"
+        print_info "Restarts via 'dml restart' may re-import the DB until dml-start.sh is present."
         return 1
     fi
 
-    chmod +x "$dest"
-    print_success "DML restart hook installed: $dest"
+    print_success "DML restart hook installed: $SERVER_DIR/dml-start.sh"
     print_info "On DML Windows: dml restart wow-server-playerbots"
 }
 
@@ -429,7 +438,10 @@ services:
       AC_AI_PLAYERBOT_RANDOM_BOT_AUTOLOGIN: "1"
       AC_AI_PLAYERBOT_MIN_RANDOM_BOTS: "1600"
       AC_AI_PLAYERBOT_MAX_RANDOM_BOTS: "2000"
+      AC_PROCESS_PRIORITY: "0"
   ac-authserver:
+    environment:
+      AC_PROCESS_PRIORITY: "0"
     build:
       context: .
       target: authserver


### PR DESCRIPTION
## Summary

Fixes DML Launcher on **Windows 11** and improves **WSL RAM management** after stopping servers. Rebased on `main` after **#48** — keeps version tooltip (`v2.1.0`), `dml doctor`, and idle fixes.

**1 file · 1 commit:** `guides/DML-Windows/Install-DML.ps1`

---

## Problems fixed

1. **Tray menu broken on Win11** — right-click did nothing; timer/handler leak broke menu over time
2. **VmmemWSL ~2 GB after stop** — tray and doctor woke WSL after intentional stop, leaving RAM allocated with no containers
3. **No escape hatch** — no way to force a clean WSL shutdown when RAM stuck
4. **No bulk restart** — restarting multiple running titles required doing each one individually

---

## Tray menu

### Per title
- **Start** · **Restart** · **Stop**

### Top level
- Install New Title…
- Open DML Shell
- Run DML Doctor
- Minimize
- **Extras** ▶
  - **Restart active server/s** — restarts all running titles (same as per-title Restart; with 1 active server it's identical)
  - **Stop WSL (release RAM)** — `compose down` all running titles, then `wsl --shutdown`
- Exit

### Other
- Right-click only (left-click does nothing)
- Hover tooltip: `DML Launcher v2.1.0`

---

## WSL RAM release

- Tray honors `.dml-servers-stopped` — won't boot WSL just to check status
- Auto re-releases RAM on launcher start or after doctor if WSL woke stale
- `dml doctor` detects high Vmmem after intentional stop and schedules release
- **Stop WSL** runs `docker compose down` on all running titles before shutting down WSL

---

## New CLI commands

| Command | What it does |
|---------|--------------|
| `dml restart-active` | Restart all currently running titles |
| `dml release-wsl` | Gracefully stop all titles, then release WSL RAM |

---

## How to test

1. Re-run `Install-DML.ps1` or update `C:\DML\` + recompile launcher
2. Right-click tray → menu opens; left-click → nothing
3. Start a title → Stop → VmmemWSL drops within ~5s
4. Run DML Doctor → should not leave Vmmem ~2 GB idle
5. Extras → Stop WSL → confirm → RAM freed; Start boots clean
6. Extras → Restart active server/s → all running titles restart
7. Per-title Restart still works for a single server

---

## Scope

Launcher tray app + `dml` CLI helpers only. Builds on merged **#48**. No WoW gameplay changes.