### PR TITLE
CI is red on Yulon: the SELinux probe lifted two of the four shell functions it runs

### DIFF
--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -583,11 +583,33 @@ def _selinux_free_path(tmp_path: Path) -> str:
     return str(bin_dir)
 
 
+# Every shell function the probe must carry, not just the entry point.
+#
+# `selinux_label_for_containers` calls the other three. An unlifted callee is
+# not an absent behaviour - it is `command not found`, which exits 127, which
+# `if ! selinux_labels_supported ...` reads as "this filesystem cannot hold
+# labels", so the function returns having relabelled nothing and the test sees
+# an empty list. That is exactly how this broke: two of the four were lifted,
+# every positive case asserted [], and it merged because the whole test is
+# skipped on the Windows dev box.
+_SELINUX_FUNCTIONS = (
+    "selinux_is_enforcing",
+    "selinux_labels_supported",
+    "selinux_drop_z_from_override",
+    "selinux_label_for_containers",
+)
+
+
 def _selinux_body(script: Path) -> str:
-    """Both functions, lifted from the shipped script rather than restated."""
+    """Every function in the call graph, lifted from the shipped script.
+
+    Lifted rather than restated so the test cannot pass against a copy of the
+    logic that the product no longer has.
+    """
     text = script.read_text(encoding="utf-8")
     out = []
-    for name in ("selinux_is_enforcing() {", "selinux_label_for_containers() {"):
+    for func in _SELINUX_FUNCTIONS:
+        name = f"{func}() {{"
         assert text.count(name) == 1, f"{script.name}: {name} appears {text.count(name)} times"
         begin = text.index(name)
         out.append(text[begin : text.index("\n}", begin) + 2])
@@ -624,12 +646,21 @@ def _selinux_calls(
         # "this kernel exposes no selinuxfs" looks like.
         "YULON_SELINUX_ENFORCE_PATH": str(sysfs) if sysfs else str(target / "no-selinuxfs"),
     }
-    subprocess.run(
+    result = subprocess.run(
         ["bash", "-c", probe, "probe", str(target)],
         capture_output=True,
         text=True,
         timeout=30,
         env=env,
+    )
+    # A helper the probe forgot to lift is `command not found`, and bash's 127
+    # is indistinguishable from a real "no" to every caller here - it silently
+    # turns "did not relabel" into the answer. Failing on the shell's own
+    # complaint names the missing function; without it the next unlifted callee
+    # arrives as an empty list that reads like a behaviour change.
+    assert "command not found" not in result.stderr, (
+        f"{script.name}: the probe is missing a function the shipped code calls, "
+        f"so its result means nothing:\n{result.stderr.strip()}"
     )
     return [line for line in calls.read_text(encoding="utf-8").splitlines() if line]
 


### PR DESCRIPTION
CI has been red on `Yulon` since the SELinux relabel merged, and every branch cut
from it inherits the failure — #99 included. The product is fine; the test
harness could not run the code it was testing.

## What fails

One test, three parametrisations, both Python versions:

```
test_the_installers_label_the_server_folder_only_where_selinux_enforces
AssertionError: assert [] == ['chcon -Rt container_file_t .../server/env']
```

## Why

The probe lifts shell functions out of the shipped installer and runs them, so
the test asserts against the product rather than a restatement of it. It lifted
**two**. `selinux_label_for_containers` calls **four**.

The two it missed do not come back as absent behaviour. They come back as
`command not found`, which exits **127**, and

```sh
if ! selinux_labels_supported "$1"; then
```

reads 127 as *"this filesystem cannot hold SELinux labels"* — so the function
takes the drop-`:z` branch and returns having relabelled nothing. Every positive
case then asserts an empty list, which looks exactly like a deliberate decision
not to relabel.

Reproduced outside pytest on Ubuntu 22.04 before touching anything:

```
stderr: selinux_labels_supported: command not found
        selinux_drop_z_from_override: command not found
calls emitted : []
```

## How it got in

The test is `skipif(sys.platform.startswith("win"))`. On the Windows dev box it
is one of the 20 skips — so the suite that was run before merging never executed
the test that checks the shell scripts. The local run was green and honest; it
simply had nothing to say about this file.

## The fix, and the part that matters more

Lifting all four functions fixes today.

The assertion on the probe's stderr is what stops tomorrow. Bash's 127 is
indistinguishable from a real "no" to every caller in that function, so the next
helper added to the shipped code would arrive here as another empty list that
reads like a behaviour change. Failing on the shell's own complaint names the
missing function instead:

```
install-wow-wotlk.sh: the probe is missing a function the shipped code calls,
so its result means nothing:
selinux_labels_supported: command not found
```

## Verification

Run on Ubuntu 22.04 — all three installers, all six cases plus both directory
assertions, **24 checks, all passing**, with the old two-function lift kept as a
negative control and still emitting `[]`:

```
=== install-wow-wotlk.sh
  PASS  sysfs=1 beats getenforce Disabled
  PASS  sysfs=0 beats getenforce Enforcing
  PASS  no sysfs, getenforce Enforcing
  PASS  no sysfs, getenforce Permissive
  PASS  no sysfs, getenforce Disabled
  PASS  no sysfs, no tools on PATH
  PASS  env/dist/etc created up front
  PASS  env/dist/logs created up front
  ... (fedora and ubuntu variants identical)

=== negative control: the OLD two-function lift must still be broken
  old lift emitted [] -> PASS (still broken, as CI reported)
```

Suite 815 passed / 27 skipped; ruff, black, mypy clean.
