### PR TITLE
the native Windows install could not write the folder it bound out

### DIFF
--- a/pylauncher/catalog/installers/wow-wotlk/native/base.yml.tmpl
+++ b/pylauncher/catalog/installers/wow-wotlk/native/base.yml.tmpl
@@ -130,6 +130,7 @@ services:
       # import that never heard of acore_playerbots leaves a worldserver that
       # cannot start its bots.
       AC_PLAYERBOTS_DATABASE_INFO: "ac-database;3306;root;${DB_ROOT_PASSWORD:-{{DB_PASSWORD}}};acore_playerbots"
+    {{CONTAINER_USER}}
     volumes:
       - ./env/dist/etc:/azerothcore/env/dist/etc
       - ./env/dist/logs:/azerothcore/env/dist/logs
@@ -212,6 +213,7 @@ services:
       AC_LOGS_DIR: "/azerothcore/env/dist/logs"
       AC_TEMP_DIR: "/azerothcore/env/dist/temp"
       AC_LOGIN_DATABASE_INFO: "ac-database;3306;root;${DB_ROOT_PASSWORD:-{{DB_PASSWORD}}};acore_auth"
+    {{CONTAINER_USER}}
     volumes:
       - ./env/dist/etc:/azerothcore/env/dist/etc
       - ./env/dist/logs:/azerothcore/env/dist/logs
@@ -259,6 +261,7 @@ services:
       # CONCATENATES ports: across files — never add a second entry for this
       # port anywhere else.
       - "${DOCKER_SOAP_EXTERNAL_PORT:-127.0.0.1:{{SOAP_PORT}}}:7878"
+    {{CONTAINER_USER}}
     volumes:
       # env/dist/etc must be bound out to the host: it is where the module
       # system reads and writes worldserver.conf and every module conf.

--- a/pylauncher/tests/test_composegen.py
+++ b/pylauncher/tests/test_composegen.py
@@ -47,6 +47,82 @@ def render(server_dir: Path) -> composegen.ComposePlan:
     )
 
 
+def _services_with_user_key(base: str) -> set[str]:
+    """Which services carry a service-level `user:`, by indentation.
+
+    Asserted structurally rather than by counting the string: a `user:` that has
+    drifted inside `build:` or `environment:` would satisfy a substring count
+    while doing nothing, and the point of the key is which container it applies
+    to.
+    """
+    services: set[str] = set()
+    service = None
+    for raw in base.split("\n"):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        if indent == 2 and raw.rstrip().endswith(":"):
+            service = raw.strip()[:-1]
+        elif indent == 4 and service and raw.strip().startswith("user:"):
+            services.add(service)
+    return services
+
+
+WRITES_TO_BOUND_ETC = {"ac-db-import", "ac-authserver", "ac-worldserver"}
+
+
+def test_windows_runs_the_env_dist_writers_as_root(tmp_path: Path) -> None:
+    """Without this, the native Windows install cannot finish.
+
+    Docker Desktop mounts a Windows drive into the WSL2 VM over 9p/drvfs with
+    `uid=0;gid=0` and mode 0755, and the images run as `acore` (uid 1000). Every
+    container that must write the bound-out `env/dist` is refused, and
+    `ac-db-import` dies with "cp: cannot create regular file ...: Permission
+    denied" on files whose Windows ACLs give the user full control. Measured on
+    a clean Windows 11 box (2026-08-25): the identical import exits 1 without
+    this key and 0 with it.
+
+    Exactly the three services that mount `env/dist/etc` - a `user:` on the
+    database or the client-data init would be scope nobody asked for.
+    """
+    plan = composegen.render(
+        ENTRY, tmp_path, templates_root=TEMPLATES, platform_id=lambda: "windows"
+    )
+    assert _services_with_user_key(plan.base) == WRITES_TO_BOUND_ETC
+    for service in WRITES_TO_BOUND_ETC:
+        assert f"{service}:" in plan.base
+    assert 'user: "0:0"' in plan.base
+
+
+@pytest.mark.parametrize("platform_id", ["linux", "macos"])
+def test_only_windows_gets_the_root_user(tmp_path: Path, platform_id: str) -> None:
+    """Everywhere else the key would cost more than it buys.
+
+    On Linux, running as root makes every file the container creates root-owned
+    ON THE HOST - and `env/dist/etc` is bound out precisely so the module system
+    and the user can edit `worldserver.conf` and every module conf. Windows pays
+    nothing for it because 9p maps ownership back to the Windows account
+    whatever uid wrote the file, which is why this is gated rather than global.
+    """
+    plan = composegen.render(
+        ENTRY, tmp_path, templates_root=TEMPLATES, platform_id=lambda: platform_id
+    )
+    assert _services_with_user_key(plan.base) == set()
+    assert "0:0" not in plan.base
+
+
+def test_the_container_user_line_is_explained_where_it_is_absent(tmp_path: Path) -> None:
+    """A line that renders to nothing teaches the next reader nothing.
+
+    On the platforms that do not get the key, the template still emits a comment
+    pointing at the function that decided - otherwise the only trace of a real,
+    measured platform difference is an absence, and absences do not survive
+    refactors.
+    """
+    plan = composegen.render(ENTRY, tmp_path, templates_root=TEMPLATES, platform_id=lambda: "linux")
+    assert plan.base.count("# user: left to the image") == len(WRITES_TO_BOUND_ETC)
+
+
 def test_ports_appear_in_exactly_one_file(tmp_path: Path) -> None:
     """`ports:` lives in the base file and NOWHERE else.
 

--- a/pylauncher/yulon/catalog/composegen.py
+++ b/pylauncher/yulon/catalog/composegen.py
@@ -261,6 +261,30 @@ class ComposePlan:
     dotenv: Mapping[str, str]
 
 
+def container_user(platform_id: Callable[[], str] = platform.detect) -> str:
+    """The `user:` line for the services that write to the bound-out env/dist.
+
+    On Windows this is `user: "0:0"`, and it is not a convenience. Docker
+    Desktop mounts a Windows drive into the WSL2 VM over 9p/drvfs with
+    `uid=0;gid=0` and mode 0755; the images run as `acore` (uid 1000); so a
+    container that must write `env/dist/etc` cannot, and `ac-db-import` fails
+    with "cp: cannot create regular file ...: Permission denied" on files whose
+    Windows ACLs give the user full control. Measured on a clean Windows 11 box
+    (2026-08-25): the identical import exits 0 with this key and 1 without it.
+    `DOCKER_USER=root`, which the image's own error text suggests, does nothing
+    here - the generated compose sets no `user:` at all, so the image wins.
+
+    Everywhere else this stays a comment, deliberately. On Linux, running as
+    root makes every file the container creates root-owned ON THE HOST, which
+    breaks the reason `env/dist/etc` is bound out in the first place: the module
+    system and the user edit those files. Windows pays no such price because 9p
+    maps ownership back to the Windows account regardless of the writing uid.
+    """
+    if platform_id() == "windows":
+        return 'user: "0:0"'
+    return "# user: left to the image (acore) - see composegen.container_user()"
+
+
 def render(
     entry: CatalogEntry,
     server_dir: Path,
@@ -313,6 +337,7 @@ def render(
             "DB_PASSWORD": password,
             "IMAGE_PREFIX": DEFAULT_IMAGE_PREFIX,
             "IMAGE_TAG": tag,
+            "CONTAINER_USER": container_user(platform_id),
         },
     )
     override = _fill(


### PR DESCRIPTION
Unblocks 6.3's Definition of done. On a clean Windows 11 box everything works up to the database import — WSL2 install, reboot, Docker Desktop install, engine 29.7.2, GUI, platform gating, clone, and the whole `build_staged()` image build — and then `ac-db-import` exits 1:

```
cp: cannot create regular file '/azerothcore/env/dist/etc/authserver.conf.dist': Permission denied
```

That is the **same sentence** the SELinux fix produced on Fedora, from an entirely unrelated cause. Both times the image blames file ownership, and both times it is wrong.

## What is actually happening

Measured on `yulon-win11` restored from a clean checkpoint, not inferred:

- the generated base compose bind-mounts `./env/dist/etc` and `./env/dist/logs` from a **Windows** path — deliberately; the template's own comment says that directory must be on the host because the module system reads and writes it;
- Docker Desktop mounts Windows drives into the WSL2 VM over **9p/drvfs with `uid=0;gid=0`**, mode `drwxr-xr-x` — read straight out of `/proc/mounts` inside the container;
- the images run as **`acore`**, uid 1000, not root;
- probed on that exact directory: **writable as root, not writable as `--user 1000:1000`**;
- the Windows ACLs are fine (`pk` has FullControl), so the restriction is purely the 9p uid mapping.

`DOCKER_USER=root`, which the image's own error text suggests, does nothing here — the generated compose sets no `user:` key at all, so the image wins. Tried it on the live install before writing this.

## The fix

The three services that mount the bound-out `env/dist` get `user: "0:0"` on Windows.

**Proven on that same failed install:** adding exactly this key to `ac-db-import` and re-running it took the identical import from `exit 1` to **`exit 0`**, with all seven config files written.

**Windows only, and that restriction is the whole design.** On Linux the same key would make every file the container creates root-owned *on the host*, which breaks the one thing binding `env/dist/etc` out is for — the module system, and the user, editing `worldserver.conf`. Windows pays no such price because 9p maps ownership back to the Windows account whatever uid wrote the file.

Where the key is absent the template renders a comment naming the function that decided, so a real, measured platform difference leaves a trace rather than an absence.

## Testing

`819 passed, 27 skipped`. ruff, black and mypy clean on linux/win32/darwin.

The tests assert **which services** carry the key, by indentation rather than by counting a substring — a `user:` that had drifted into `build:` would satisfy a count while doing nothing. Mutation-checked both directions: never emitting it fails the Windows test; always emitting it fails the Linux and macOS ones.

**Not yet run end to end:** that a full clean-box Windows install now *completes*. The key's effect is measured on the live failure and the generated file is asserted structurally, but the whole install has not been repeated from scratch with a rebuilt artifact — that is hours of WSL, Docker Desktop, clone and compile. Happy to run it if you want the box ticked rather than the blocker cleared.
