### PR TITLE
the packaged launcher broke every tool it shells out to, then blamed the machine

### DIFF
--- a/pylauncher/tests/test_runner.py
+++ b/pylauncher/tests/test_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import subprocess
 import threading
 import time
@@ -200,3 +201,131 @@ def test_interact_cancel_interrupts_a_child_stuck_on_a_prompt(tmp_path: Path) ->
         lines.append(line)
     assert time.monotonic() - started < 20  # would never return before this fix
     assert lines and lines[0] == "hello"
+
+
+# ---------------------------------------------------- the frozen library path
+# The bug these cover shipped and could not be seen from here: it exists ONLY
+# in the packaged app, and everything in this file runs from source.
+
+
+def _frozen(monkeypatch: pytest.MonkeyPatch, **env: str) -> None:
+    """Pretend to be the PyInstaller bundle, with the environment it creates."""
+    monkeypatch.setattr(runner.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(runner.os, "environ", dict(env))
+
+
+def test_running_from_source_leaves_the_child_environment_alone() -> None:
+    """None means "inherit", which is what every caller has always got.
+
+    The fix must not change the unfrozen case at all: the bug does not exist
+    there, and a source checkout that suddenly spawns children with a rebuilt
+    environment would be a new bug wearing the old one's clothes.
+    """
+    assert runner.child_env() is None
+    assert runner.child_env({"A": "1"}) == {"A": "1"}
+
+
+@pytest.mark.parametrize(
+    "var", ["LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH", "LIBPATH"]
+)
+def test_a_frozen_launcher_hands_back_the_users_own_loader_path(
+    monkeypatch: pytest.MonkeyPatch, var: str
+) -> None:
+    """PyInstaller saves the pre-launch value; the child must get THAT one.
+
+    Parametrised across all four because the bug is one bug and a fix applied
+    to `LD_LIBRARY_PATH` alone is a fix on Linux only - macOS carries the same
+    breakage under two different names.
+    """
+    _frozen(monkeypatch, **{var: "/bundle/_internal", f"{var}_ORIG": "/opt/mine/lib"})
+    got = runner.child_env()
+    assert got is not None
+    assert got[var] == "/opt/mine/lib"
+    assert f"{var}_ORIG" not in got
+
+
+@pytest.mark.parametrize("orig", ["", None])
+def test_a_frozen_launcher_unsets_a_path_the_user_never_had(
+    monkeypatch: pytest.MonkeyPatch, orig: str | None
+) -> None:
+    """No _ORIG, or an empty one, means it was unset before the bundle set it.
+
+    Unset is not the same as empty: an empty `LD_LIBRARY_PATH` means "look in
+    the current directory" to some loaders, so leaving one behind would swap a
+    library-path bug for a subtler one. Measured inside the real AppImage:
+    `LD_LIBRARY_PATH_ORIG` is present and EMPTY there, which is exactly this
+    case and the one that bites (2026-08-24).
+    """
+    env = {"LD_LIBRARY_PATH": "/bundle/_internal"}
+    if orig is not None:
+        env["LD_LIBRARY_PATH_ORIG"] = orig
+    _frozen(monkeypatch, **env)
+    got = runner.child_env()
+    assert got is not None
+    assert "LD_LIBRARY_PATH" not in got
+    assert "LD_LIBRARY_PATH_ORIG" not in got
+
+
+def test_a_caller_supplied_environment_is_sanitised_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`platform._c_locale_env()` copies os.environ, so it carries the poison.
+
+    A caller passing an environment is not opting out of this - it is usually
+    os.environ plus one key, which is the exact shape that hands the bundle's
+    libraries to a child while looking deliberate.
+    """
+    _frozen(monkeypatch)
+    poisoned = {"LC_ALL": "C", "LD_LIBRARY_PATH": "/bundle/_internal"}
+    got = runner.child_env(poisoned)
+    assert got == {"LC_ALL": "C"}
+
+
+def test_every_spawn_site_in_this_module_sanitises_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Asked of the seam, not of the source.
+
+    Grepping for `child_env(` would pass on a call that computes the right
+    environment and then throws it away, and the defect being guarded against
+    is precisely a spawn site that forgets. So each entry point is driven and
+    the environment `subprocess` was actually handed is read back.
+    """
+    _frozen(monkeypatch, LD_LIBRARY_PATH="/bundle/_internal", PATH="/usr/bin")
+    seen: list[dict[str, str] | None] = []
+
+    class _Proc:
+        returncode = 0
+        pid = 1234
+
+        def __init__(self, *a: object, **kw: object) -> None:
+            seen.append(kw.get("env"))  # type: ignore[arg-type]
+            # Real file objects: `stream()` asserts on both and iterates stdout,
+            # so a double with None here fails for the wrong reason.
+            self.stdout = io.StringIO("")
+            self.stderr = io.StringIO("")
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def poll(self) -> int:
+            return 0
+
+        def kill(self) -> None:
+            return None
+
+    def fake_run(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+        seen.append(kw.get("env"))  # type: ignore[arg-type]
+        return subprocess.CompletedProcess([], 0, "", "")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+    monkeypatch.setattr(runner.subprocess, "Popen", _Proc)
+
+    runner.run(["true"])
+    runner.run(["true"], env={"LD_LIBRARY_PATH": "/bundle/_internal", "X": "1"})
+    list(runner.stream(["true"]))
+
+    assert seen, "no spawn site was reached; this test is measuring nothing"
+    for env in seen:
+        assert env is not None, "a frozen spawn passed env=None and so inherited the bundle's path"
+        assert "LD_LIBRARY_PATH" not in env, env

--- a/pylauncher/yulon/apply.py
+++ b/pylauncher/yulon/apply.py
@@ -183,7 +183,7 @@ class DockerSql:
                 # (2026-08-23).
                 errors="replace",
                 check=False,
-                env=self._env(),
+                env=runner.child_env(self._env()),
                 creationflags=runner.creationflags(),
             )
         except OSError as exc:

--- a/pylauncher/yulon/controller_wow_wotlk/console.py
+++ b/pylauncher/yulon/controller_wow_wotlk/console.py
@@ -196,6 +196,7 @@ def send_command(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             bufsize=0,
+            env=runner.child_env(),
             creationflags=runner.creationflags(),
         )
     except OSError as exc:

--- a/pylauncher/yulon/controller_wow_wotlk/maintenance.py
+++ b/pylauncher/yulon/controller_wow_wotlk/maintenance.py
@@ -336,7 +336,7 @@ class DockerMysql:
                 stdout=stdout if stdout is not None else subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=False,
-                env=mysql_env(self.root_password),
+                env=runner.child_env(mysql_env(self.root_password)),
                 creationflags=runner.creationflags(),
             )
         except OSError as exc:

--- a/pylauncher/yulon/platform.py
+++ b/pylauncher/yulon/platform.py
@@ -2538,6 +2538,12 @@ def _spawn_detached(argv: list[str]) -> subprocess.Popen[bytes]:
         argv,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        # Sanitised like every other spawn: this one starts `systemd-inhibit`
+        # or `caffeinate`, and a frozen launcher that hands them its own
+        # libraries gets a keep-awake that silently never starts. Missed on the
+        # first pass of the library-path fix precisely because it is the one
+        # spawn site not in `runner` and not named in `creationflags()`'s list.
+        env=runner.child_env(),
         creationflags=runner.creationflags(),
     )
 

--- a/pylauncher/yulon/runner.py
+++ b/pylauncher/yulon/runner.py
@@ -70,6 +70,68 @@ def creationflags() -> int:
     return int(getattr(subprocess, "CREATE_NO_WINDOW"))  # noqa: B009 - Windows-only attribute
 
 
+_FROZEN_LIBRARY_VARS = (
+    "LD_LIBRARY_PATH",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    "LIBPATH",
+)
+"""Loader search paths PyInstaller rewrites, and children must not inherit.
+
+One per platform family - Linux/BSD, macOS (two of them), AIX - listed together
+because the bug is one bug and a fix applied to some of them is a fix on some
+platforms only.
+"""
+
+
+def child_env(env: Mapping[str, str] | None = None) -> dict[str, str] | None:
+    """The environment a spawned child should actually get.
+
+    THE PACKAGED LAUNCHER BREAKS THE TOOLS IT SHELLS OUT TO, and this is where
+    that stops. PyInstaller points `LD_LIBRARY_PATH` at the bundle's own
+    `_internal` directory so the frozen interpreter finds its libraries. Every
+    child process inherits it, and a system binary that links anything the
+    bundle also ships then loads the BUNDLE's copy. Measured inside the v0.6.5
+    AppImage on Arch, 2026-08-24:
+
+        bash  -> symbol lookup error: undefined symbol: rl_print_keybinding
+        curl  -> libssl.so.3: version `OPENSSL_3.2.0' not found
+                 (required by /usr/lib/libcurl.so.4)
+        git   -> libpcre2-8.so.0: no version information available
+
+    bash dies outright, so `installer.bash_available()` - which runs
+    `bash -c "exit 0"` and is the FIRST subprocess an install makes - answers
+    False, and the user is told "this machine has no working bash" about a
+    machine whose bash is fine. curl loses HTTPS entirely, which is what
+    "refuses to download files" looks like from the outside.
+
+    PyInstaller saves the pre-launch value as `<VAR>_ORIG` for exactly this
+    purpose. Restoring it (or removing the variable when there was nothing to
+    restore) hands the child the environment it would have had if the user had
+    typed the command themselves.
+
+    Returns None when not frozen, so a source checkout keeps inheriting this
+    process's environment exactly as before - the bug does not exist there, and
+    neither should the fix. That asymmetry is also why the whole test suite and
+    the CLI harness stayed green while the shipped artifact could not run
+    `bash`: they never run frozen.
+    """
+    if not getattr(sys, "frozen", False):
+        return dict(env) if env is not None else None
+    base = dict(env) if env is not None else dict(os.environ)
+    for var in _FROZEN_LIBRARY_VARS:
+        original = base.pop(f"{var}_ORIG", None)
+        if original:
+            base[var] = original
+        else:
+            # No _ORIG, or an empty one: the variable was unset before the
+            # bundle set it, so unset is what the child should see. Leaving an
+            # empty string behind is not the same thing - an empty
+            # LD_LIBRARY_PATH means "the current directory" to some loaders.
+            base.pop(var, None)
+    return base
+
+
 def stream(
     command: list[str], cwd: Path | None = None, *, merge_stderr: bool = False
 ) -> Generator[str, None, None]:
@@ -123,6 +185,7 @@ def stream(
         text=True,
         encoding="utf-8",
         errors="replace",
+        env=child_env(),
         creationflags=creationflags(),
     )
     stderr_lines: list[str] = []
@@ -208,7 +271,7 @@ def run(
         return subprocess.run(
             command,
             cwd=_cwd_arg(cwd),
-            env=dict(env) if env is not None else None,
+            env=child_env(env),
             capture_output=True,
             text=True,
             encoding="utf-8",
@@ -401,7 +464,7 @@ def interact(
                 stdin=slave,
                 stdout=slave,
                 stderr=slave,
-                env=dict(env) if env is not None else None,
+                env=child_env(env),
                 bufsize=0,
                 start_new_session=True,  # see _CLAIM_THE_TERMINAL
             )
@@ -412,7 +475,7 @@ def interact(
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                env=dict(env) if env is not None else None,
+                env=child_env(env),
                 bufsize=0,
                 creationflags=creationflags(),
             )


### PR DESCRIPTION
On a clean Arch box, the shipped AppImage cannot run a shell script. Not
`bash -c` specifically — **any** shell script, including the installer scripts
themselves:

```
$ /bin/sh -c 'echo ok'                                    ok
$ LD_LIBRARY_PATH=<bundle>/_internal /bin/sh -c 'echo ok'
  /bin/sh: symbol lookup error: /bin/sh: undefined symbol: rl_print_keybinding
```

PyInstaller points `LD_LIBRARY_PATH` at the bundle's own `_internal` directory so
the frozen interpreter finds its libraries. **Every child process inherits it**,
and a system binary that links anything the bundle also ships loads the bundle's
copy instead of the system's. Measured inside the current build:

| tool | result |
|---|---|
| `bash` / `/bin/sh` | `undefined symbol: rl_print_keybinding` — **fatal** |
| `curl` | `libssl.so.3: version 'OPENSSL_3.2.0' not found (required by libcurl.so.4)` — **fatal for HTTPS** |
| `git` | `libpcre2-8.so.0: no version information available` — degraded |
| `sudo`, `systemctl` | unaffected |

`installer.bash_available()` runs `bash -c "exit 0"` and is the first subprocess
an install makes, so it answers False and the user is told **"this machine has
no working bash"** about a machine whose bash is fine. The launcher broke it and
then reported it as the user's problem. `curl` losing HTTPS is what *"the
installer refuses to download files"* looks like from the outside — which is the
field report this started from.

### Why the test suite is blind to it

788 tests, four mypy platform settings and the CLI harness all run **from
source**, where `LD_LIBRARY_PATH` is unset and the bug cannot exist. It lives
only in the shipped artifact. Same shape as the missing `libxcb-cursor0`: green
everywhere, broken in the one build a user actually runs.

### The fix

PyInstaller saves the pre-launch value as `<VAR>_ORIG` for exactly this purpose.
`runner.child_env()` restores it — or **unsets** the variable when there was
nothing to restore, because an empty `LD_LIBRARY_PATH` means "the current
directory" to some loaders and would trade one library bug for a subtler one.
Inside the real AppImage `LD_LIBRARY_PATH_ORIG` is present and *empty*, so that
is the case that bites, not a hypothetical.

Applied at every spawn site, including the three outside `runner` that
`creationflags()`'s docstring already names (`apply.py`, `maintenance.py`,
`console.py`) and one it does not (`platform._spawn_detached()`, the keep-awake
helper — the second commit). All four loader variables, not just the Linux one:
macOS carries the same breakage under `DYLD_LIBRARY_PATH` and
`DYLD_FRAMEWORK_PATH`, and a fix applied to one name is a fix on one platform.

Not frozen means not touched — `child_env()` returns `None` so a source checkout
inherits the environment exactly as before.

### Verified in a real bundle, not just in tests

A fake `docker` on `PATH` that dumps its own environment, then `--provision` run
against each build on a clean Arch box:

| build | children spawned | their environment |
|---|---|---|
| current `Yulon` | **0** — the shell could not start | — |
| with this fix | **17** | **clean**, no `LD_LIBRARY_PATH` |

Four mutations die: either of two spawn sites reverting, the macOS variables
dropped from the list, and the empty-`_ORIG` branch no longer unsetting. The
spawn-site test drives `run()`/`stream()` and reads back the environment
`subprocess` was actually handed rather than grepping for the call — the defect
being guarded against is a site that computes the right environment and forgets
to pass it.

797 passed, 20 skipped. ruff, black and mypy clean on all four platform settings.
