### PR TITLE
Yu'lon follow-up: Windows verification, the bash-on-PATH trap, and the CI/doc bits #84 missed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
   push:
     tags:
       - "v*"
+  # So the matrix can be PROVEN without publishing anything: a manual run builds
+  # all three artifacts and uploads them to the run; only a v* tag attaches them
+  # to a GitHub Release (roadmap Phase 5 exit criteria).
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -111,6 +115,7 @@ jobs:
           path: pylauncher/release/*
 
       - name: Attach to the GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: pylauncher/release/*

--- a/pylauncher/development.md
+++ b/pylauncher/development.md
@@ -70,3 +70,25 @@ YULON_WOTLK_SERVER_DIR=~/wow-server-playerbots pytest -m integration tests/integ
 - All four checks above (`pytest`, `mypy`, `ruff`, `black --check`) are expected to run in CI —
   see `pyplan/roadmap.md` Phase 0.2.
 - See `pyplan/style-guide.md` before writing any code — it is a hard constraint, not a preference.
+
+
+## Building the UI in Qt Designer
+
+The views are hand-written widgets today, but nothing in `yulon/` depends on that: every view is
+handed its dependencies as a seam (`ControllerServices`, `JobRunner`, `LogPanel`) and talks back
+with signals, so the widget layer can be replaced by Designer-built forms without touching the
+core.
+
+```bash
+pyside6-designer                  # ships with PySide6; save forms as yulon/ui/forms/<name>.ui
+pyside6-uic yulon/ui/forms/x.ui -o yulon/ui/forms/ui_x.py   # or load the .ui at runtime
+```
+
+Two rules keep a Designer form working with the rest of the app:
+
+1. **Long calls stay off the GUI thread.** Route every service call through `self._run(...)`
+   (`yulon/ui/widgets/job.py`), never straight from a slot — `docker compose up`, a module
+   install and a networking plan all take seconds to minutes.
+2. **Callbacks must be bound methods of the view** (`@Slot(object)` on the widget class). A plain
+   function or lambda connected to a worker's signal is delivered ON THE WORKER THREAD in PySide6,
+   even with an explicit `QueuedConnection`.

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -210,6 +210,7 @@ def test_installer_fails_gracefully_without_docker(tmp_path: Path) -> None:
             "windows", done=("wsl --install",), reboot_required=True, manual_steps=("Reboot.",)
         ),
         package_manager=lambda: None,  # default script, not a distro variant
+        bash_check=lambda: True,  # this box's bash is irrelevant to what is asserted
     )
     with pytest.raises(DockerUnavailableError, match="reboot is needed"):
         rebooter.preflight(InstallOptions())

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -24,10 +24,15 @@ from yulon.catalog.installer import (
     Installer,
     InstallerError,
     InstallOptions,
+    bash_available,
     make_responder,
 )
 
-needs_bash = pytest.mark.skipif(shutil.which("bash") is None, reason="bash not on PATH")
+# Not just `which bash`: on Windows that finds the Store alias for WSL, which fails
+# with execvpe(/bin/bash) when no distro is installed (Windows test VM, 2026-08-21).
+needs_bash = pytest.mark.skipif(
+    not bash_available(), reason="no bash that can run a script on this machine"
+)
 
 FAKE_INSTALLER = r"""
 W='\033[1;37m'; NC='\033[0m'
@@ -250,3 +255,42 @@ def test_installer_wraps_script_failure(tmp_path: Path) -> None:
         for line in installer.run():
             got.append(line)
     assert got == ["step 1"]
+
+
+def test_preflight_refuses_when_bash_cannot_run(tmp_path: Path) -> None:
+    """A `bash` that is only the WSL alias must produce advice, not an execvpe error."""
+    entry = load_catalog().get("wow-wotlk")
+    script = tmp_path / entry.install.script
+    script.parent.mkdir(parents=True)
+    script.write_text("", encoding="utf-8")
+    installer = Installer(
+        entry,
+        repo_root=tmp_path,
+        docker_check=lambda: True,
+        package_manager=lambda: None,
+        bash_check=lambda: False,
+    )
+    with pytest.raises(InstallerError, match="no working `bash`"):
+        list(installer.run())
+
+
+def test_bash_available_probes_that_bash_actually_runs() -> None:
+    """`which bash` is not enough — the probe must execute something."""
+    import subprocess as sp
+
+    calls: list[list[str]] = []
+
+    def ok(argv: list[str], *a: object, **k: object) -> sp.CompletedProcess[str]:
+        calls.append(argv)
+        return sp.CompletedProcess(argv, 0, "", "")
+
+    def broken(argv: list[str], *a: object, **k: object) -> sp.CompletedProcess[str]:
+        calls.append(argv)
+        return sp.CompletedProcess(argv, 1, "", "execvpe(/bin/bash) failed")
+
+    if shutil.which("bash") is None:
+        assert bash_available(ok) is False  # nothing to probe
+        return
+    assert bash_available(ok) is True
+    assert calls[-1] == ["bash", "-c", "exit 0"]
+    assert bash_available(broken) is False

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -128,6 +128,7 @@ def test_installer_runs_the_entry_script_through_interact(tmp_path: Path) -> Non
         docker_check=lambda: True,
         interact=_fake_interact(calls),  # type: ignore[arg-type]
         package_manager=lambda: None,
+        bash_check=lambda: True,
     )
     assert list(installer.run(InstallOptions(server_dir=Path("/srv")))) == ["hello", "done"]
     assert calls[0]["command"] == ["bash", str(script)]
@@ -195,6 +196,7 @@ def test_installer_fails_gracefully_without_docker(tmp_path: Path) -> None:
         ),
         interact=_fake_interact(calls),  # type: ignore[arg-type]
         package_manager=lambda: None,  # the file below is the default script, not a variant
+        bash_check=lambda: True,  # this box's bash is irrelevant to what is asserted
     )
     with pytest.raises(DockerUnavailableError, match="could not be set up automatically"):
         list(installer.run())
@@ -220,7 +222,9 @@ def test_installer_requires_the_client_dir_when_the_script_asks_for_it(tmp_path:
     script = tmp_path / entry.install.script
     script.parent.mkdir(parents=True)
     script.write_text("", encoding="utf-8")
-    installer = Installer(entry, repo_root=tmp_path, docker_check=lambda: True)
+    installer = Installer(
+        entry, repo_root=tmp_path, docker_check=lambda: True, bash_check=lambda: True
+    )
     with pytest.raises(InstallerError, match="never downloads game clients"):
         list(installer.run())
     with pytest.raises(InstallerError, match="does not exist"):
@@ -249,6 +253,7 @@ def test_installer_wraps_script_failure(tmp_path: Path) -> None:
         docker_check=lambda: True,
         interact=failing,  # type: ignore[arg-type]
         package_manager=lambda: None,  # the file below is the default script, not a variant
+        bash_check=lambda: True,  # this box's bash is irrelevant to what is asserted
     )
     got: list[str] = []
     with pytest.raises(InstallerError, match="status 7"):

--- a/pylauncher/tests/test_runner.py
+++ b/pylauncher/tests/test_runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 import threading
 import time
@@ -11,9 +10,14 @@ from pathlib import Path
 import pytest
 
 from yulon import runner
+from yulon.catalog.installer import bash_available
 from yulon.runner import run, stream
 
-needs_bash = pytest.mark.skipif(shutil.which("bash") is None, reason="bash not on PATH")
+# Not just `which bash`: on Windows that finds the Store alias for WSL, which fails
+# with execvpe(/bin/bash) when no distro is installed (Windows test VM, 2026-08-21).
+needs_bash = pytest.mark.skipif(
+    not bash_available(), reason="no bash that can run a script on this machine"
+)
 
 
 def _python_cmd(script: str) -> list[str]:

--- a/pylauncher/yulon/catalog/installer.py
+++ b/pylauncher/yulon/catalog/installer.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import subprocess
 import sys
 import threading
@@ -122,6 +123,32 @@ def host_package_manager() -> str | None:
     return platform.linux_package_manager()
 
 
+def bash_available(run: Callable[..., subprocess.CompletedProcess[str]] | None = None) -> bool:
+    """True if a `bash` that can actually run a script is on PATH.
+
+    Being on PATH is not enough on Windows: `bash.exe` there is usually the
+    Store alias for WSL, which fails with `execvpe(/bin/bash)` when no distro
+    is installed (found on the Windows test VM, 2026-08-21). Docker Desktop's
+    own WSL distros do not provide one.
+    """
+    if shutil.which("bash") is None:
+        return False
+    call = run if run is not None else runner.run
+    try:
+        return call(["bash", "-c", "exit 0"]).returncode == 0
+    except OSError:
+        return False
+
+
+NO_BASH_HELP = (
+    "The installers are shell scripts and this machine has no working `bash`. "
+    "On Windows that usually means WSL has no Linux distribution yet: install "
+    "one (`wsl --install -d Ubuntu`), reopen the app, and try again. Yu'lon "
+    "sets up WSL2 and Docker Desktop for you, but the install script itself "
+    "still needs a distro to run in."
+)
+
+
 def docker_available() -> bool:
     """True if `docker info` succeeds; False if the binary or daemon is missing."""
     try:
@@ -147,6 +174,7 @@ class Installer:
         interact: Callable[..., Iterator[str]] = runner.interact,
         env: Mapping[str, str] | None = None,
         package_manager: Callable[[], str | None] = host_package_manager,
+        bash_check: Callable[[], bool] = bash_available,
     ) -> None:
         self.entry = entry
         self.repo_root = repo_root
@@ -155,6 +183,7 @@ class Installer:
         self._interact = interact
         self._env = env
         self._package_manager = package_manager
+        self._bash_check = bash_check
 
     @property
     def script(self) -> Path:
@@ -190,6 +219,8 @@ class Installer:
         """
         if not self.script.is_file():
             raise InstallerError(f"install script not found: {self.script}")
+        if not self._bash_check():
+            raise InstallerError(NO_BASH_HELP)
         if self.entry.install.requires_client_dir and options.client_dir is None:
             raise InstallerError(
                 f"{self.entry.name} needs the folder of your {self.entry.client.version} "

--- a/pyplan/README.md
+++ b/pyplan/README.md
@@ -209,11 +209,12 @@ pylauncher/
 ├── requirements-dev.txt          # pytest, mypy, black, ruff — pinned dev tooling
 ├── pyproject.toml                # black/ruff/mypy/pytest config
 ├── development.md                # contributor setup doc
-├── build/                        # PyInstaller specs
-│   └── pylauncher.spec
-└── .github/workflows/
-    ├── ci.yml                    # lint + type-check + test on every push/PR
-    └── release.yml               # build matrix → AppImage/dmg/exe
+└── build/                        # PyInstaller specs
+    └── pylauncher.spec
+
+<repo root>/.github/workflows/    # NOT under pylauncher/: GitHub only runs workflows from the repo root
+├── ci.yml                        # lint + type-check + test on every push/PR (working-directory: pylauncher)
+└── release.yml                   # build matrix → AppImage/dmg/exe
 ```
 
 **Status as of this writing:** only `controller_wow_wotlk/` exists. The other three v1 servers

--- a/pyplan/checklist.md
+++ b/pyplan/checklist.md
@@ -60,11 +60,11 @@
 
 ## Phase 5 — Windows/macOS provisioning + packaging
 
-- [x] 5.1 Silent Docker Desktop / WSL2 provisioning + doc update — **Linux path verified for real on a fresh Ubuntu 24.04 VM (2026-08-20, see Cross-cutting); Windows/macOS fresh-machine runs NOT yet verified**
+- [x] 5.1 Silent Docker Desktop / WSL2 provisioning + doc update — Linux path verified for real on a fresh Ubuntu 24.04 VM (2026-08-20); the Windows detection/short-circuit/plan paths verified on a real Windows 11 box (2026-08-21). The silent Docker Desktop **install** itself is still unverified (both test machines already had Docker), and macOS has no machine at all — see Cross-cutting.
 - [x] 5.2 PyInstaller specs finalized (local `pyinstaller build/pylauncher.spec` builds `build/dist/yulon/`; bundles manifests/, catalog.json and the install scripts; `YULON_SMOKE_TEST=1` runs the frozen exe headless)
 - [x] 5.3 GitHub Actions release matrix complete — `ci.yml` + `release.yml` now live at the repo root `.github/workflows/` (2026-08-21), which is the only path GitHub reads; both run with `working-directory: pylauncher`. Neither upstream branch had a root `.github/`, so nothing was overwritten. The release job still only proves itself on a `v*` tag.
 - [x] 5.4 Application self-update check (README §10)
-- [ ] **Phase 5 exit criteria met**
+- [ ] **Phase 5 exit criteria met** — `ci.yml` is green on GitHub for the first time (2026-08-21, run 32432706579); `release.yml` has never run: `workflow_dispatch` only works from a repository's default branch (the fork's is `rust-main`, which does not carry the file), and the only other trigger is a `v*` tag, which publishes a Release. One tag push proves the three artifacts.
 
 ---
 
@@ -212,6 +212,32 @@
   the `docker` group — the running process keeps its old groups, so it reports "Docker not
   reachable" until relaunched. The report already says "log out and back in"; the UI should say it
   where the status is shown (follow-up).
+- **5.1 on real Windows (2026-08-21, `test-env-win11`, Windows 11 + Docker Desktop + WSL2,
+  with a live WoW server on it that was never touched):** `config_dir()` resolved to
+  `%APPDATA%\yulon` (README §11's claim), `detect()` to `windows`, `docker_ready()` True,
+  `in_wsl()` False. `ensure_wsl2()` reported `WSL2 present` and installed nothing;
+  `ensure_docker()` short-circuited with `docker already running` and executed only
+  `docker info` — the safety property that matters most, since a wrong answer would have
+  started an unattended Docker Desktop install on a machine hosting a live server. The dry
+  run of the Docker-missing path planned exactly `powershell.exe -NoProfile -Command
+  Start-Process wsl.exe -Verb RunAs -Wait -ArgumentList '--install','--no-distribution'`
+  with `reboot_required=True` and stopped there (Docker Desktop comes after the reboot),
+  executing nothing. Full battery on that machine: ruff/black/mypy clean, 188 passed,
+  5 skipped; `YULON_SMOKE_TEST=1 python main.py` built the window and exited 0.
+  **Still unverified:** the silent Docker Desktop download+install (needs a Windows box
+  WITHOUT Docker) and everything macOS (no machine).
+- **Windows finding — `bash` on PATH is not necessarily a usable bash (2026-08-21):** on that
+  machine `bash.exe` was the Store alias for WSL and failed with
+  `execvpe(/bin/bash) failed: No such file or directory`, because no distro is installed
+  (Docker Desktop's own WSL distros do not provide one). Three tests failed there purely
+  because `needs_bash` checked `shutil.which("bash")`, and a real install would have shown
+  the user that raw WSL error. `installer.bash_available()` now probes `bash -c 'exit 0'`,
+  `preflight()` refuses with instructions (install a distro, reopen the app), and the test
+  markers use the same probe. **This also means Phase 3a installs are Linux-only in
+  practice**: a Windows user needs a WSL distro, and later either path translation for the
+  shell script or the PowerShell installer the repo already ships
+  (`archive/guides/wow-wotlk/Install-WoW-WotLK.ps1`). `install.script_variants` is the
+  natural place to hang a `windows` entry when that is done.
 - **3.4 record (2026-08-20):** mirrors `WoW-Wotlk-NETWORKING.md` exactly — ufw/firewalld/netsh
   command blocks (SteamOS wraps ufw in `steamos-readonly disable/enable`), `ip route`-equivalent
   LAN detection (inside WSL it asks Windows via `powershell.exe`, never the 172.x guest IP),

--- a/pyplan/checklist.md
+++ b/pyplan/checklist.md
@@ -62,7 +62,7 @@
 
 - [x] 5.1 Silent Docker Desktop / WSL2 provisioning + doc update — **Linux path verified for real on a fresh Ubuntu 24.04 VM (2026-08-20, see Cross-cutting); Windows/macOS fresh-machine runs NOT yet verified**
 - [x] 5.2 PyInstaller specs finalized (local `pyinstaller build/pylauncher.spec` builds `build/dist/yulon/`; bundles manifests/, catalog.json and the install scripts; `YULON_SMOKE_TEST=1` runs the frozen exe headless)
-- [ ] 5.3 GitHub Actions release matrix complete — **workflow written (AppImage/zip/dmg, attaches to the Release) but unverified: it lives at `pylauncher/.github/workflows/`, and GitHub only runs workflows from the repo root `.github/workflows/` — moving/merging it there is an upstream decision**
+- [x] 5.3 GitHub Actions release matrix complete — `ci.yml` + `release.yml` now live at the repo root `.github/workflows/` (2026-08-21), which is the only path GitHub reads; both run with `working-directory: pylauncher`. Neither upstream branch had a root `.github/`, so nothing was overwritten. The release job still only proves itself on a `v*` tag.
 - [x] 5.4 Application self-update check (README §10)
 - [ ] **Phase 5 exit criteria met**
 


### PR DESCRIPTION
Six commits that landed after #84 was merged, rebased onto `Yulon` (so they sit on top of your two test-fault fixes — your `_FakeProc` dup/tty-capture fix is better than what I had, and it is kept as is).

## Why

I ran the 5.1 gate on a real Windows 11 box (`test-env-win11`, Docker Desktop + WSL2, a live WoW server on it that was never touched). Everything that can be verified without a Docker-less machine passed:

- `config_dir()` → `%APPDATA%\yulon`, `detect()` → `windows`, `docker_ready()` → True.
- `ensure_wsl2()` reported `WSL2 present` and installed nothing.
- `ensure_docker()` short-circuited with `docker already running`, executing only `docker info` — the property that matters most, since a wrong answer there would have kicked off an unattended Docker Desktop install on a machine hosting a live server.
- The Docker-missing path (dry run) planned exactly the elevated `wsl --install --no-distribution` with `reboot_required`, and stopped there.
- Battery on that machine: ruff/black/mypy clean, 188 passed, 5 skipped. `YULON_SMOKE_TEST=1 python main.py` built the window and exited 0.

## What it found

**`bash` being on PATH does not mean bash works.** On that box `bash.exe` is the Store alias for WSL and fails with `execvpe(/bin/bash) failed: No such file or directory`, because no distro is installed (Docker Desktop's own WSL distros do not provide one). Three tests failed there purely because `needs_bash` checked `shutil.which("bash")` — and a real install would have shown the user that raw WSL error.

- `installer.bash_available()` probes `bash -c 'exit 0'`; `preflight()` refuses with instructions ("install a distro, reopen the app") instead of surfacing `execvpe`; the test markers use the same probe.
- Consequence worth knowing: **Phase 3a installs are Linux-only in practice** on Windows until there is a distro (and later, either path translation for the shell script or the PowerShell installer the repo already ships). `install.script_variants` is where a `windows` entry would hang.

## The rest

- **CI docs/ticks that #84 dropped**: a swallowed `git add` error meant the 5.3 tick, the README tree fix (the workflows are at the repo root now, not under `pylauncher/`) and a Qt Designer section in `development.md` never made it into that PR. The Designer note is two rules that cost me an evening: long calls go through the job runner, and callbacks must be bound slots — a plain function connected to a worker signal runs ON the worker in PySide6, even with an explicit QueuedConnection.
- **`release.yml` gains `workflow_dispatch`**, with the Release-attachment step guarded to `v*` tags, so the three-artifact matrix can be proven without publishing anything. Caveat: `workflow_dispatch` only works from a repository's **default branch**, so it still needs the file on `main` (or one tag push) to actually be exercised — that is the last unchecked box in the checklist.
- Test pins so the suite stops depending on the host's package manager and bash.

Battery here: 191 passed, 2 skipped, mypy --strict/ruff/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QiDCebC8U2kAXrbYdMXof