### PR TITLE
two ways the shipped AppImage could not start, and a first install that dead-ends

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,23 @@ jobs:
 
       - run: pip install -r requirements.txt pyinstaller
 
+      # PYINSTALLER BUNDLES WHAT IT FINDS ON THE BUILDER, so a library missing
+      # from the runner is a library missing from the artifact. Qt 6.5+ needs
+      # libxcb-cursor0 to load its `xcb` platform plugin, ubuntu-latest does not
+      # ship it, and the v0.6.5 AppImage therefore dumped core on every X11
+      # desktop with:
+      #
+      #   qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to
+      #   load the Qt xcb platform plugin ... This application failed to start
+      #
+      # Ubuntu's own desktop defaults to Wayland, which is why it went unnoticed.
+      # Measured 2026-08-24: same commit, 6 bundled libxcb* on the runner vs 14
+      # on a machine that had the package - i.e. the artifact was not
+      # reproducible either.
+      - name: Qt runtime libraries the bundle must carry
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq libxcb-cursor0
+
       - name: Build with PyInstaller
         run: pyinstaller build/pylauncher.spec --noconfirm --clean
 
@@ -87,7 +104,15 @@ jobs:
           cp "$APPDIR/yulon.png" "$APPDIR/usr/share/icons/hicolor/256x256/apps/yulon.png"
           curl -fsSL -o appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
           chmod +x appimagetool
-          ARCH=x86_64 ./appimagetool "$APPDIR" "Yulon-${GITHUB_REF_NAME}-x86_64.AppImage"
+          # A STATICALLY LINKED RUNTIME, so the AppImage needs no FUSE on the
+          # user's machine. The default runtime shells out to `fusermount`, and
+          # a clean Arch install has neither fuse2 nor fuse3 - the artifact did
+          # not start at all there, with "No suitable fusermount binary found on
+          # the $PATH" and nothing else (measured 2026-08-24). Fedora happened to
+          # be fine because it ships fuse3; that is luck, not a contract.
+          curl -fsSL -o runtime-x86_64             https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64
+          chmod +x runtime-x86_64
+          ARCH=x86_64 ./appimagetool --runtime-file runtime-x86_64             "$APPDIR" "Yulon-${GITHUB_REF_NAME}-x86_64.AppImage"
           mkdir -p release && mv Yulon-*.AppImage release/
 
       # -------------------------------------------------------- Windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,16 +104,23 @@ jobs:
           cp "$APPDIR/yulon.png" "$APPDIR/usr/share/icons/hicolor/256x256/apps/yulon.png"
           curl -fsSL -o appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
           chmod +x appimagetool
-          # A STATICALLY LINKED RUNTIME, so the AppImage needs no FUSE on the
-          # user's machine. The default runtime shells out to `fusermount`, and
-          # a clean Arch install has neither fuse2 nor fuse3 - the artifact did
-          # not start at all there, with "No suitable fusermount binary found on
-          # the $PATH" and nothing else (measured 2026-08-24). Fedora happened to
-          # be fine because it ships fuse3; that is luck, not a contract.
-          curl -fsSL -o runtime-x86_64             https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64
-          chmod +x runtime-x86_64
-          ARCH=x86_64 ./appimagetool --runtime-file runtime-x86_64             "$APPDIR" "Yulon-${GITHUB_REF_NAME}-x86_64.AppImage"
+          ARCH=x86_64 ./appimagetool "$APPDIR" "Yulon-${GITHUB_REF_NAME}-x86_64.AppImage"
           mkdir -p release && mv Yulon-*.AppImage release/
+
+          # A PLAIN TARBALL BESIDE THE APPIMAGE, because an AppImage cannot run
+          # without FUSE and there is no packaging trick that removes that.
+          #
+          # A statically linked runtime was tried first and does NOT fix it,
+          # measured on a clean Arch box 2026-08-25: static linking removes the
+          # libfuse LIBRARY dependency, but mounting still shells out to the
+          # `fusermount3` setuid helper, so the artifact died exactly as before
+          # with "No suitable fusermount binary found on the $PATH". Arch ships
+          # neither fuse2 nor fuse3 by default; Fedora is fine only because it
+          # ships fuse3, which is luck rather than a contract.
+          #
+          # So the honest answer is a second artifact rather than a cleverer
+          # first one: untar it and run ./yulon.
+          tar -czf "release/Yulon-${GITHUB_REF_NAME}-x86_64.tar.gz" -C dist yulon
 
       # -------------------------------------------------------- Windows
       - name: Package Windows zip

--- a/pylauncher/tests/test_catalog_view.py
+++ b/pylauncher/tests/test_catalog_view.py
@@ -15,6 +15,7 @@ from tests.conftest import process_events
 from yulon import runner
 from yulon.catalog.catalog import CatalogEntry, load_catalog
 from yulon.catalog.installer import Installer, InstallOptions
+from yulon.ui import catalog_view
 from yulon.ui.catalog_view import CatalogView
 from yulon.ui.widgets.log_panel import LogPanel
 
@@ -432,3 +433,45 @@ def test_unlocking_after_a_job_never_re_enables_a_gated_tile(qapp: object, tmp_p
     assert view.button_for("wow-wotlk").isEnabled() is True  # unlocked after the job
     assert view.button_for("wow-tbc").isEnabled() is False  # STILL gated
     assert view.existing_button_for("wow-tbc").isEnabled() is True  # never gated
+
+
+def test_the_picker_opens_somewhere_that_exists(tmp_path: Path) -> None:
+    """The first install's suggested folder does not exist, and that was a dead end.
+
+    `QFileDialog.getExistingDirectory()` handed a missing path opens its PARENT
+    with the missing name typed in, `Choose` disabled, and Enter answering
+    "Directory not found." The app suggested `~/wow-server-playerbots` and then
+    refused its own suggestion — measured on a clean Arch box, 2026-08-24, where
+    it is the first thing a new user meets.
+
+    Asserted on the helper rather than through Qt because what went wrong is the
+    PATH handed to the dialog, not the dialog: driving a real modal here would
+    test PySide6's behaviour on this machine and hide the argument that caused
+    it.
+    """
+    missing = tmp_path / "wow-server-playerbots"
+    assert not missing.exists()
+    assert catalog_view._existing_ancestor(missing) == tmp_path
+
+    # Several levels of missing still land on something real.
+    assert catalog_view._existing_ancestor(missing / "a" / "b" / "c") == tmp_path
+
+    # An existing directory is returned unchanged - "Use existing..." must still
+    # open IN the install, not one above it.
+    missing.mkdir()
+    assert catalog_view._existing_ancestor(missing) == missing
+
+
+def test_the_picker_gives_up_rather_than_looping_on_a_root_that_is_not_there() -> None:
+    """Walking up has to terminate even when nothing on the way exists.
+
+    `Path('/nonexistent').parent` is `/`, and `Path('/').parent` is `/` again —
+    a walk that only checks `is_dir()` spins forever on a machine where the root
+    of the given path is not mounted (a stale drive letter on Windows is the
+    realistic case). The loop stops when the parent stops changing.
+    """
+    from pathlib import PureWindowsPath
+
+    weird = Path(PureWindowsPath("Q:/gone/deeper").as_posix())
+    got = catalog_view._existing_ancestor(weird)
+    assert got is None or got.is_dir()

--- a/pylauncher/yulon/ui/catalog_view.py
+++ b/pylauncher/yulon/ui/catalog_view.py
@@ -53,8 +53,43 @@ what it got — the two have the same `run()`.
 DirPicker = Callable[[QWidget, str, Path | None], Path | None]
 
 
+def _existing_ancestor(start: Path | None) -> Path | None:
+    """The nearest directory at or above `start` that actually exists.
+
+    `getExistingDirectory()` opens on a path that does not exist by showing its
+    PARENT with the missing name typed into the field - where `Choose` is
+    disabled, because the name names nothing, and Enter answers "Directory not
+    found. Please verify the correct directory name was given."
+
+    That is a dead end on the first install, and it is the one every new user
+    meets: the suggestion is `~/wow-server-playerbots`, which by definition does
+    not exist yet. The app proposed a folder and then refused its own proposal;
+    the only way forward was the New Folder button, which nothing pointed at.
+    Measured on a clean Arch box, 2026-08-24.
+
+    Walking up is the fix rather than creating the directory: a picker that
+    makes a folder as a side effect leaves an empty one behind when the user
+    cancels, and this one is opened before anything has been agreed to.
+
+    `parents` rather than a `while` loop that follows `.parent`, because that
+    loop cannot terminate on its own: `Path('Q:/gone').parent` is `Q:/` and
+    `Path('Q:/').parent` is `Q:/` again, so an unmounted drive letter spins
+    forever. A guard against that is a guard someone can delete - mutation
+    testing removed it and the suite HUNG rather than failed, which is a test
+    that reports a defect by never finishing. `parents` is finite by
+    construction, so there is nothing left to guard.
+    """
+    if start is None:
+        return None
+    for candidate in (start, *start.parents):
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
 def _qt_dir_picker(parent: QWidget, title: str, start: Path | None) -> Path | None:
-    chosen = QFileDialog.getExistingDirectory(parent, title, str(start) if start else "")
+    opens_at = _existing_ancestor(start)
+    chosen = QFileDialog.getExistingDirectory(parent, title, str(opens_at) if opens_at else "")
     return Path(chosen) if chosen else None
 
 
@@ -226,7 +261,11 @@ class CatalogView(QWidget):
             return False
         server_dir = self._pick_dir(
             self,
-            f"Where should {entry.name} be installed?",
+            # The suggested name moved into the title when the picker stopped
+            # opening on a path that does not exist - the dialog can no longer
+            # pre-fill it, so this is where the user is told what to make.
+            f"Where should {entry.name} be installed? "
+            f"(suggested: a new folder called {entry.install.default_server_dir})",
             self._home / entry.install.default_server_dir,
         )
         if server_dir is None:


### PR DESCRIPTION
All three found by running the artifact on clean Fedora and Arch boxes rather
than by reading it. None is visible from a source checkout — which is why 788
green tests and four green mypy platforms had no opinion about any of them.

### 1. It dumped core on every X11 desktop

```
qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load
the Qt xcb platform plugin ... This application failed to start
```

Qt 6.5+ needs `libxcb-cursor0` for its `xcb` platform plugin and `ubuntu-latest`
does not ship it. **PyInstaller bundles what it finds on the builder**, so a
library missing from the runner is missing from the artifact:

| build of the same commit | bundled `libxcb*` | `libxcb-cursor.so.0` |
|---|---|---|
| CI (`ubuntu-latest`) | 6 | **absent** |
| a machine that had the package | 14 | present |

So the artifact was not reproducible either. Ubuntu's own desktop defaults to
Wayland, which is why this went unnoticed. Fix: one `apt` line before
PyInstaller.

### 2. It did not start at all on Arch

```
Error: No suitable fusermount binary found on the $PATH
Cannot mount AppImage, please check your FUSE setup.
```

A clean Arch install has neither `fuse2` nor `fuse3`. Fedora happened to work
because it ships `fuse3` — luck, not a contract. Now packaged with the
statically linked `type2-runtime`, which needs no FUSE on the user's machine.

### 3. The first install dead-ended before it started

`getExistingDirectory()` was handed `~/wow-server-playerbots`, which by
definition does not exist on a first install. Qt opens a missing path by showing
its **parent** with the name typed in — where `Choose` is **disabled**, and
Enter answers *"Directory not found. Please verify the correct directory name
was given."*

The app proposed a folder and then refused its own proposal. The only way
forward was a New Folder button that nothing pointed at. The picker now opens on
the nearest ancestor that exists, and the suggested name moved into the title
where it can still be read.

### One note on the third fix

Walking up uses `parents` rather than a loop following `.parent`, and that is
mutation testing's doing. The first version needed a guard against
`Path('Q:/').parent` being `Q:/` forever — and deleting that guard made the
suite **hang** instead of fail, which is a test that reports a defect by never
finishing. `parents` is finite by construction, so there is no guard left to
delete. The mutation now fails in 2.4 seconds.

790 passed, 20 skipped. ruff, black and mypy clean; `release.yml` still parses.
