### PR TITLE
Re-running the installer can offer to delete a working install (database included)

### DIFF
--- a/guides/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/guides/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -1085,8 +1085,15 @@ install_server() {
     # If they already exist in $SERVER_DIR, skip the 2-4 hour compile
     # and just start the server — the rest of the install continues
     # normally (account creation, launcher setup, etc.).
+    # `docker compose images` only lists images belonging to the project's
+    # CONTAINERS, so after an ordinary `docker compose down` it reports nothing
+    # even though the built images are still on the system. Without the second
+    # test, a complete install looks uncompiled here and falls through to the
+    # "Remove it and start fresh?" prompt below, which deletes the database
+    # volume and the server folder.
     if [ -d "$SERVER_DIR" ] && \
-       (cd "$SERVER_DIR" && docker compose images 2>/dev/null | grep -qi "worldserver"); then
+       (cd "$SERVER_DIR" && { docker compose images 2>/dev/null | grep -qi "worldserver" \
+          || docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | grep -qi "worldserver"; }); then
         print_success "Compiled images already found in $SERVER_DIR"
         print_info "Skipping compile — reusing your existing build."
         print_info "To force a fresh compile, remove the server folder:"

--- a/guides/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/guides/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -863,8 +863,15 @@ install_server() {
     # If they already exist in $SERVER_DIR, skip the 2-4 hour compile
     # and just start the server — the rest of the install continues
     # normally (account creation, launcher setup, etc.).
+    # `docker compose images` only lists images belonging to the project's
+    # CONTAINERS, so after an ordinary `docker compose down` it reports nothing
+    # even though the built images are still on the system. Without the second
+    # test, a complete install looks uncompiled here and falls through to the
+    # "Remove it and start fresh?" prompt below, which deletes the database
+    # volume and the server folder.
     if [ -d "$SERVER_DIR" ] && \
-       (cd "$SERVER_DIR" && docker compose images 2>/dev/null | grep -qi "worldserver"); then
+       (cd "$SERVER_DIR" && { docker compose images 2>/dev/null | grep -qi "worldserver" \
+          || docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | grep -qi "worldserver"; }); then
         print_success "Compiled images already found in $SERVER_DIR"
         print_info "Skipping compile — reusing your existing build."
         print_info "To force a fresh compile, remove the server folder:"

--- a/guides/wow-wotlk/install-wow-wotlk.sh
+++ b/guides/wow-wotlk/install-wow-wotlk.sh
@@ -1007,8 +1007,15 @@ install_server() {
     # If they already exist in $SERVER_DIR, skip the 2-4 hour compile
     # and just start the server — the rest of the install continues
     # normally (account creation, launcher setup, etc.).
+    # `docker compose images` only lists images belonging to the project's
+    # CONTAINERS, so after an ordinary `docker compose down` it reports nothing
+    # even though the built images are still on the system. Without the second
+    # test, a complete install looks uncompiled here and falls through to the
+    # "Remove it and start fresh?" prompt below, which deletes the database
+    # volume and the server folder.
     if [ -d "$SERVER_DIR" ] && \
-       (cd "$SERVER_DIR" && docker compose images 2>/dev/null | grep -qi "worldserver"); then
+       (cd "$SERVER_DIR" && { docker compose images 2>/dev/null | grep -qi "worldserver" \
+          || docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | grep -qi "worldserver"; }); then
         print_success "Compiled images already found in $SERVER_DIR"
         print_info "Skipping compile — reusing your existing build."
         print_info "To force a fresh compile, remove the server folder:"


### PR DESCRIPTION
### What happens now

Re-run the installer after stopping your server with `docker compose down`, and it offers:

> Existing folder found at … (no compiled images present)
> **Remove it and start fresh? (y/n)**

Answer `y` and it runs `docker compose down -v` — which deletes the `ac-database` volume, taking **every account, character and world edit** with it — then `sudo rm -rf "$SERVER_DIR"`.

The install was complete and working. It just looked uncompiled.

### Why

The "already built?" guard is:

```bash
docker compose images 2>/dev/null | grep -qi "worldserver"
```

`docker compose images` lists images belonging to the project's **containers**, not images built by the project. Once the containers are removed, it reports nothing — even though the built images are still right there.

### Why it's easy to hit

Stopping with `docker compose down` is what the project itself recommends: the generated launcher does it, and `MY_SERVER.txt` suggests it too. So the ordinary "stop the server, run the installer again later" path leads here.

### Verified

Docker Compose v5.4.0, throwaway project with a service named `worldserver`:

| | `compose images \| grep worldserver` | `docker images` |
|---|---|---|
| containers running | matches | image present |
| after `docker compose down` | **no match** | image still present |

### The fix

Add a fallback that checks the image store when the first test comes back empty.

This is deliberately additive — when containers exist, behaviour is exactly as before. It only removes the false negative, so there's no change to your intended logic to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
