### PR TITLE
fix(vanilla): escape $$ in compose healthcheck heredoc

### DIFF
--- a/guides/wow-vanilla/install-wow-vanilla.sh
+++ b/guides/wow-vanilla/install-wow-vanilla.sh
@@ -1111,7 +1111,7 @@ services:
     networks:
       - vanilla-net
     healthcheck:
-      test: ["CMD-SHELL", "MYSQL_PWD=$$MARIADB_ROOT_PASSWORD mariadb -u root -e 'SELECT 1'"]
+      test: ["CMD-SHELL", "MYSQL_PWD=\$\$MARIADB_ROOT_PASSWORD mariadb -u root -e 'SELECT 1'"]
       interval: 10s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
## Summary

Fixes the vanilla installer hanging ~5 min then dying with `dependency failed to start: container vanilla-db is unhealthy`.

The `compose.yml` heredoc in `install-wow-vanilla.sh` is unquoted (`<< EOF`), so `$$MARIADB_ROOT_PASSWORD` in the db healthcheck gets bash-expanded to the shell's PID **before docker compose ever sees it** — the generated file literally contains `MYSQL_PWD=2798MARIADB_ROOT_PASSWORD` (PID varies per run).

The DB healthcheck then connects with a garbage password, MariaDB logs `Access denied for user 'root'@'localhost'` every 10s, the container never reports `healthy`, and `depends_on: service_healthy` blocks `realmd`/`mangosd` — the installer times out after ~5 min and exits with the unhealthy-dependency error.

## Fix

Escaping the dollar signs (`\$\$`) makes the heredoc emit a literal `$$` into `compose.yml`, which docker compose correctly renders as `$MARIADB_ROOT_PASSWORD` for the container's shell to expand at runtime. The other heredoc variables (`${DB_PASSWORD}`, `${SERVER_IMAGE}`) keep interpolating as before — the heredoc must NOT be fully quoted (`<< 'EOF'`) or those break.

## Verification

- Simulated the exact heredoc with a local bash run: output line is now `MYSQL_PWD=$$MARIADB_ROOT_PASSWORD` (literal), while `${DB_PASSWORD}` and `${SERVER_IMAGE}` still interpolate
- Applied the equivalent fix to a running install: db container passes healthcheck (`healthy`), realmd + mangosd start, world boots to `Avg Diff:` (the ready signal)
- This bug is platform-independent — it bites on Steam Deck too, not just WSL2/Windows