### PR TITLE
the pwd import cannot be typed for Windows and Linux at once — and CI could only ever see one of them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,20 @@ jobs:
       - name: black (format check)
         run: python -m black --check .
 
-      - name: mypy (types)
+      # Three platforms, because a POSIX-only or Windows-only import is red on
+      # whichever platform it was not written for, and one run can only ever
+      # see one of them. `pwd` shipped twice in one day - once needing a
+      # `type: ignore` (green on the Windows box it was written on, red here)
+      # and once without one (green here, red for every Windows developer).
+      # Neither could be caught by a checker that runs Linux only.
+      - name: mypy (types, this platform)
         run: python -m mypy yulon main.py
+
+      - name: mypy (types, as Windows)
+        run: python -m mypy --platform win32 yulon main.py
+
+      - name: mypy (types, as macOS)
+        run: python -m mypy --platform darwin yulon main.py
 
       - name: pytest (tests)
         run: python -m pytest -q

--- a/pylauncher/yulon/platform.py
+++ b/pylauncher/yulon/platform.py
@@ -1649,11 +1649,23 @@ def _linux_user(explicit: str | None) -> str:
                 return invoker
     if euid is not None:
         try:
-            import pwd
-
-            # `str()` because mypy runs on Windows here, where the POSIX stub
-            # is not resolvable — the guard above is what makes the call safe
-            # at runtime, not the type checker.
+            # Imported dynamically for the same reason `_registry_search_path()`
+            # imports `winreg` that way, and the reason `runner.open_pty()`
+            # fetches `os.openpty` that way: the module is POSIX-only and this
+            # file is type-checked for BOTH platforms.
+            #
+            # THE TWO OBVIOUS SPELLINGS ARE EACH RED WHERE THE OTHER IS GREEN.
+            # `import pwd` + a direct call is `Module has no attribute
+            # "getpwuid"` on Windows, where the stub does not resolve. Adding
+            # `# type: ignore[attr-defined]` fixes that and is then an
+            # `unused-ignore` error on Linux, where it does — `pyproject.toml`
+            # sets `warn_unused_ignores = true`. This project is developed on
+            # Windows and its CI runs Linux, so each spelling passes for its
+            # author and fails for everyone else; both have now shipped and
+            # both have been reverted (2026-08-24). A dynamic import is `Any`,
+            # so neither checker has anything to say, and `str()` is what keeps
+            # the promise this signature makes.
+            pwd = importlib.import_module("pwd")
             return str(pwd.getpwuid(euid).pw_name)
         except (ImportError, KeyError):
             logger.info(f"no passwd entry for uid {euid}; falling back to the environment")


### PR DESCRIPTION
CI went red on the merge commit for #92, and the `6.5 fix` that turned it green
broke the same line for every Windows checkout. Both are correct fixes for the
platform they were written on. The line simply cannot be spelled either way.

`pwd` is POSIX-only:

- `import pwd` + a direct call is `Module has no attribute "getpwuid"` on
  Windows, where the stub does not resolve.
- Adding `# type: ignore[attr-defined]` fixes that, and is then
  `Unused "type: ignore"` on Linux, where it does resolve — `pyproject.toml`
  sets `warn_unused_ignores = true`.

This project is developed on Windows and its CI runs Linux, so each spelling
passes for whoever wrote it and fails for everyone else. Measured both ways on
one box with mypy's own `--platform` flag:

| | `mypy` on Windows | `mypy --platform linux` |
|---|---|---|
| with the ignore | clean | `Unused "type: ignore"` |
| without it (`6.5 fix`) | `Module has no attribute "getpwuid"` | clean |
| `importlib.import_module("pwd")` | clean | clean |

**The fix is the idiom this file already uses twice.** `_registry_search_path()`
imports `winreg` dynamically and its docstring gives exactly this reason, and
the `ctypes.windll` call at platform.py:2399 spells out the trap in a comment:
"a `type: ignore` for that is itself an error when the same checker runs on a
developer's Windows box". A dynamic import is `Any`, so neither checker has
anything to say; `str()` keeps the promise the signature makes.

**CI now runs mypy three times** — host, `--platform win32`, `--platform
darwin`. A Linux-only run can only ever catch the direction pointed at it,
which is why it caught the first spelling and waved the second one through.
Adds about five seconds.

Verified clean on all three platform settings. 783 passed, 20 skipped.
