### PR TITLE
wow-manage: add City Bots (mod-city-bots) incl. the roster import the core updater cannot do

### DIFF
--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -1104,6 +1104,7 @@ declare -a MODULE_REGISTRY=(
     "mod-transmog|Transmogrification|https://github.com/azerothcore/mod-transmog.git|world,characters"
     "mod-profession-progression|Profession Progression (unlock extra profession slots by leveling)|https://github.com/TopHatMan/mod-profession-progression.git|"
     "mod-mount-scaling|Mount Scaling (level-based progressive mount speed)|https://github.com/claudevandort/mod-mount-scaling.git|world"
+    "mod-city-bots|City Bots (fixed 400-bot city ambience cast — needs Playerbots)|https://github.com/pjerra/mod-city-bots.git|auth,characters,world"
 )
 
 # ─────────────────────────────────────────────────────────────
@@ -1676,6 +1677,9 @@ declare -a MODULE_UPDATE_FILES=(
     "mod-individual-progression|acore_world|"
     "mod-autobalance|acore_world|"
     "mod-ale|acore_world|"
+    "mod-city-bots|acore_auth|2026_07_16_03_stage_cast_one_account_per_bot.sql"
+    "mod-city-bots|acore_characters|2026_08_22_00_stage_cast_characters.sql 2026_08_22_01_stage_cast_outfits.sql"
+    "mod-city-bots|acore_world|2026_07_13_01_city_bot_poi.sql 2026_07_13_02_city_bot_ambiance.sql 2026_07_15_05_playercreateinfo_human_undead_hunter.sql"
 )
 
 # ALE Lua Script registry.
@@ -2133,6 +2137,11 @@ module_install() {
     if [ -n "$sql_dirs" ]; then
         print_info "Module SQL will be auto-applied on next server start"
         print_info "(AzerothCore's update system handles this — no manual import needed.)"
+    fi
+    if [ "$key" = "mod-city-bots" ]; then
+        print_warning "Exception: data/sql/playerbots (the 400-bot roster) is NEVER auto-applied —"
+        print_info    "mod-playerbots updates acore_playerbots with its own loader. The post-install"
+        print_info    "step / Configure imports it for you after the first server start."
     fi
     return 0
 }
@@ -2769,6 +2778,132 @@ configure_module_learn_spells() {
     fi
     echo ""
     print_info "Restart the worldserver for the new conf to take effect."
+}
+
+# ─────────────────────────────────────────────────────────────
+# CITY BOTS (mod-city-bots) — roster import + conf
+#   AzerothCore's updater auto-applies the module's db-auth / db-characters /
+#   db-world SQL, but NEVER data/sql/playerbots: mod-playerbots updates
+#   acore_playerbots with its own DatabaseLoader, which does not scan other
+#   modules. The 400-bot roster therefore has to be imported once, by hand,
+#   after acore_playerbots exists (= after the first worldserver start with
+#   Playerbots). This is the ONE manual import that does not break AC's
+#   update tracking: the core never sees that file, so nothing re-applies.
+# ─────────────────────────────────────────────────────────────
+CITY_BOTS_ROSTER_REL="data/sql/playerbots/updates/2026_07_15_00_citizen_roster.sql"
+CITY_BOTS_ROSTER_IMPORTED=0
+
+city_bots_roster_count() {
+    docker exec "$DB_CONTAINER" mysql -uroot -p"$DB_ROOT_PASSWORD" -N \
+        -e "SELECT COUNT(*) FROM acore_playerbots.citizen_roster;" 2>/dev/null | tail -1
+}
+
+city_bots_import_roster() {
+    local roster="$SERVER_DIR/modules/mod-city-bots/$CITY_BOTS_ROSTER_REL"
+    if [ ! -f "$roster" ]; then
+        print_error "Roster SQL not found: $roster"
+        return 1
+    fi
+
+    refresh_container_names
+    if ! container_running "$DB_CONTAINER"; then
+        print_info "Database container is not running — starting it..."
+        (cd "$SERVER_DIR" && docker compose up -d ac-database 2>/dev/null) || true
+        local w
+        for w in $(seq 1 12); do
+            refresh_container_names
+            container_running "$DB_CONTAINER" && break
+            sleep 5
+        done
+        if ! container_running "$DB_CONTAINER"; then
+            print_error "Database container did not start."
+            return 1
+        fi
+    fi
+
+    # acore_playerbots is created by worldserver on its first start with
+    # mod-playerbots. Right after a rebuild it can take a moment to appear.
+    local i have_db=""
+    for i in $(seq 1 "${CITY_BOTS_DB_WAIT:-24}"); do
+        have_db=$(docker exec "$DB_CONTAINER" mysql -uroot -p"$DB_ROOT_PASSWORD" -N \
+            -e "SHOW DATABASES LIKE 'acore_playerbots';" 2>/dev/null | tail -1)
+        [ -n "$have_db" ] && break
+        [ "$i" -eq 1 ] && print_info "Waiting for database acore_playerbots (created on the first worldserver start with Playerbots)..."
+        sleep 5
+    done
+    if [ -z "$have_db" ]; then
+        print_error "acore_playerbots does not exist yet."
+        print_info "Start the server once (mod-playerbots creates the database), then run"
+        print_info "Modules → c<num> (Configure) on City Bots to import the roster."
+        return 1
+    fi
+
+    local before; before=$(city_bots_roster_count)
+    if [ "${before:-0}" -ge 400 ] 2>/dev/null; then
+        print_info "citizen_roster already holds $before rows."
+        if ! ask_yes_no "Re-import the shipped roster anyway (resets roster rows to the shipped cast)?"; then
+            return 0
+        fi
+    fi
+
+    print_info "Importing roster into acore_playerbots..."
+    local out; out=$(sqlmod_run_sql_file acore_playerbots "$roster")
+    local after; after=$(city_bots_roster_count)
+    if [ "${after:-0}" -ge 400 ] 2>/dev/null; then
+        print_success "City Bots roster imported ($after entries)."
+        CITY_BOTS_ROSTER_IMPORTED=1
+        return 0
+    fi
+    print_error "Roster import failed (citizen_roster has ${after:-0} rows)."
+    [ -n "$out" ] && echo "$out" | grep -v "Using a password" | tail -5 | sed 's/^/  /'
+    return 1
+}
+
+# ─────────────────────────────────────────────────────────────
+# configure_module_city_bots
+#   1) imports the roster into acore_playerbots (see above)
+#   2) copies mod_city_bots.conf.dist → mod_city_bots.conf and offers to
+#      open it. Shipped defaults are the maintainer's live-server values.
+# ─────────────────────────────────────────────────────────────
+configure_module_city_bots() {
+    print_step "Configuring City Bots"
+
+    local module_dir="$SERVER_DIR/modules/mod-city-bots"
+    if [ ! -d "$module_dir" ]; then
+        print_error "City Bots module not installed (expected at $module_dir)."
+        return 1
+    fi
+    if [ ! -d "$SERVER_DIR/modules/mod-playerbots" ]; then
+        print_warning "mod-playerbots not found under modules/ — City Bots is a Playerbots extension and will not work without it."
+    fi
+
+    echo ""
+    print_info "Step 1/2 — roster import into acore_playerbots (the one file AzerothCore never auto-applies)."
+    city_bots_import_roster || true
+
+    echo ""
+    print_info "Step 2/2 — conf file."
+    local conf_dist="$module_dir/conf/mod_city_bots.conf.dist"
+    local conf_dest="$SERVER_DIR/env/dist/etc/modules/mod_city_bots.conf"
+    mkdir -p "$SERVER_DIR/env/dist/etc/modules"
+    if [ ! -f "$conf_dest" ]; then
+        if [ -f "$conf_dist" ]; then
+            cp "$conf_dist" "$conf_dest"
+            print_success "Created $conf_dest"
+        else
+            print_warning "conf.dist not found at $conf_dist"
+        fi
+    else
+        print_info "Using existing $conf_dest"
+    fi
+    print_info "Reserved ranges: accounts 12001-12400, character GUIDs 9000001-9000400."
+    print_info "worldserver.conf PlayerLimit must cover MaxRandomBots + 400 city bots."
+    if [ -f "$conf_dest" ] && ask_yes_no "Open mod_city_bots.conf in the editor?"; then
+        _open_text_file "$conf_dest"
+    fi
+    echo ""
+    print_info "Restart the worldserver so it loads the roster and conf (Server → Restart)."
+    print_info "Expected log line: 'mod-city-bots: stage cast loaded: 400 roster entries'."
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -5170,6 +5305,23 @@ configure_sqlmod_xprates() {
 _get_about_text() {
     local key="$1"
     case "$key" in
+        mod-city-bots)
+            printf '%s\n' \
+                'A fixed cast of 400 playerbots that populate capitals and' \
+                'social hubs: ambience crowds, gate duel hubs, fishers, inn' \
+                'dancers, bank/AH crowds. Created by deadtrickz; maintained' \
+                'fork by pjerra. Requires mod-playerbots.' \
+                '' \
+                'Reserved: auth accounts 12001-12400 (citybot12001.., password' \
+                'citybot_stage) and character GUIDs 9000001-9000400. Set' \
+                'worldserver PlayerLimit >= MaxRandomBots + 400.' \
+                '' \
+                'Install: clone -> rebuild -> server starts once -> Configure' \
+                'imports the roster into acore_playerbots (the core updater' \
+                'never applies data/sql/playerbots) -> restart.' \
+                '' \
+                'Commands: (none — everything is driven by mod_city_bots.conf)'
+            ;;
         mod-ah-bot)
             printf '%s\n' \
                 'An Auction House bot that populates faction AH listings' \
@@ -5811,6 +5963,21 @@ _module_post_install_hook() {
             print_info "Learn Spells requires a conf file — create/activate it now to avoid config spam on every bot login."
             if ask_yes_no "Configure Learn Spells (create conf with defaults) now?"; then configure_module_learn_spells; fi
             ;;
+        mod-city-bots)
+            echo ""
+            print_info "City Bots needs ONE step the AzerothCore updater cannot do: the 400-bot roster"
+            print_info "lives in data/sql/playerbots, which is never auto-applied (mod-playerbots updates"
+            print_info "acore_playerbots with its own loader). Accounts, characters and world SQL auto-apply."
+            print_info "Order: rebuild → server starts once (creates acore_playerbots) → import roster → restart."
+            if ask_yes_no "Import the City Bots roster and set up its conf now?"; then
+                configure_module_city_bots
+                if [ "$CITY_BOTS_ROSTER_IMPORTED" = 1 ] && ask_yes_no "Restart the worldserver now so the city bots log in?"; then
+                    (cd "$SERVER_DIR" && docker compose restart ac-worldserver) || print_warning "Restart failed — use Server → Restart."
+                fi
+            else
+                print_info "Later: Modules → c<num> (Configure) on City Bots does the import."
+            fi
+            ;;
     esac
 }
 
@@ -6056,6 +6223,7 @@ menu_modules() {
                     mod-learn-spells)            configure_module_learn_spells ;;
                     mod-profession-progression)  configure_module_profession_progression ;;
                     mod-mount-scaling)           configure_module_mount_scaling ;;
+                    mod-city-bots)               configure_module_city_bots ;;
                     *)
                         print_info "$name has no dedicated configure option."
                         print_info "Edit its .conf file in $SERVER_DIR/env/dist/etc/modules/ directly."

--- a/guides/wow-wotlk/wow-manage.sh
+++ b/guides/wow-wotlk/wow-manage.sh
@@ -1104,7 +1104,7 @@ declare -a MODULE_REGISTRY=(
     "mod-transmog|Transmogrification|https://github.com/azerothcore/mod-transmog.git|world,characters"
     "mod-profession-progression|Profession Progression (unlock extra profession slots by leveling)|https://github.com/TopHatMan/mod-profession-progression.git|"
     "mod-mount-scaling|Mount Scaling (level-based progressive mount speed)|https://github.com/claudevandort/mod-mount-scaling.git|world"
-    "mod-city-bots|City Bots (fixed 400-bot city ambience cast — needs Playerbots)|https://github.com/pjerra/mod-city-bots.git|auth,characters,world"
+    "mod-city-bots|City Bots (400-bot city cast — needs Playerbots)|https://github.com/pjerra/mod-city-bots.git|auth,characters,world"
 )
 
 # ─────────────────────────────────────────────────────────────
@@ -2791,45 +2791,81 @@ configure_module_learn_spells() {
 #   update tracking: the core never sees that file, so nothing re-applies.
 # ─────────────────────────────────────────────────────────────
 CITY_BOTS_ROSTER_REL="data/sql/playerbots/updates/2026_07_15_00_citizen_roster.sql"
-CITY_BOTS_ROSTER_IMPORTED=0
+CITY_BOTS_ROSTER_IMPORTED=0     # set by city_bots_import_roster on a verified import
+CITY_BOTS_WORLD_RESTARTED=0     # set when the import stopped+started ac-worldserver itself
 
+# Resolve a compose service's RUNNING container for THIS install (not the
+# first name-match on the host — several AzerothCore stacks can coexist).
+_city_bots_service_container() {
+    local svc="$1" id=""
+    id=$(cd "$SERVER_DIR" 2>/dev/null && docker compose ps -q "$svc" 2>/dev/null | head -1)
+    [ -n "$id" ] && docker ps --format '{{.ID}}' 2>/dev/null | grep -q "^${id:0:12}" && echo "$id"
+}
+
+city_bots_db_query() {
+    docker exec "$DB_CONTAINER" mysql -uroot -p"$DB_ROOT_PASSWORD" -N -e "$1" 2>/dev/null | tail -1
+}
 city_bots_roster_count() {
-    docker exec "$DB_CONTAINER" mysql -uroot -p"$DB_ROOT_PASSWORD" -N \
-        -e "SELECT COUNT(*) FROM acore_playerbots.citizen_roster;" 2>/dev/null | tail -1
+    city_bots_db_query "SELECT COUNT(*) FROM acore_playerbots.citizen_roster;"
+}
+city_bots_account_type_count() {
+    city_bots_db_query "SELECT COUNT(*) FROM acore_playerbots.playerbots_account_type WHERE account_id BETWEEN 12001 AND 12400 AND account_type = 3;"
 }
 
 city_bots_import_roster() {
+    CITY_BOTS_ROSTER_IMPORTED=0
+    CITY_BOTS_WORLD_RESTARTED=0
     local roster="$SERVER_DIR/modules/mod-city-bots/$CITY_BOTS_ROSTER_REL"
     if [ ! -f "$roster" ]; then
         print_error "Roster SQL not found: $roster"
         return 1
     fi
+    if [ ! -d "$SERVER_DIR/modules/mod-playerbots" ]; then
+        print_error "mod-playerbots is not under modules/ — City Bots is a Playerbots extension; acore_playerbots would never be created."
+        return 1
+    fi
 
-    refresh_container_names
-    if ! container_running "$DB_CONTAINER"; then
+    # Database container: prefer this install's compose project, fall back to
+    # the host-wide name match the rest of this script uses.
+    local db_id; db_id=$(_city_bots_service_container ac-database)
+    if [ -n "$db_id" ]; then
+        DB_CONTAINER="$db_id"
+    else
+        refresh_container_names
+    fi
+    if [ -z "$db_id" ] && ! container_running "$DB_CONTAINER"; then
         print_info "Database container is not running — starting it..."
         (cd "$SERVER_DIR" && docker compose up -d ac-database 2>/dev/null) || true
         local w
         for w in $(seq 1 12); do
-            refresh_container_names
-            container_running "$DB_CONTAINER" && break
+            db_id=$(_city_bots_service_container ac-database)
+            [ -n "$db_id" ] && { DB_CONTAINER="$db_id"; break; }
             sleep 5
         done
-        if ! container_running "$DB_CONTAINER"; then
+        if [ -z "$db_id" ]; then
             print_error "Database container did not start."
             return 1
         fi
     fi
+    # "container running" is not "mysql ready"
+    local m
+    for m in $(seq 1 24); do
+        docker exec "$DB_CONTAINER" mysqladmin ping -uroot -p"$DB_ROOT_PASSWORD" --silent >/dev/null 2>&1 && break
+        [ "$m" -eq 1 ] && print_info "Waiting for MySQL to accept connections..."
+        sleep 5
+    done
 
     # acore_playerbots is created by worldserver on its first start with
-    # mod-playerbots. Right after a rebuild it can take a moment to appear.
-    local i have_db=""
-    for i in $(seq 1 "${CITY_BOTS_DB_WAIT:-24}"); do
-        have_db=$(docker exec "$DB_CONTAINER" mysql -uroot -p"$DB_ROOT_PASSWORD" -N \
-            -e "SHOW DATABASES LIKE 'acore_playerbots';" 2>/dev/null | tail -1)
+    # mod-playerbots. Only a running worldserver can make it appear, so only
+    # wait while one is running; otherwise probe once and say what to do.
+    local world_id; world_id=$(_city_bots_service_container ac-worldserver)
+    local i have_db="" wait_n=1
+    [ -n "$world_id" ] && wait_n="${CITY_BOTS_DB_WAIT:-60}"   # × 5 s
+    for i in $(seq 1 "$wait_n"); do
+        have_db=$(city_bots_db_query "SHOW DATABASES LIKE 'acore_playerbots';")
         [ -n "$have_db" ] && break
-        [ "$i" -eq 1 ] && print_info "Waiting for database acore_playerbots (created on the first worldserver start with Playerbots)..."
-        sleep 5
+        [ "$i" -eq 1 ] && [ "$wait_n" -gt 1 ] && print_info "Waiting for database acore_playerbots (created by the starting worldserver, up to $(( wait_n * 5 / 60 )) min)..."
+        [ "$wait_n" -gt 1 ] && sleep 5
     done
     if [ -z "$have_db" ]; then
         print_error "acore_playerbots does not exist yet."
@@ -2838,24 +2874,61 @@ city_bots_import_roster() {
         return 1
     fi
 
+    # Any existing rows = this is a (destructive) re-import: the roster file
+    # drops/recreates citizen_roster and rewrites account_type rows 12001-12400.
     local before; before=$(city_bots_roster_count)
-    if [ "${before:-0}" -ge 400 ] 2>/dev/null; then
-        print_info "citizen_roster already holds $before rows."
-        if ! ask_yes_no "Re-import the shipped roster anyway (resets roster rows to the shipped cast)?"; then
+    if [ "${before:-0}" -gt 0 ] 2>/dev/null; then
+        print_warning "citizen_roster already holds $before rows."
+        print_info "Re-importing resets the roster (and playerbots_account_type 12001-12400) to the shipped cast;"
+        print_info "hand-edited roster rows are lost."
+        if ! ask_yes_no "Re-import the shipped roster anyway?"; then
             return 0
         fi
     fi
 
+    # Do not rewrite the roster under a running worldserver: stop it for the
+    # import (the server needs a restart to pick the roster up anyway).
+    local stopped_world=0
+    world_id=$(_city_bots_service_container ac-worldserver)
+    if [ -n "$world_id" ]; then
+        print_info "worldserver is running. The roster is only read at startup, so a restart is needed either way."
+        if ask_yes_no "Stop the worldserver for the import and start it again afterwards? (recommended)"; then
+            (cd "$SERVER_DIR" && docker compose stop -t 60 ac-worldserver) || print_warning "Could not stop ac-worldserver — importing anyway."
+            stopped_world=1
+        else
+            print_warning "Importing while the worldserver runs; city bots pick it up after your next restart."
+        fi
+    fi
+
     print_info "Importing roster into acore_playerbots..."
-    local out; out=$(sqlmod_run_sql_file acore_playerbots "$roster")
-    local after; after=$(city_bots_roster_count)
-    if [ "${after:-0}" -ge 400 ] 2>/dev/null; then
-        print_success "City Bots roster imported ($after entries)."
+    local out rc
+    out=$(sqlmod_run_sql_file acore_playerbots "$roster"); rc=$?
+    local after_roster after_types
+    after_roster=$(city_bots_roster_count)
+    after_types=$(city_bots_account_type_count)
+
+    local ok=0
+    if [ "$rc" -eq 0 ] && [ "${after_roster:-0}" -eq 400 ] 2>/dev/null && [ "${after_types:-0}" -eq 400 ] 2>/dev/null; then
+        ok=1
+    fi
+
+    if [ "$stopped_world" -eq 1 ]; then
+        print_info "Starting the worldserver again..."
+        if (cd "$SERVER_DIR" && docker compose start ac-worldserver); then
+            CITY_BOTS_WORLD_RESTARTED=1
+        else
+            print_warning "Could not start ac-worldserver — use Server Controls → Start."
+        fi
+    fi
+
+    if [ "$ok" -eq 1 ]; then
+        print_success "City Bots roster imported and verified (400 roster rows, 400 citybot account types)."
         CITY_BOTS_ROSTER_IMPORTED=1
         return 0
     fi
-    print_error "Roster import failed (citizen_roster has ${after:-0} rows)."
-    [ -n "$out" ] && echo "$out" | grep -v "Using a password" | tail -5 | sed 's/^/  /'
+    print_error "Roster import failed (mysql rc=$rc; citizen_roster rows=${after_roster:-0}, account types=${after_types:-0}; both must be 400)."
+    [ -n "$out" ] && echo "$out" | grep -v "Using a password" | tail -8 | sed 's/^/  /'
+    print_info "Fix the error above and re-run Modules → c<num> (Configure) on City Bots."
     return 1
 }
 
@@ -2873,10 +2946,6 @@ configure_module_city_bots() {
         print_error "City Bots module not installed (expected at $module_dir)."
         return 1
     fi
-    if [ ! -d "$SERVER_DIR/modules/mod-playerbots" ]; then
-        print_warning "mod-playerbots not found under modules/ — City Bots is a Playerbots extension and will not work without it."
-    fi
-
     echo ""
     print_info "Step 1/2 — roster import into acore_playerbots (the one file AzerothCore never auto-applies)."
     city_bots_import_roster || true
@@ -2902,8 +2971,13 @@ configure_module_city_bots() {
         _open_text_file "$conf_dest"
     fi
     echo ""
-    print_info "Restart the worldserver so it loads the roster and conf (Server → Restart)."
-    print_info "Expected log line: 'mod-city-bots: stage cast loaded: 400 roster entries'."
+    if [ "$CITY_BOTS_WORLD_RESTARTED" = 1 ]; then
+        print_info "worldserver was restarted around the import; city bots log in after random-bot autologin."
+    else
+        print_info "Restart the worldserver so it loads the roster and conf (Server Controls → Restart)."
+    fi
+    print_info "Expected log line: 'mod-city-bots: stage cast loaded: 400/400 roster entries'."
+    print_info "Removing the module later: data/sql/uninstall/ in the module has the manual cleanup SQL."
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -5319,6 +5393,8 @@ _get_about_text() {
                 'Install: clone -> rebuild -> server starts once -> Configure' \
                 'imports the roster into acore_playerbots (the core updater' \
                 'never applies data/sql/playerbots) -> restart.' \
+                'Remove (r<num>) keeps the 400 accounts/characters and the roster;' \
+                'the module ships data/sql/uninstall/ for manual cleanup.' \
                 '' \
                 'Commands: (none — everything is driven by mod_city_bots.conf)'
             ;;
@@ -5971,8 +6047,10 @@ _module_post_install_hook() {
             print_info "Order: rebuild → server starts once (creates acore_playerbots) → import roster → restart."
             if ask_yes_no "Import the City Bots roster and set up its conf now?"; then
                 configure_module_city_bots
-                if [ "$CITY_BOTS_ROSTER_IMPORTED" = 1 ] && ask_yes_no "Restart the worldserver now so the city bots log in?"; then
-                    (cd "$SERVER_DIR" && docker compose restart ac-worldserver) || print_warning "Restart failed — use Server → Restart."
+                if [ "$CITY_BOTS_ROSTER_IMPORTED" = 1 ] && [ "$CITY_BOTS_WORLD_RESTARTED" != 1 ] \
+                   && [ -n "$(_city_bots_service_container ac-worldserver)" ] \
+                   && ask_yes_no "Restart the worldserver now so the city bots log in? (only useful once it was rebuilt with City Bots)"; then
+                    (cd "$SERVER_DIR" && docker compose restart -t 60 ac-worldserver) || print_warning "Restart failed — use Server Controls → Restart."
                 fi
             else
                 print_info "Later: Modules → c<num> (Configure) on City Bots does the import."


### PR DESCRIPTION
Adds **City Bots** (https://github.com/pjerra/mod-city-bots — deadtrickz's 400-bot city ambience cast, needs Playerbots) to `guides/wow-wotlk/wow-manage.sh`'s Modules menu.

## Why a dedicated entry
The module's roster lives in `data/sql/playerbots/updates/2026_07_15_00_citizen_roster.sql`. AzerothCore's updater never applies a module's `data/sql/playerbots/` — mod-playerbots updates `acore_playerbots` with its own `DatabaseLoader` that carries no modules list (confirmed in the Playerbot-branch source). `db-auth/db-characters/db-world` auto-apply; the roster must be imported once after `acore_playerbots` exists (first worldserver start with Playerbots). This was the cause of the module's "crash on fresh install" report (pjerra/mod-city-bots#1, fixed there for the auto-applied part); wow-manage's generic "SQL auto-applies, no manual import" message is wrong for this one file.

## What's added (single file, additive)
- `MODULE_REGISTRY` entry, `MODULE_UPDATE_FILES` rows (repair menu), About text.
- `city_bots_import_roster`: resolves this install's `ac-database`/`ac-worldserver` via `docker compose ps -q` (host-wide name match as fallback), waits for MySQL and — only while a worldserver is running — for `acore_playerbots` (up to 5 min; single probe otherwise), prompts before any destructive re-import (roster has rows), offers to stop the worldserver (`-t 60`) for the import and start it afterwards, imports via the existing `sqlmod_run_sql_file`, checks mysql rc **and** verifies 400 roster rows + 400 citybot `account_type` rows before claiming success.
- `configure_module_city_bots` (`c<num>`): roster import + `mod_city_bots.conf` from `conf.dist`, editor offer.
- `_module_post_install_hook` case: explains rebuild → first start → import → restart and offers to do it.
- `module_install` prints the one exception to "SQL auto-applies".

## Testing
Functions exercised against a throwaway `mysql:8.4` with the mod-playerbots base tables (print/ask/container helpers stubbed): missing mod-playerbots → early error; missing DB with no worldserver → 3 s, clear message; empty roster → verified import; re-import declined → no-op; **partial failure** (account_type table dropped → mysql rc 1, error shown, not reported as success); configure → conf created; customized roster (10 rows) → prompt; DB container stopped → clean failure. `bash -n` passes. Not run: the full interactive menu on a real install.

Reviewed by three independent passes (code-reviewer agent, superpowers reviewer, Codex adversarial); their findings are the second commit.

