### PR TITLE
AzerothCore installers leave MySQL on 0.0.0.0 with the default root password

### DIFF
--- a/guides/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/guides/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -1137,6 +1137,28 @@ install_server() {
         print_info "You can add it manually later: git clone ... $SERVER_DIR/modules/mod-playerbots"
     fi
 
+    # AzerothCore's compose file resolves ${DOCKER_DB_ROOT_PASSWORD:-password}
+    # and ${DOCKER_DB_EXTERNAL_PORT:-3306}:3306. Without a .env both defaults
+    # apply, so MySQL is published on every interface with the root password
+    # "password". The port value is substituted into compose short syntax, so
+    # "127.0.0.1:3306" becomes "127.0.0.1:3306:3306" and binds loopback only.
+    #
+    # This has to be written before the first `up`: the MySQL image only reads
+    # MYSQL_ROOT_PASSWORD when it initialises the data volume.
+    #
+    # The game ports (3724 auth, 8085 world) are deliberately left alone.
+    if [ ! -f "$SERVER_DIR/.env" ]; then
+        umask 077
+        cat > "$SERVER_DIR/.env" << ENVEOF
+DOCKER_DB_ROOT_PASSWORD=$(openssl rand -hex 24)
+DOCKER_DB_EXTERNAL_PORT=127.0.0.1:3306
+DOCKER_SOAP_EXTERNAL_PORT=127.0.0.1:7878
+ENVEOF
+        umask 022
+        chmod 600 "$SERVER_DIR/.env"
+        print_success "Database secured (random root password, bound to localhost)"
+    fi
+
     cat > "$SERVER_DIR/docker-compose.override.yml" << 'OVERRIDE'
 services:
   ac-worldserver:

--- a/guides/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/guides/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -1148,14 +1148,29 @@ install_server() {
     #
     # The game ports (3724 auth, 8085 world) are deliberately left alone.
     if [ ! -f "$SERVER_DIR/.env" ]; then
+        # Generate the password FIRST and verify it is non-empty. If this were
+        # inlined in the heredoc and openssl were missing, the value would be an
+        # empty string -- and compose treats ${VAR:-password} as unset when empty,
+        # silently restoring the very default this is meant to replace.
+        _db_pw="$(openssl rand -hex 24 2>/dev/null || true)"
+        if [ -z "$_db_pw" ]; then
+            _db_pw="$(tr -dc 'a-f0-9' < /dev/urandom 2>/dev/null | head -c 48 || true)"
+        fi
+        if [ -z "$_db_pw" ]; then
+            print_error "Could not generate a database password (no openssl, no /dev/urandom)."
+            print_error "Refusing to continue - the database would be left with the default password."
+            exit 1
+        fi
+
         umask 077
         cat > "$SERVER_DIR/.env" << ENVEOF
-DOCKER_DB_ROOT_PASSWORD=$(openssl rand -hex 24)
+DOCKER_DB_ROOT_PASSWORD=$_db_pw
 DOCKER_DB_EXTERNAL_PORT=127.0.0.1:3306
 DOCKER_SOAP_EXTERNAL_PORT=127.0.0.1:7878
 ENVEOF
         umask 022
         chmod 600 "$SERVER_DIR/.env"
+        unset _db_pw
         print_success "Database secured (random root password, bound to localhost)"
     fi
 

--- a/guides/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/guides/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -915,6 +915,28 @@ install_server() {
         print_info "You can add it manually later: git clone ... $SERVER_DIR/modules/mod-playerbots"
     fi
 
+    # AzerothCore's compose file resolves ${DOCKER_DB_ROOT_PASSWORD:-password}
+    # and ${DOCKER_DB_EXTERNAL_PORT:-3306}:3306. Without a .env both defaults
+    # apply, so MySQL is published on every interface with the root password
+    # "password". The port value is substituted into compose short syntax, so
+    # "127.0.0.1:3306" becomes "127.0.0.1:3306:3306" and binds loopback only.
+    #
+    # This has to be written before the first `up`: the MySQL image only reads
+    # MYSQL_ROOT_PASSWORD when it initialises the data volume.
+    #
+    # The game ports (3724 auth, 8085 world) are deliberately left alone.
+    if [ ! -f "$SERVER_DIR/.env" ]; then
+        umask 077
+        cat > "$SERVER_DIR/.env" << ENVEOF
+DOCKER_DB_ROOT_PASSWORD=$(openssl rand -hex 24)
+DOCKER_DB_EXTERNAL_PORT=127.0.0.1:3306
+DOCKER_SOAP_EXTERNAL_PORT=127.0.0.1:7878
+ENVEOF
+        umask 022
+        chmod 600 "$SERVER_DIR/.env"
+        print_success "Database secured (random root password, bound to localhost)"
+    fi
+
     cat > "$SERVER_DIR/docker-compose.override.yml" << 'OVERRIDE'
 services:
   ac-worldserver:

--- a/guides/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/guides/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -926,14 +926,29 @@ install_server() {
     #
     # The game ports (3724 auth, 8085 world) are deliberately left alone.
     if [ ! -f "$SERVER_DIR/.env" ]; then
+        # Generate the password FIRST and verify it is non-empty. If this were
+        # inlined in the heredoc and openssl were missing, the value would be an
+        # empty string -- and compose treats ${VAR:-password} as unset when empty,
+        # silently restoring the very default this is meant to replace.
+        _db_pw="$(openssl rand -hex 24 2>/dev/null || true)"
+        if [ -z "$_db_pw" ]; then
+            _db_pw="$(tr -dc 'a-f0-9' < /dev/urandom 2>/dev/null | head -c 48 || true)"
+        fi
+        if [ -z "$_db_pw" ]; then
+            print_error "Could not generate a database password (no openssl, no /dev/urandom)."
+            print_error "Refusing to continue - the database would be left with the default password."
+            exit 1
+        fi
+
         umask 077
         cat > "$SERVER_DIR/.env" << ENVEOF
-DOCKER_DB_ROOT_PASSWORD=$(openssl rand -hex 24)
+DOCKER_DB_ROOT_PASSWORD=$_db_pw
 DOCKER_DB_EXTERNAL_PORT=127.0.0.1:3306
 DOCKER_SOAP_EXTERNAL_PORT=127.0.0.1:7878
 ENVEOF
         umask 022
         chmod 600 "$SERVER_DIR/.env"
+        unset _db_pw
         print_success "Database secured (random root password, bound to localhost)"
     fi
 

--- a/guides/wow-wotlk/install-wow-wotlk.sh
+++ b/guides/wow-wotlk/install-wow-wotlk.sh
@@ -1079,14 +1079,29 @@ install_server() {
     #
     # The game ports (3724 auth, 8085 world) are deliberately left alone.
     if [ ! -f "$SERVER_DIR/.env" ]; then
+        # Generate the password FIRST and verify it is non-empty. If this were
+        # inlined in the heredoc and openssl were missing, the value would be an
+        # empty string -- and compose treats ${VAR:-password} as unset when empty,
+        # silently restoring the very default this is meant to replace.
+        _db_pw="$(openssl rand -hex 24 2>/dev/null || true)"
+        if [ -z "$_db_pw" ]; then
+            _db_pw="$(tr -dc 'a-f0-9' < /dev/urandom 2>/dev/null | head -c 48 || true)"
+        fi
+        if [ -z "$_db_pw" ]; then
+            print_error "Could not generate a database password (no openssl, no /dev/urandom)."
+            print_error "Refusing to continue - the database would be left with the default password."
+            exit 1
+        fi
+
         umask 077
         cat > "$SERVER_DIR/.env" << ENVEOF
-DOCKER_DB_ROOT_PASSWORD=$(openssl rand -hex 24)
+DOCKER_DB_ROOT_PASSWORD=$_db_pw
 DOCKER_DB_EXTERNAL_PORT=127.0.0.1:3306
 DOCKER_SOAP_EXTERNAL_PORT=127.0.0.1:7878
 ENVEOF
         umask 022
         chmod 600 "$SERVER_DIR/.env"
+        unset _db_pw
         print_success "Database secured (random root password, bound to localhost)"
     fi
 

--- a/guides/wow-wotlk/install-wow-wotlk.sh
+++ b/guides/wow-wotlk/install-wow-wotlk.sh
@@ -1068,6 +1068,28 @@ install_server() {
         fi
     fi
 
+    # AzerothCore's compose file resolves ${DOCKER_DB_ROOT_PASSWORD:-password}
+    # and ${DOCKER_DB_EXTERNAL_PORT:-3306}:3306. Without a .env both defaults
+    # apply, so MySQL is published on every interface with the root password
+    # "password". The port value is substituted into compose short syntax, so
+    # "127.0.0.1:3306" becomes "127.0.0.1:3306:3306" and binds loopback only.
+    #
+    # This has to be written before the first `up`: the MySQL image only reads
+    # MYSQL_ROOT_PASSWORD when it initialises the data volume.
+    #
+    # The game ports (3724 auth, 8085 world) are deliberately left alone.
+    if [ ! -f "$SERVER_DIR/.env" ]; then
+        umask 077
+        cat > "$SERVER_DIR/.env" << ENVEOF
+DOCKER_DB_ROOT_PASSWORD=$(openssl rand -hex 24)
+DOCKER_DB_EXTERNAL_PORT=127.0.0.1:3306
+DOCKER_SOAP_EXTERNAL_PORT=127.0.0.1:7878
+ENVEOF
+        umask 022
+        chmod 600 "$SERVER_DIR/.env"
+        print_success "Database secured (random root password, bound to localhost)"
+    fi
+
     cat > "$SERVER_DIR/docker-compose.override.yml" << 'OVERRIDE'
 services:
   ac-worldserver:


### PR DESCRIPTION
### What happens now

The AzerothCore installers never write a `.env`, so upstream's compose defaults apply as-is:

```yaml
ports:       - ${DOCKER_DB_EXTERNAL_PORT:-3306}:3306
environment: - MYSQL_ROOT_PASSWORD=${DOCKER_DB_ROOT_PASSWORD:-password}
```

Both defaults take effect: **MySQL is published on every interface with the root password `password`**, and the mysql image creates `root@'%'`. On a home network that's reachable by anything else on the LAN — a guest phone, a smart TV, anything that joins the wifi.

### This is your own standard, not an outside opinion

The CMaNGOS installers in this repo already do the right thing:

- `install-wow-tbc.sh:114` — `DB_PASSWORD="tbc$(openssl rand -hex 8)"`
- `install-wow-vanilla.sh:114` — `DB_PASSWORD="vanilla$(openssl rand -hex 8)"`

and neither publishes 3306. The AzerothCore ones are the odd ones out.

### The fix

Write a `.env` with a generated root password, and bind MySQL and SOAP to loopback. The game ports (**3724 auth, 8085 world**) are deliberately untouched — those still need to be reachable from your LAN for clients to connect.

### Two details worth knowing for review

**The port value works because of compose short syntax.** `DOCKER_DB_EXTERNAL_PORT=127.0.0.1:3306` expands to `127.0.0.1:3306:3306`, which binds loopback only. Adding a `ports:` block to the override instead would *not* work — compose **appends** short-syntax port entries rather than replacing them, so you'd end up with both bindings open.

**It has to run before the first `up`.** The mysql image only reads `MYSQL_ROOT_PASSWORD` when it initialises the data volume; afterwards it takes an `ALTER USER`.

### Nothing breaks for existing users

The whole block is skipped when a `.env` already exists, so current installs are untouched.

⚠️ One deliberate behaviour change worth calling out: after this, connecting to the database from **another machine** (Keira3, HeidiSQL, etc.) won't work by default. Deleting the two port lines from `.env` restores the old behaviour.

### Second commit

The first version inlined `$(openssl rand -hex 24)` in the heredoc. Without openssl that expands to an empty string — and compose treats `${VAR:-password}` as unset when empty, silently restoring the `password` default with no sign anything went wrong. It now generates into a variable, falls back to `/dev/urandom`, and aborts with a clear message if neither is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
