### PR TITLE
fix(DML-Windows): missing BOM breaks Install-DML.ps1 on PowerShell 5.1

### DIFF
--- a/guides/DML-Windows/HOWTO-WINDOWS-WSL2.md
+++ b/guides/DML-Windows/HOWTO-WINDOWS-WSL2.md
@@ -284,9 +284,7 @@ You are ready for the next step!
 
 ## 👤 PART 4 — Your Account (WoW)
 
-The installer automatically creates an **admin / admin** account with GM Level 3. You can use that to log in immediately — no extra setup required.
-
-To create additional accounts, open the GM console:
+The installer does **not** create any account for you — you create your own the first time you start the server. Open the GM console:
 
 ```bash
 docker attach $(docker ps --format '{{.Names}}' | grep -i "worldserver\|mangosd" | head -1)

--- a/guides/DML-Windows/Install-DML.ps1
+++ b/guides/DML-Windows/Install-DML.ps1
@@ -1,4 +1,4 @@
-#Requires -RunAsAdministrator
+﻿#Requires -RunAsAdministrator
 <#
 .SYNOPSIS
     Dad's MMO Lab -- Windows Substrate Installer

--- a/guides/wow-wotlk/dml-start.sh
+++ b/guides/wow-wotlk/dml-start.sh
@@ -113,7 +113,9 @@ _log "Waiting for AzerothCore (playerbots first boot can take several minutes)..
 if _wait_ready; then
   _log "wow-server-playerbots is ready"
   _log "Realm: AzerothCore at ${REALM_ADDRESS}:8085"
-  _log "Login: admin / admin"
+  _log "No account yet? Attach to the worldserver console and run:"
+  _log "  account create USERNAME PASSWORD"
+  _log "  account set gmlevel USERNAME 3 -1   (for GM/admin access)"
   docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' | grep -E 'NAMES|ac-'
   exit 0
 fi


### PR DESCRIPTION
## Summary
- `main`'s `Install-DML.ps1` (current, post PR #48) has no UTF-8 BOM. Classic Windows PowerShell 5.1 -- still the Windows default -- falls back to the system ANSI codepage without one, corrupting every em-dash used in the file's log messages and cascading into parse errors.
- PR #52 fixed a separate issue (a stray ``).`n`` sequence -- closing paren, period, then a backtick-n newline escape -- in a handful of messages), but didn't address this. Different root cause, same symptom class.
- Also fixes two copies of an already-diagnosed-elsewhere bug that PR #48 brought in independently: `dml-start.sh` and the Windows/WSL2 howto both claimed the installer creates a default `admin / admin` account. It doesn't -- account creation is a manual, one-time step via the worldserver console (`account create` / `account set gmlevel`). Both now point at the real steps instead.
- This same fix is already present independently on the open v2.2 launcher-tray PR (#51), via its own earlier commits -- confirmed both branches carry it.

## Why a missing BOM breaks this
A script file is just bytes -- something has to decide which text encoding those bytes represent. Windows PowerShell 5.1 (.NET Framework) determines this by sniffing for a byte-order-mark at the start of the file: BOM present -> use the encoding it signals (UTF-8, UTF-16, etc.); BOM absent -> fall back to the system's legacy ANSI codepage instead of assuming UTF-8. PowerShell 7 (.NET) made UTF-8-without-BOM the default instead, which is why PS 7 was never affected by this.

This file has UTF-8 multi-byte characters in it -- the em-dashes (`—`) used throughout its log messages are 3 bytes each (`E2 80 94`) in UTF-8. Read under the wrong single-byte codepage, each of those 3 bytes gets decoded as a separate, unrelated character instead of one em-dash. In at least one spot, that corruption happens to land inside a quoted string in a way that makes the tokenizer lose track of where the string actually ends -- it starts consuming subsequent lines looking for a closing quote it no longer recognizes, and by the time it stumbles onto a stray quote character deep in unrelated code, everything from there on gets misparsed as PowerShell syntax instead of string content. That's the mechanism behind the 200+ cascading errors from what's really a single 3-byte character being misread.

Adding the UTF-8 BOM (3 bytes, `EF BB BF`, prepended before `#Requires`) is the explicit signal PS 5.1's file-loading logic checks for. With it present, PS 5.1 decodes the file as UTF-8 correctly and the ambiguity is gone -- there's nothing left to misread.

## Why the Install-DML.ps1 diff looks empty
Since the BOM is those 3 invisible bytes and nothing else, GitHub's diff viewer renders no visible text change on that line -- it still counts as "1 addition, 1 deletion" (the line's bytes changed) even though nothing appears different to read. That's expected and correct for this fix, not a mistake. Confirm the bytes are there with:
```
git show <commit>:guides/DML-Windows/Install-DML.ps1 | head -c 10 | xxd
```
which should show `ef bb bf 23 52 65 71 75 69 72` (BOM followed by `#Requir`).

## Verification
Ran the actual PS 5.1 and PS 7 parsers (`[System.Management.Automation.Language.Parser]::ParseFile`) against `main`'s current file before/after:
- Before: 209 errors (PS 5.1) / 0 errors (PS 7)
- After: 0 errors on both

## Scope
This is intentionally minimal and separate from the still-open v2.2 launcher-tray PR (#51) -- just the BOM plus the two false-claim corrections, verified against `main` as it exists today.

## Test plan
- [ ] Run Install-DML.ps1 with classic powershell.exe (5.1) and confirm it parses/starts
- [ ] Run with pwsh.exe (7) and confirm it parses/starts