### PR TITLE
Fix healthcheck command syntax in install script

### DIFF
--- a/guides/wow-vanilla/install-wow-vanilla.sh
+++ b/guides/wow-vanilla/install-wow-vanilla.sh
@@ -1111,7 +1111,7 @@ services:
     networks:
       - vanilla-net
     healthcheck:
-      test: ["CMD-SHELL", "MYSQL_PWD=$$MARIADB_ROOT_PASSWORD mariadb -u root -e 'SELECT 1'"]
+      test: ["CMD-SHELL", "MYSQL_PWD=\$\$MARIADB_ROOT_PASSWORD mariadb -u root -e 'SELECT 1'"]
       interval: 10s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
The bash generation for `compose.yml` uses `$$MARIADB_ROOT_PASSWORD`. In bash, `$$` evaluates to the script's PID, resulting in a malformed healthcheck string like `MYSQL_PWD=109454MARIADB_ROOT_PASSWORD` written to the file.

Escaping both dollar signs to `\$\$MARIADB_ROOT_PASSWORD` ensures the literal `$$` is written to `compose.yml`, allowing Docker Compose to correctly pass the environment variable into the container's `healthcheck` shell.

This was therefore causing the wow-db to fail to startup due to `Access denied for user 'root'@'localhost' (using password: YES)` 

My host machine is Windows 11. I was using the DML Launcher "Install New Title..." pointed to a cloned local copy of the `wow-vanilla` install script.