### PR TITLE
Build failures print no error and never show the log path

### DIFF
--- a/guides/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/guides/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -949,9 +949,12 @@ OVERRIDE
     print_info "Go make a coffee — this will take a while! ☕"
 
     cd "$SERVER_DIR"
-    docker compose up -d --build 2>&1 | tee ~/playerbots-build.log
-
-    if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    # Test the pipeline directly rather than checking PIPESTATUS afterwards:
+    # with `set -euo pipefail` (line 70) a failed build aborts the script AT
+    # this line, so a check on the following line is never reached and the
+    # error below is never printed. Inside `if !`, errexit is suspended for
+    # this command while pipefail still reports docker's real exit status.
+    if ! docker compose up -d --build 2>&1 | tee ~/playerbots-build.log; then
         print_error "Compilation failed. Check ~/playerbots-build.log"
         exit 1
     fi

--- a/guides/wow-wotlk/install-wow-wotlk.sh
+++ b/guides/wow-wotlk/install-wow-wotlk.sh
@@ -1102,9 +1102,12 @@ OVERRIDE
     print_info "Go make a coffee — this will take a while! ☕"
 
     cd "$SERVER_DIR"
-    docker compose up -d --build 2>&1 | tee ~/playerbots-build.log
-
-    if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    # Test the pipeline directly rather than checking PIPESTATUS afterwards:
+    # with `set -euo pipefail` (line 70) a failed build aborts the script AT
+    # this line, so a check on the following line is never reached and the
+    # error below is never printed. Inside `if !`, errexit is suspended for
+    # this command while pipefail still reports docker's real exit status.
+    if ! docker compose up -d --build 2>&1 | tee ~/playerbots-build.log; then
         print_error "Compilation failed. Check ~/playerbots-build.log"
         exit 1
     fi


### PR DESCRIPTION
### What happens now

If the build fails, the installer prints **nothing** — no error, and no mention of where the log is. After a 2–4 hour compile it just stops, and there's no clue what went wrong.

### Why

`set -euo pipefail` is set at line 70. When `docker compose up -d --build` fails, `pipefail` makes the whole pipeline non-zero and `errexit` aborts the script **at that line** — so the `if [ ${PIPESTATUS[0]} -ne 0 ]` check on the next line is never reached, and the `print_error` inside it never runs.

### The quickest way to confirm it

`install-wow-wotlk-fedora.sh` has the **identical** handler, and there it works — because that script doesn't set `set -euo pipefail`. Same code, two files, opposite behaviour.

That's also why this PR only touches the two scripts that do set it. The Fedora one is left alone.

### The fix

Test the pipeline directly with `if ! …; then`. `errexit` is suspended for a command whose status is being tested, so the handler is reachable again, and `pipefail` still surfaces docker's real exit status.

### Verified

On bash 5.2.21, with the trap and keepalive structure from the end of the script:

- **current form** — handler does not run, no message printed
- **with this change** — handler runs, prints the error, exits 1
- **successful build** — still takes the success path

*(One thing I checked and want to be accurate about: the script does still exit non-zero today. A bare `exit` inside an EXIT trap preserves the triggering status. So this is about the missing message, not a wrong exit code.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
