### PR TITLE
The Fedora installer reboots your computer, and the consent banner never said so

### DIFF
--- a/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
+++ b/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
@@ -424,6 +424,21 @@ clone_source() {
     fi
 
     mkdir -p "$SERVER_DIR" "$SERVER_DIR/data"
+
+    # Keep the generated root password somewhere other than the compose file.
+    # It is interpolated into MARIADB_ROOT_PASSWORD below and was otherwise
+    # unrecoverable, so the launcher had no way to reach this server's database
+    # and fell back to a default that was simply wrong. Same shape as the TBC
+    # and Vanilla installers: reload it when it already exists, so re-running
+    # the script against an existing database does not lock itself out.
+    pw_file="$SERVER_DIR/.db_password"
+    if [ -f "$pw_file" ]; then
+        DB_PASSWORD=$(cat "$pw_file")
+        print_info "Loaded existing database password from previous install."
+    else
+        echo "$DB_PASSWORD" > "$pw_file"
+        chmod 600 "$pw_file"
+    fi
     print_info "Cloning $SOURCE_REPO ..."
     if ! git clone --depth 1 "$SOURCE_REPO" "$SERVER_DIR/src"; then
         print_error "git clone failed."; exit 1

--- a/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
+++ b/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
@@ -431,13 +431,34 @@ clone_source() {
     # and fell back to a default that was simply wrong. Same shape as the TBC
     # and Vanilla installers: reload it when it already exists, so re-running
     # the script against an existing database does not lock itself out.
-    pw_file="$SERVER_DIR/.db_password"
-    if [ -f "$pw_file" ]; then
+    local pw_file="$SERVER_DIR/.db_password"
+    local db_password_loaded=false
+    if [ -s "$pw_file" ]; then
+        # -s, not -f: a zero-byte file is not a password, and treating one as
+        # "loaded" would hand MariaDB an empty root password and report success.
         DB_PASSWORD=$(cat "$pw_file")
+        db_password_loaded=true
         print_info "Loaded existing database password from previous install."
     else
-        echo "$DB_PASSWORD" > "$pw_file"
+        # Created empty and locked down BEFORE the secret goes in: writing first
+        # and chmod-ing after leaves it world-readable in between.
+        rm -f "$pw_file"
+        (umask 077; : > "$pw_file")
         chmod 600 "$pw_file"
+        echo "$DB_PASSWORD" > "$pw_file"
+    fi
+
+    # A generated password is only ever applied to an EMPTY database volume:
+    # MariaDB reads MARIADB_ROOT_PASSWORD on first init and never again. So a
+    # new password beside a surviving volume is a database nothing can log into.
+    if [ "$db_password_loaded" = false ]; then
+        local db_volume
+        db_volume="$(basename "$SERVER_DIR")_dbdata"
+        if docker volume ls -q 2>/dev/null | grep -qx "$db_volume"; then
+            print_warning "Found a database volume from an earlier install whose password is"
+            print_warning "unknown - removing it so the database re-initialises with this one."
+            docker volume rm "$db_volume" 2>/dev/null || true
+        fi
     fi
     print_info "Cloning $SOURCE_REPO ..."
     if ! git clone --depth 1 "$SOURCE_REPO" "$SERVER_DIR/src"; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -1854,8 +1854,11 @@ exec > >(tee -a "$INSTALL_LOG") 2>&1
 
 echo ""
 echo -e "\033[1;33m⚠️  This installer needs sudo access for:\033[0m"
-echo -e "\033[1;33m   • Installing Docker (if not present)\033[0m"
-echo -e "\033[1;33m   • Fixing file ownership after build\033[0m"
+echo -e "\033[1;33m   • Installing Docker and the packages it needs, if they are missing\033[0m"
+echo -e "\033[1;33m   • Enabling and starting the Docker service\033[0m"
+echo -e "\033[1;33m   • Adding you to the docker group, which you are asked about first\033[0m"
+echo -e "\033[1;33m   • Running docker itself, until that group membership takes effect\033[0m"
+echo -e "\033[1;33m   • Deleting the old server folder - only if you choose to reinstall\033[0m"
 echo ""
 echo -e "\033[1;37mPlease enter your password if prompted:\033[0m"
 if ! sudo -v; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -1860,6 +1860,7 @@ echo -e "\033[1;33m   • Adding you to the docker group, which you are asked ab
 echo -e "\033[1;33m   • Running docker itself, until that group membership takes effect\033[0m"
 echo -e "\033[1;33m   • Deleting the old server folder - only if you choose to reinstall\033[0m"
 echo -e "\033[1;33m   • Adding Docker's package repository to this system\033[0m"
+echo -e "\033[1;33m   • Removing conflicting packages before installing Docker CE, including podman-docker and moby-engine\033[0m"
 echo -e "\033[1;33m   • Restarting your computer - immutable Fedora (Silverblue, Bazzite) can only layer packages across a reboot, and this installer triggers one\033[0m"
 echo ""
 echo -e "\033[1;37mPlease enter your password if prompted:\033[0m"

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -1859,6 +1859,8 @@ echo -e "\033[1;33m   • Enabling and starting the Docker service\033[0m"
 echo -e "\033[1;33m   • Adding you to the docker group, which you are asked about first\033[0m"
 echo -e "\033[1;33m   • Running docker itself, until that group membership takes effect\033[0m"
 echo -e "\033[1;33m   • Deleting the old server folder - only if you choose to reinstall\033[0m"
+echo -e "\033[1;33m   • Adding Docker's package repository to this system\033[0m"
+echo -e "\033[1;33m   • Restarting your computer - immutable Fedora (Silverblue, Bazzite) can only layer packages across a reboot, and this installer triggers one\033[0m"
 echo ""
 echo -e "\033[1;37mPlease enter your password if prompted:\033[0m"
 if ! sudo -v; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -1674,6 +1674,7 @@ echo -e "\033[1;33m   • Adding you to the docker group, which you are asked ab
 echo -e "\033[1;33m   • Running docker itself, until that group membership takes effect\033[0m"
 echo -e "\033[1;33m   • Deleting the old server folder - only if you choose to reinstall\033[0m"
 echo -e "\033[1;33m   • Adding Docker's apt repository to this system\033[0m"
+echo -e "\033[1;33m   • Removing conflicting packages before installing Docker CE, including podman-docker, containerd and runc\033[0m"
 echo -e "\033[1;33m   • Removing a conflicting Docker snap, if one is installed\033[0m"
 echo ""
 echo -e "\033[1;37mPlease enter your password if prompted:\033[0m"

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -1674,6 +1674,7 @@ echo -e "\033[1;33m   • Adding you to the docker group, which you are asked ab
 echo -e "\033[1;33m   • Running docker itself, until that group membership takes effect\033[0m"
 echo -e "\033[1;33m   • Deleting the old server folder - only if you choose to reinstall\033[0m"
 echo -e "\033[1;33m   • Adding Docker's apt repository to this system\033[0m"
+echo -e "\033[1;33m   • Removing a conflicting Docker snap, if one is installed\033[0m"
 echo ""
 echo -e "\033[1;37mPlease enter your password if prompted:\033[0m"
 if ! sudo -v; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -1668,8 +1668,12 @@ exec > >(tee -a "$INSTALL_LOG") 2>&1
 
 echo ""
 echo -e "\033[1;33m⚠️  This installer needs sudo access for:\033[0m"
-echo -e "\033[1;33m   • Installing Docker (if not present)\033[0m"
-echo -e "\033[1;33m   • Fixing file ownership after build\033[0m"
+echo -e "\033[1;33m   • Installing Docker and the packages it needs, if they are missing\033[0m"
+echo -e "\033[1;33m   • Enabling and starting the Docker service\033[0m"
+echo -e "\033[1;33m   • Adding you to the docker group, which you are asked about first\033[0m"
+echo -e "\033[1;33m   • Running docker itself, until that group membership takes effect\033[0m"
+echo -e "\033[1;33m   • Deleting the old server folder - only if you choose to reinstall\033[0m"
+echo -e "\033[1;33m   • Adding Docker's apt repository to this system\033[0m"
 echo ""
 echo -e "\033[1;37mPlease enter your password if prompted:\033[0m"
 if ! sudo -v; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -1807,8 +1807,13 @@ exec > >(tee -a "$INSTALL_LOG") 2>&1
 
 echo ""
 echo -e "\033[1;33m⚠️  This installer needs sudo access for:\033[0m"
-echo -e "\033[1;33m   • Installing Docker (if not present)\033[0m"
-echo -e "\033[1;33m   • Fixing file ownership after build\033[0m"
+echo -e "\033[1;33m   • Installing Docker and the packages it needs, if they are missing\033[0m"
+echo -e "\033[1;33m   • Enabling and starting the Docker service\033[0m"
+echo -e "\033[1;33m   • Adding you to the docker group, which you are asked about first\033[0m"
+echo -e "\033[1;33m   • Running docker itself, until that group membership takes effect\033[0m"
+echo -e "\033[1;33m   • Deleting the old server folder - only if you choose to reinstall\033[0m"
+echo -e "\033[1;33m   • Turning the SteamOS read-only root off, and back on afterwards\033[0m"
+echo -e "\033[1;33m   • Repairing the pacman keyring, if package installs fail\033[0m"
 echo ""
 echo -e "\033[1;37mPlease enter your password if prompted:\033[0m"
 if ! sudo -v; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -1813,6 +1813,7 @@ echo -e "\033[1;33m   • Adding you to the docker group, which you are asked ab
 echo -e "\033[1;33m   • Running docker itself, until that group membership takes effect\033[0m"
 echo -e "\033[1;33m   • Deleting the old server folder - only if you choose to reinstall\033[0m"
 echo -e "\033[1;33m   • Turning the SteamOS read-only root off, and back on afterwards\033[0m"
+echo -e "\033[1;33m   • Turning on SteamOS developer mode\033[0m"
 echo -e "\033[1;33m   • Repairing the pacman keyring, if package installs fail\033[0m"
 echo ""
 echo -e "\033[1;37mPlease enter your password if prompted:\033[0m"

--- a/pylauncher/main.py
+++ b/pylauncher/main.py
@@ -68,6 +68,12 @@ def build_window() -> object:
         from yulon.controller_wow_wotlk import repair as wotlk_repair
 
         spec = entry.container_spec()
+        # Not `db_password()` here, deliberately: this factory has no server_dir,
+        # and the password only reaches the two import seams below, which are
+        # wired solely for an entry that names an `import_service`. wow-wotlk is
+        # the only one and it carries a fixed password, so a game that GENERATES
+        # its password can never reach this line. The Server tab's copy of this
+        # wiring does have a server_dir, and does read the file.
         password = entry.install.db_root_password or wotlk_modules.DEFAULT_DB_ROOT_PASSWORD
         sql = DockerSql(spec.db, password)
         mysql = wotlk_maintenance.DockerMysql(spec.db, password)

--- a/pylauncher/tests/test_catalog.py
+++ b/pylauncher/tests/test_catalog.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
@@ -100,3 +102,57 @@ def test_unknown_game_and_bad_entries_are_rejected() -> None:
             }
         )
     assert CATALOG_FILE.name == "catalog.json"
+
+
+def test_db_password_prefers_a_fixed_one_then_the_generated_file(tmp_path: Path) -> None:
+    """Where the root password comes from, for a game that does not have a fixed one.
+
+    `db_root_password_file` was declared in the schema and read nowhere, so
+    every caller fell back to the shared default - which for TBC and Vanilla is
+    simply the wrong password, because their installers generate one. Start and
+    Stop need no database, so it would have surfaced on Create account.
+    """
+    catalog = load_catalog()
+
+    wotlk = catalog.get("wow-wotlk").install
+    assert wotlk.db_password(tmp_path) == "password", "a fixed password wins outright"
+
+    tbc = catalog.get("wow-tbc").install
+    assert tbc.db_root_password_file, "wow-tbc is expected to generate its password"
+    assert tbc.db_password(tmp_path) is None, "no file yet, so nothing is knowable"
+
+    (tmp_path / tbc.db_root_password_file).write_text("tbcdeadbeef\n", encoding="utf-8")
+    assert tbc.db_password(tmp_path) == "tbcdeadbeef", "read, and stripped of its newline"
+
+    (tmp_path / tbc.db_root_password_file).write_text("   \n", encoding="utf-8")
+    assert tbc.db_password(tmp_path) is None, "a blank file is not a password"
+
+
+def test_db_password_is_none_when_the_file_cannot_be_read(tmp_path: Path) -> None:
+    """A directory where the password file should be is unreadable, not empty.
+
+    None rather than the default on purpose: the caller is then free to say the
+    password is unknown instead of authenticating with a guess.
+    """
+    tbc = load_catalog().get("wow-tbc").install
+    assert tbc.db_root_password_file
+    (tmp_path / tbc.db_root_password_file).mkdir()
+    assert tbc.db_password(tmp_path) is None
+
+
+def test_every_game_says_how_its_db_password_can_be_known() -> None:
+    """A game that declares neither is a controller that cannot use its database.
+
+    The app needs the root password for every SQL-backed control - accounts,
+    backup, restore, the repair probes. An entry that names no fixed password
+    AND no generated-password file silently resolves to the shared default,
+    which is right only by accident. This is the invariant that caught
+    wow-tortoise: its installer generates `tortoise$(date +%s | tail -c 6)` and
+    the catalog declared nothing at all.
+    """
+    for entry in load_catalog().games:
+        install = entry.install
+        assert install.db_root_password or install.db_root_password_file, (
+            f"{entry.id} declares neither db_root_password nor db_root_password_file, "
+            f"so the app would authenticate to its database with the shared default"
+        )

--- a/pylauncher/tests/test_catalog_view.py
+++ b/pylauncher/tests/test_catalog_view.py
@@ -30,10 +30,18 @@ CATALOG = load_catalog()
 class _FakeInstaller(Installer):
     """An `Installer` whose run() is a canned stream; preflight is a no-op."""
 
-    def __init__(self, entry: CatalogEntry, lines: list[str], *, installs: bool = True) -> None:
+    def __init__(
+        self,
+        entry: CatalogEntry,
+        lines: list[str],
+        *,
+        installs: bool = True,
+        compose_name: str = "docker-compose.yml",
+    ) -> None:
         super().__init__(entry, docker_check=lambda: True)
         self.lines = lines
         self.installs = installs
+        self.compose_name = compose_name
         self.ran_with: list[InstallOptions] = []
         self.cancels: list[threading.Event | None] = []
         self.asks: list[object] = []
@@ -54,14 +62,16 @@ class _FakeInstaller(Installer):
         self.cancels.append(cancel)
         self.asks.append(ask)
         yield from self.lines
-        # A real install leaves a `docker-compose.yml` in the server dir: it
-        # comes out of the clone, and it is the one artefact every install of
-        # every game has. `installs=False` models the OTHER way these scripts
-        # exit 0 — "Keeping existing install — exiting." — which the view must
-        # not read as a finished install.
+        # A real install leaves a compose file in the server dir, and that is the
+        # one artefact every install of every game has — but NOT always under the
+        # same name, which is what `compose_name` exists to model: the WotLK and
+        # Tortoise scripts write `docker-compose.yml`, the TBC and Vanilla ones
+        # write `compose.yml`. `installs=False` models the OTHER way these
+        # scripts exit 0 — "Keeping existing install — exiting." — which the view
+        # must not read as a finished install.
         if self.installs and opts.server_dir is not None:
             opts.server_dir.mkdir(parents=True, exist_ok=True)
-            (opts.server_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+            (opts.server_dir / self.compose_name).write_text("services: {}\n", encoding="utf-8")
 
 
 class _CancellableInstaller(Installer):
@@ -194,6 +204,73 @@ def test_use_existing_registers_a_folder_that_holds_an_install(
     (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
     assert view.attach_existing(CATALOG.get("wow-wotlk")) is True
     assert got == [("wow-wotlk", tmp_path, None)]
+
+
+@pytest.mark.parametrize("compose_name", ["compose.yml", "compose.yaml", "docker-compose.yaml"])
+def test_use_existing_accepts_every_name_compose_itself_accepts(
+    qapp: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, compose_name: str
+) -> None:
+    """A server the app cannot see is a server the app cannot manage.
+
+    The TBC and Vanilla installers write `compose.yml`; only WotLK and Tortoise
+    write `docker-compose.yml`. The view checked for the latter alone, so a TBC
+    install could finish a multi-hour compile and "Use existing…" would still
+    say there was nothing there — measured 2026-08-25. Docker Compose has
+    accepted all four spellings for years and picks whichever it finds, so the
+    app has no business being stricter than the tool it drives.
+    """
+    from PySide6.QtWidgets import QMessageBox
+
+    monkeypatch.setattr(
+        runner, "run", lambda cmd, cwd=None, timeout=None: _completed()  # type: ignore[arg-type]
+    )
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)  # type: ignore[attr-defined]
+    panel = LogPanel()
+    view = CatalogView(
+        CATALOG,
+        lambda e: _FakeInstaller(e, []),
+        panel,
+        pick_dir=lambda *_: tmp_path,
+        home=tmp_path,
+    )
+    got: list[tuple[str, object, object]] = []
+    view.installed.connect(lambda g, s, c: got.append((g, s, c)))
+    (tmp_path / compose_name).write_text("services: {}\n", encoding="utf-8")
+    assert view.attach_existing(CATALOG.get("wow-wotlk")) is True
+    assert got == [("wow-wotlk", tmp_path, None)]
+
+
+def test_an_install_that_wrote_compose_yml_is_remembered(
+    qapp: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same blindness on the other path, and this one costs a whole install.
+
+    `start_install()` refuses to remember a folder with no compose file, which
+    is right — exit 0 is not proof of an install. But it asked only for
+    `docker-compose.yml`, so a successful TBC or Vanilla install was discarded
+    at the finish line and the user was told there was nothing installed.
+    """
+    ran: list[list[str]] = []
+    monkeypatch.setattr(
+        runner, "run", lambda cmd, cwd=None, timeout=None: ran.append(cmd) or _completed()  # type: ignore[func-returns-value]
+    )
+    panel = LogPanel()
+    view = CatalogView(
+        CATALOG,
+        lambda e: _FakeInstaller(e, ["done"], compose_name="compose.yml"),
+        panel,
+        pick_dir=lambda *_: tmp_path,
+        home=tmp_path,
+        platform_id=lambda: "linux",
+    )
+    events: list[str] = []
+    view.install_finished.connect(lambda g, ok, m: events.append(f"finished:{ok}"))
+    view.installed.connect(lambda g, s, c: events.append("installed"))
+
+    assert view.start_install(CATALOG.get("wow-wotlk")) is True
+    _wait(panel)
+    assert "installed" in events, f"a finished install was discarded: {events}"
+    assert "finished:True" in events
 
 
 def test_use_existing_does_not_pin_the_compose_project(

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -720,6 +720,102 @@ def test_the_installers_label_the_server_folder_only_where_selinux_enforces(
     assert (target / "env" / "dist" / "logs").is_dir()
 
 
+# What the sudo banner is allowed to claim, and the command that has to back it.
+#
+# A banner shown immediately before `sudo -v` is a PROMISE about what the
+# password will be used for, and it is the only such promise the user gets. It
+# had been claiming "Fixing file ownership after build" since before there was
+# anything to own: the WotLK scripts contain no `chown` at all, so a password
+# was being asked for work that never happened - while four things sudo really
+# does (starting the Docker service, joining the docker group, running docker
+# before that membership is live, and `rm -rf` on the server folder) went
+# unmentioned.
+#
+# Keyed on a phrase in the bullet rather than the whole line so the wording
+# stays free to improve; the regex is what makes the claim true.
+SUDO_BANNER_CLAIMS: dict[str, str] = {
+    "Installing Docker": r"sudo (pacman|dnf|apt-get|rpm-ostree)",
+    "Docker service": r"sudo systemctl (enable|start|restart) docker",
+    "docker group": r"sudo usermod -aG docker",
+    "Running docker": r"sudo docker\b",
+    "old server folder": r'sudo rm -rf "?\$SERVER_DIR',
+    "SteamOS": r"sudo steamos-readonly",
+    "pacman keyring": r"sudo rm -rf /etc/pacman\.d/gnupg",
+    "apt repository": r"sudo tee /etc/apt/sources\.list\.d/docker\.list",
+}
+
+
+def _sudo_banner_bullets(text: str) -> list[str]:
+    """The bullet lines between the banner header and the password prompt."""
+    begin = text.index("This installer needs sudo access for")
+    end = text.index("Please enter your password", begin)
+    return [line for line in text[begin:end].splitlines() if "\u2022" in line]
+
+
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_the_sudo_banner_only_claims_things_the_script_actually_does(script_name: str) -> None:
+    """The password prompt must not ask for work the script never performs.
+
+    Measured 2026-08-25: all three scripts promised "Fixing file ownership after
+    build" and none of them contains a `chown` - the only match in each file is
+    a comment. The banner is the whole of the user's informed consent here, so a
+    claim with nothing behind it is the same defect as an unannounced
+    escalation, pointing the other way.
+
+    Asserted against the emitted argv rather than prose, which is the same rule
+    the docker-group tests follow: a promise spelled one way in a banner and
+    another in the commands is exactly what this caught.
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    text = script.read_text(encoding="utf-8")
+    bullets = _sudo_banner_bullets(text)
+    assert bullets, f"{script_name}: no bullets found under the sudo banner"
+
+    for bullet in bullets:
+        keys = [k for k in SUDO_BANNER_CLAIMS if k in bullet]
+        assert keys, (
+            f"{script_name}: the banner claims something with no known backing command:\n"
+            f"  {bullet.strip()}\n"
+            f"Either drop the claim or add it to SUDO_BANNER_CLAIMS with the command that "
+            f"makes it true."
+        )
+        assert len(keys) == 1, f"{script_name}: bullet matches {keys}, which is ambiguous"
+        pattern = SUDO_BANNER_CLAIMS[keys[0]]
+        assert re.search(pattern, text), (
+            f"{script_name}: the banner promises {keys[0]!r} but nothing in the script "
+            f"matches {pattern!r} - the password is being asked for work that never runs."
+        )
+
+
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_the_sudo_banner_names_every_privileged_thing_the_script_does(script_name: str) -> None:
+    """And the other direction: a real use of sudo must be declared.
+
+    The first version of this pair only checked that claims were backed, which
+    would have passed a banner listing one true thing and hiding four others -
+    which is what the scripts actually shipped. Both directions or neither.
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    text = script.read_text(encoding="utf-8")
+    bullets = " ".join(_sudo_banner_bullets(text))
+    for key, pattern in SUDO_BANNER_CLAIMS.items():
+        if re.search(pattern, text):
+            assert key in bullets, (
+                f"{script_name}: the script runs {pattern!r} under sudo but the banner never "
+                f"mentions {key!r}, so the user consents to less than they get."
+            )
+
+
 def _override_volumes(script: Path) -> dict[str, list[str]]:
     """Volumes per service from the override heredoc, by structure not substring.
 

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -720,125 +720,180 @@ def test_the_installers_label_the_server_folder_only_where_selinux_enforces(
     assert (target / "env" / "dist" / "logs").is_dir()
 
 
-# What the sudo banner is allowed to claim, and the command that has to back it.
+# The sudo banner, checked against the argv the script actually runs.
 #
-# A banner shown immediately before `sudo -v` is a PROMISE about what the
-# password will be used for, and it is the only such promise the user gets. It
-# had been claiming "Fixing file ownership after build" since before there was
-# anything to own: the WotLK scripts contain no `chown` at all, so a password
-# was being asked for work that never happened - while four things sudo really
-# does (starting the Docker service, joining the docker group, running docker
-# before that membership is live, and `rm -rf` on the server folder) went
-# unmentioned.
+# A banner shown immediately before `sudo -v` is the whole of the user's
+# informed consent, and it is checked in BOTH directions off this one table:
+# every bullet must be backed by a command, and every privileged command must
+# have a bullet. The second is the one with teeth - the first version of this
+# check was a closed world of hand-written keys, so `sudo systemctl reboot`
+# (five sites in the Fedora installer, four of them with no confirmation at all)
+# sat behind a test whose docstring claimed a real use of sudo must be declared.
 #
-# Keyed on a phrase in the bullet rather than the whole line so the wording
-# stays free to improve; the regex is what makes the claim true.
-SUDO_BANNER_CLAIMS: dict[str, str] = {
-    "Installing Docker": r"sudo (pacman|dnf|apt-get|rpm-ostree)",
-    "Docker service": r"sudo systemctl (enable|start|restart) docker",
-    "docker group": r"sudo usermod -aG docker",
-    "Running docker": r"sudo docker\b",
-    "old server folder": r'sudo rm -rf "?\$SERVER_DIR',
-    "SteamOS": r"sudo steamos-readonly",
-    "pacman keyring": r"sudo rm -rf /etc/pacman\.d/gnupg",
-    "apt repository": r"sudo tee /etc/apt/sources\.list\.d/docker\.list",
+# Keyed on a phrase in the bullet so wording stays free to improve, and valued
+# by the VERBS that justify it, taken from the same extraction the reverse
+# direction uses - so the two can never disagree about what a script does.
+SUDO_BANNER_CLAIMS: dict[str, frozenset[str]] = {
+    "Installing Docker": frozenset({"dnf", "apt-get", "pacman", "rpm-ostree install"}),
+    "Docker service": frozenset(
+        {
+            "systemctl enable",
+            "systemctl start",
+            "systemctl restart",
+            "systemctl daemon-reload",
+            "systemctl reset-failed",
+        }
+    ),
+    "docker group": frozenset({"usermod"}),
+    "Running docker": frozenset({"docker"}),
+    "old server folder": frozenset({"rm"}),
+    "repository": frozenset({"tee", "install", "curl", "bash", "chmod"}),
+    "Restarting your computer": frozenset({"systemctl reboot"}),
+    "Docker snap": frozenset({"snap remove"}),
+    "SteamOS read-only root": frozenset({"steamos-readonly enable", "steamos-readonly disable"}),
+    "developer mode": frozenset({"steamos-devmode"}),
+    "pacman keyring": frozenset(
+        {"pacman-key --init", "pacman-key --populate", "pacman-key --list-keys"}
+    ),
 }
 
+# Privileged calls that need no bullet, each with the reason it needs none.
+# Anything NOT here and not in a claim above fails the suite by name.
+SUDO_EXEMPT: dict[str, str] = {
+    "-v": "the credential prompt itself - this IS the thing the banner introduces",
+    "true": "`sudo -n true`, the keepalive that refreshes the cache already granted",
+    "systemctl status": "read-only diagnostics",
+    "systemctl is-active": "read-only diagnostics",
+    "journalctl": "read-only diagnostics",
+}
 
-def test_compose_file_finds_every_name_and_prefers_composes_own_order(tmp_path: Path) -> None:
-    """`compose_file()` answers what Docker Compose would answer.
+# `sudo` inside an echo/print_* line is advice being PRINTED, not run - the
+# installers tell the user what to type when something fails, and counting that
+# as an action would make every one of those messages a consent obligation.
+_SUDO_CALL = re.compile(r"(?<![\w-])sudo\s+((?:-\w+\s+)*)([\w./-]+)(?:\s+([\w-]+))?")
+_NOT_A_CALL = re.compile(r"^\s*#|^\s*(echo|print_\w+|printf)\b")
+_PRINTED = re.compile(r"(echo|print_\w+|printf)\b[^\n]*sudo")
 
-    Order matters and is not ours to invent: Compose reads `compose.yaml` first
-    and falls back through `compose.yml`, `docker-compose.yaml`,
-    `docker-compose.yml`. A folder holding two of them is not hypothetical - a
-    script-installed server that the native engine later writes into would have
-    exactly that - and answering with the one Compose ignores would have the app
-    reading a file the daemon never loads.
-    """
-    assert installer_module.compose_file(tmp_path) is None
-
-    (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
-    assert installer_module.compose_file(tmp_path) == tmp_path / "docker-compose.yml"
-
-    (tmp_path / "compose.yaml").write_text("services: {}\n", encoding="utf-8")
-    assert installer_module.compose_file(tmp_path) == tmp_path / "compose.yaml"
+# Programs whose SUBCOMMAND changes what the user is consenting to. Enabling a
+# service and rebooting the machine are both `systemctl`, and collapsing them
+# would hide the reboot behind the service bullet.
+_SUBCOMMAND_MATTERS = frozenset(
+    {"systemctl", "rpm-ostree", "steamos-readonly", "snap", "pacman-key"}
+)
 
 
-def test_compose_file_ignores_a_directory_of_that_name(tmp_path: Path) -> None:
-    """`is_file()`, not `exists()` - a directory called `compose.yml` is not an install."""
-    (tmp_path / "compose.yml").mkdir()
-    assert installer_module.compose_file(tmp_path) is None
+def _sudo_verbs(text: str) -> dict[str, int]:
+    """Every executable `sudo` call in `text`, normalised to a verb, with its line."""
+    found: dict[str, int] = {}
+    for number, line in enumerate(text.splitlines(), 1):
+        if _NOT_A_CALL.match(line) or _PRINTED.search(line):
+            continue
+        for _flags, program, sub in _SUDO_CALL.findall(line):
+            verb = f"{program} {sub}" if program in _SUBCOMMAND_MATTERS and sub else program
+            found.setdefault(verb, number)
+    return found
 
 
 def _sudo_banner_bullets(text: str) -> list[str]:
-    """The bullet lines between the banner header and the password prompt."""
-    begin = text.index("This installer needs sudo access for")
-    end = text.index("Please enter your password", begin)
-    return [line for line in text[begin:end].splitlines() if "\u2022" in line]
+    """The bullet lines between the banner header and the password prompt.
 
-
-@pytest.mark.parametrize(
-    "script_name",
-    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
-)
-def test_the_sudo_banner_only_claims_things_the_script_actually_does(script_name: str) -> None:
-    """The password prompt must not ask for work the script never performs.
-
-    Measured 2026-08-25: all three scripts promised "Fixing file ownership after
-    build" and none of them contains a `chown` - the only match in each file is
-    a comment. The banner is the whole of the user's informed consent here, so a
-    claim with nothing behind it is the same defect as an unannounced
-    escalation, pointing the other way.
-
-    Asserted against the emitted argv rather than prose, which is the same rule
-    the docker-group tests follow: a promise spelled one way in a banner and
-    another in the commands is exactly what this caught.
+    Anchored on the `echo` that prints the header rather than on the text
+    appearing anywhere, so a comment quoting the banner cannot shadow it.
     """
-    script = (
+    header = re.search(r"^echo .*This installer needs sudo access for", text, re.MULTILINE)
+    assert header, "no sudo banner header found"
+    end = text.index("Please enter your password", header.start())
+    return [line for line in text[header.start() : end].splitlines() if "\u2022" in line]
+
+
+def _wotlk_script(script_name: str) -> Path:
+    return (
         Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
     )
-    text = script.read_text(encoding="utf-8")
+
+
+WOTLK_SCRIPTS = [
+    "install-wow-wotlk.sh",
+    "install-wow-wotlk-fedora.sh",
+    "install-wow-wotlk-ubuntu.sh",
+]
+
+
+@pytest.mark.parametrize("script_name", WOTLK_SCRIPTS)
+def test_the_sudo_banner_declares_every_privileged_thing_the_script_does(script_name: str) -> None:
+    """No privileged action may be absent from the banner - and none may be unknown.
+
+    This is the direction that failed before. It used to iterate the claims
+    table, so a command outside it could never be required; `sudo systemctl
+    reboot` was exactly that, and the Fedora installer reboots the machine after
+    a 10-second sleep with no confirmation on four of its five paths. Now the
+    iteration is over what the SCRIPT does, and a verb this table has never
+    heard of fails by name rather than passing by omission.
+    """
+    text = _wotlk_script(script_name).read_text(encoding="utf-8")
+    bullets = " ".join(_sudo_banner_bullets(text))
+    for verb, line in sorted(_sudo_verbs(text).items()):
+        if verb in SUDO_EXEMPT:
+            continue
+        claims = [phrase for phrase, verbs in SUDO_BANNER_CLAIMS.items() if verb in verbs]
+        assert claims, (
+            f"{script_name}:{line}: `sudo {verb}` is a privileged action this table has never "
+            f"heard of. Add it to SUDO_BANNER_CLAIMS with the bullet that discloses it, or to "
+            f"SUDO_EXEMPT with the reason it needs none. Do not leave it unlisted: that is how "
+            f"a reboot shipped undisclosed."
+        )
+        assert any(phrase in bullets for phrase in claims), (
+            f"{script_name}:{line}: the script runs `sudo {verb}` but no banner bullet mentions "
+            f"{' or '.join(repr(c) for c in claims)}, so the user consents to less than they get."
+        )
+
+
+@pytest.mark.parametrize("script_name", WOTLK_SCRIPTS)
+def test_the_sudo_banner_claims_nothing_the_script_does_not_do(script_name: str) -> None:
+    """And the other way: a promise with nothing behind it.
+
+    All three scripts used to promise "Fixing file ownership after build" and
+    none of them contains a `chown` - the only match in each file is a comment,
+    which is why this now reads extracted argv rather than the file's text.
+    """
+    text = _wotlk_script(script_name).read_text(encoding="utf-8")
+    present = set(_sudo_verbs(text))
     bullets = _sudo_banner_bullets(text)
     assert bullets, f"{script_name}: no bullets found under the sudo banner"
 
     for bullet in bullets:
-        keys = [k for k in SUDO_BANNER_CLAIMS if k in bullet]
-        assert keys, (
+        phrases = [phrase for phrase in SUDO_BANNER_CLAIMS if phrase in bullet]
+        assert phrases, (
             f"{script_name}: the banner claims something with no known backing command:\n"
             f"  {bullet.strip()}\n"
-            f"Either drop the claim or add it to SUDO_BANNER_CLAIMS with the command that "
-            f"makes it true."
+            f"Either drop the claim, or add it to SUDO_BANNER_CLAIMS with the verbs that make "
+            f"it true."
         )
-        assert len(keys) == 1, f"{script_name}: bullet matches {keys}, which is ambiguous"
-        pattern = SUDO_BANNER_CLAIMS[keys[0]]
-        assert re.search(pattern, text), (
-            f"{script_name}: the banner promises {keys[0]!r} but nothing in the script "
-            f"matches {pattern!r} - the password is being asked for work that never runs."
-        )
-
-
-@pytest.mark.parametrize(
-    "script_name",
-    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
-)
-def test_the_sudo_banner_names_every_privileged_thing_the_script_does(script_name: str) -> None:
-    """And the other direction: a real use of sudo must be declared.
-
-    The first version of this pair only checked that claims were backed, which
-    would have passed a banner listing one true thing and hiding four others -
-    which is what the scripts actually shipped. Both directions or neither.
-    """
-    script = (
-        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
-    )
-    text = script.read_text(encoding="utf-8")
-    bullets = " ".join(_sudo_banner_bullets(text))
-    for key, pattern in SUDO_BANNER_CLAIMS.items():
-        if re.search(pattern, text):
-            assert key in bullets, (
-                f"{script_name}: the script runs {pattern!r} under sudo but the banner never "
-                f"mentions {key!r}, so the user consents to less than they get."
+        for phrase in phrases:
+            assert SUDO_BANNER_CLAIMS[phrase] & present, (
+                f"{script_name}: the banner promises {phrase!r} but the script runs none of "
+                f"{sorted(SUDO_BANNER_CLAIMS[phrase])} - a password asked for work that never "
+                f"happens."
             )
+
+
+def test_the_verb_extractor_ignores_advice_and_comments() -> None:
+    """The extractor's own trap, pinned.
+
+    The installers print `sudo` commands as advice when something fails, and
+    they carry comments naming commands they no longer run. Counting either as
+    an action would make the banner grow obligations the script does not have -
+    and counting a comment as BACKING is how the first version of this check
+    could be satisfied without any real command at all.
+    """
+    text = (
+        "# sudo rm -rf /etc/pacman.d/gnupg\n"
+        'print_info "  sudo chcon -Rt container_file_t /srv"\n'
+        'echo "run: sudo usermod -aG docker $USER"\n'
+        "sudo systemctl reboot\n"
+        "sudo systemctl enable docker\n"
+    )
+    assert set(_sudo_verbs(text)) == {"systemctl reboot", "systemctl enable"}
 
 
 def _override_volumes(script: Path) -> dict[str, list[str]]:

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -720,6 +720,36 @@ def test_the_installers_label_the_server_folder_only_where_selinux_enforces(
     assert (target / "env" / "dist" / "logs").is_dir()
 
 
+def test_compose_file_answers_in_composes_own_order(tmp_path: Path) -> None:
+    """The order is Compose's, and it is not the obvious one.
+
+    Measured against Docker Compose v5.3.1: with all four names present it
+    reports its own search list - compose.yaml, compose.yml, docker-compose.yml,
+    docker-compose.yaml - so `.yml` beats `.yaml` in the second pair and loses in
+    the first. An earlier version of COMPOSE_FILENAMES had that pair swapped, and
+    the test that claimed to check the order never exercised it.
+    """
+    assert installer_module.compose_file(tmp_path) is None
+
+    (tmp_path / "docker-compose.yaml").write_text("services: {}\n", encoding="utf-8")
+    assert installer_module.compose_file(tmp_path) == tmp_path / "docker-compose.yaml"
+
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    assert installer_module.compose_file(tmp_path) == tmp_path / "docker-compose.yml"
+
+    (tmp_path / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+    assert installer_module.compose_file(tmp_path) == tmp_path / "compose.yml"
+
+    (tmp_path / "compose.yaml").write_text("services: {}\n", encoding="utf-8")
+    assert installer_module.compose_file(tmp_path) == tmp_path / "compose.yaml"
+
+
+def test_compose_file_ignores_a_directory_of_that_name(tmp_path: Path) -> None:
+    """`is_file()`, not `exists()` - a directory called `compose.yml` is not an install."""
+    (tmp_path / "compose.yml").mkdir()
+    assert installer_module.compose_file(tmp_path) is None
+
+
 # The sudo banner, checked against the argv the script actually runs.
 #
 # A banner shown immediately before `sudo -v` is the whole of the user's
@@ -734,7 +764,17 @@ def test_the_installers_label_the_server_folder_only_where_selinux_enforces(
 # by the VERBS that justify it, taken from the same extraction the reverse
 # direction uses - so the two can never disagree about what a script does.
 SUDO_BANNER_CLAIMS: dict[str, frozenset[str]] = {
-    "Installing Docker": frozenset({"dnf", "apt-get", "pacman", "rpm-ostree install"}),
+    "Installing Docker": frozenset(
+        {
+            "dnf install",
+            "apt-get install",
+            "apt-get update",
+            "pacman",
+            "rpm-ostree install",
+        }
+    ),
+    # Taking software OFF the machine is a different consent from putting it on.
+    "Removing conflicting packages": frozenset({"dnf remove", "apt-get remove"}),
     "Docker service": frozenset(
         {
             "systemctl enable",
@@ -746,14 +786,20 @@ SUDO_BANNER_CLAIMS: dict[str, frozenset[str]] = {
     ),
     "docker group": frozenset({"usermod"}),
     "Running docker": frozenset({"docker"}),
-    "old server folder": frozenset({"rm"}),
-    "repository": frozenset({"tee", "install", "curl", "bash", "chmod"}),
+    "old server folder": frozenset({"rm $SERVER_DIR"}),
+    "repository": frozenset({"tee", "install", "curl", "chmod", "bash -c curl", "bash -c echo"}),
     "Restarting your computer": frozenset({"systemctl reboot"}),
     "Docker snap": frozenset({"snap remove"}),
     "SteamOS read-only root": frozenset({"steamos-readonly enable", "steamos-readonly disable"}),
     "developer mode": frozenset({"steamos-devmode"}),
     "pacman keyring": frozenset(
-        {"pacman-key --init", "pacman-key --populate", "pacman-key --list-keys"}
+        {
+            "pacman-key --init",
+            "pacman-key --populate",
+            "pacman-key --list-keys",
+            "pacman-key --refresh-keys",
+            "rm /etc/pacman.d/gnupg",
+        }
     ),
 }
 
@@ -765,32 +811,116 @@ SUDO_EXEMPT: dict[str, str] = {
     "systemctl status": "read-only diagnostics",
     "systemctl is-active": "read-only diagnostics",
     "journalctl": "read-only diagnostics",
+    "dnf list": "read-only query - asks what is installed, changes nothing",
+    "steamos-readonly status": "read-only diagnostics - reports the mode, does not change it",
 }
 
-# `sudo` inside an echo/print_* line is advice being PRINTED, not run - the
-# installers tell the user what to type when something fails, and counting that
-# as an action would make every one of those messages a consent obligation.
-_SUDO_CALL = re.compile(r"(?<![\w-])sudo\s+((?:-\w+\s+)*)([\w./-]+)(?:\s+([\w-]+))?")
+# `sudo` inside an echo/print_* line is usually advice being PRINTED - the
+# installers tell the user what to type when something fails - and counting that
+# as an action would make every one of those messages a consent obligation. But
+# only usually: a `$(...)` on the same line RUNS, and `$(sudo systemctl reboot)`
+# dropped into one of those echoes passed this check until the fragments below
+# existed.
+_SUDO_CALL = re.compile(r"(?<![\w-])sudo\s+((?:-\w+\s+)*)([\w./-]+)((?:\s+[^\s;&|]+)*)")
 _NOT_A_CALL = re.compile(r"^\s*#|^\s*(echo|print_\w+|printf)\b")
 _PRINTED = re.compile(r"(echo|print_\w+|printf)\b[^\n]*sudo")
+_SUBSTITUTION = re.compile(r"\$\(([^()]*)\)")
+# `sudo bash -c '<body>'` runs <body> AS ROOT. Collapsing it to the verb `bash`
+# discarded everything that actually ran, and `bash` was already approved for
+# repository setup - so any command could be hidden inside those quotes.
+_SHELL_C = re.compile(r"""(?<![\w-])sudo\s+(?:-\w+\s+)*(?:bash|sh)\s+-c\s+(['"])(.*?)\1""")
 
 # Programs whose SUBCOMMAND changes what the user is consenting to. Enabling a
 # service and rebooting the machine are both `systemctl`, and collapsing them
-# would hide the reboot behind the service bullet.
+# would hide the reboot behind the service bullet. `rm` is here because the
+# generic script wipes two very different things - the server folder the user
+# chose to reinstall, and the system's pacman keyring.
 _SUBCOMMAND_MATTERS = frozenset(
     {"systemctl", "rpm-ostree", "steamos-readonly", "snap", "pacman-key"}
 )
+# Package managers put flags before the subcommand (`dnf -y install`), while
+# pacman-key's subcommand IS a flag (`--populate`). Reading them the same way
+# filed `pacman-key --populate archlinux holo` under the verb "archlinux".
+_FLAGS_BEFORE_SUBCOMMAND = frozenset({"dnf", "apt-get"})
+_TARGET_MATTERS = frozenset({"rm"})
 
 
-def _sudo_verbs(text: str) -> dict[str, int]:
-    """Every executable `sudo` call in `text`, normalised to a verb, with its line."""
-    found: dict[str, int] = {}
-    for number, line in enumerate(text.splitlines(), 1):
-        if _NOT_A_CALL.match(line) or _PRINTED.search(line):
+def _executable_parts(line: str) -> list[str]:
+    """The parts of `line` that actually run, printed text removed.
+
+    A command substitution runs wherever it appears, including inside the echo
+    that prints its output - which is why it is pulled out before the advisory
+    check rather than after.
+    """
+    parts: list[str] = list(_SUBSTITUTION.findall(line))
+    if not (_NOT_A_CALL.match(line) or _PRINTED.search(line)):
+        parts.append(line)
+    return parts
+
+
+def _normalise(program: str, rest: str) -> str:
+    """One `sudo` call as the verb a user would have to consent to."""
+    words = rest.split()
+    if program in _SUBCOMMAND_MATTERS and words:
+        return f"{program} {words[0]}"
+    if program in _FLAGS_BEFORE_SUBCOMMAND:
+        subcommand = next((w for w in words if not w.startswith("-")), "")
+        return f"{program} {subcommand}" if subcommand else program
+    if program in _TARGET_MATTERS:
+        target = next((w for w in words if not w.startswith("-")), "")
+        return f"{program} {target.strip(chr(34) + chr(39))}" if target else program
+    return program
+
+
+def _logical_lines(text: str) -> list[tuple[int, str]]:
+    """Physical lines joined across backslash continuations, keyed by first line.
+
+    The real `sudo bash -c '...'` in the Fedora installer wraps its body onto a
+    second physical line, so a per-line regex saw an unterminated quote and the
+    body - which runs as root - was never inspected at all.
+    """
+    joined: list[tuple[int, str]] = []
+    number = 0
+    buffer = ""
+    for index, line in enumerate(text.splitlines(), 1):
+        if not buffer:
+            number = index
+        stripped = line.rstrip()
+        if stripped.endswith("\\"):
+            buffer += stripped[:-1] + " "
             continue
-        for _flags, program, sub in _SUDO_CALL.findall(line):
-            verb = f"{program} {sub}" if program in _SUBCOMMAND_MATTERS and sub else program
-            found.setdefault(verb, number)
+        joined.append((number, buffer + line))
+        buffer = ""
+    if buffer:
+        joined.append((number, buffer))
+    return joined
+
+
+def _sudo_verbs(text: str) -> dict[str, list[int]]:
+    """Every executable `sudo` call in `text`, normalised to a verb, with its lines.
+
+    Every line is kept, not just the first: a verb recorded once could be
+    supplied by an unrelated call elsewhere in the file, so deleting the call a
+    bullet actually describes still passed.
+    """
+    found: dict[str, list[int]] = {}
+    for number, line in _logical_lines(text):
+        # `sudo bash -c '<body>'` runs <body> as root. Name the verb after what
+        # the body actually starts with, attributed to the wrapper that gave it
+        # root, so replacing the body changes the verb and fails the check.
+        wrapped = _SHELL_C.findall(line)
+        for _quote, body in wrapped:
+            words = body.strip().split()
+            if words:
+                found.setdefault(f"bash -c {words[0]}", []).append(number)
+        for part in _executable_parts(line):
+            for _flags, program, rest in _SUDO_CALL.findall(part):
+                # Already accounted for, with its body, just above. When the
+                # body could NOT be read the wrapper is left to fail as an
+                # unknown verb rather than vanish.
+                if program in {"bash", "sh"} and wrapped:
+                    continue
+                found.setdefault(_normalise(program, rest), []).append(number)
     return found
 
 
@@ -832,7 +962,8 @@ def test_the_sudo_banner_declares_every_privileged_thing_the_script_does(script_
     """
     text = _wotlk_script(script_name).read_text(encoding="utf-8")
     bullets = " ".join(_sudo_banner_bullets(text))
-    for verb, line in sorted(_sudo_verbs(text).items()):
+    for verb, lines in sorted(_sudo_verbs(text).items()):
+        line = lines[0]
         if verb in SUDO_EXEMPT:
             continue
         claims = [phrase for phrase, verbs in SUDO_BANNER_CLAIMS.items() if verb in verbs]

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -745,6 +745,31 @@ SUDO_BANNER_CLAIMS: dict[str, str] = {
 }
 
 
+def test_compose_file_finds_every_name_and_prefers_composes_own_order(tmp_path: Path) -> None:
+    """`compose_file()` answers what Docker Compose would answer.
+
+    Order matters and is not ours to invent: Compose reads `compose.yaml` first
+    and falls back through `compose.yml`, `docker-compose.yaml`,
+    `docker-compose.yml`. A folder holding two of them is not hypothetical - a
+    script-installed server that the native engine later writes into would have
+    exactly that - and answering with the one Compose ignores would have the app
+    reading a file the daemon never loads.
+    """
+    assert installer_module.compose_file(tmp_path) is None
+
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    assert installer_module.compose_file(tmp_path) == tmp_path / "docker-compose.yml"
+
+    (tmp_path / "compose.yaml").write_text("services: {}\n", encoding="utf-8")
+    assert installer_module.compose_file(tmp_path) == tmp_path / "compose.yaml"
+
+
+def test_compose_file_ignores_a_directory_of_that_name(tmp_path: Path) -> None:
+    """`is_file()`, not `exists()` - a directory called `compose.yml` is not an install."""
+    (tmp_path / "compose.yml").mkdir()
+    assert installer_module.compose_file(tmp_path) is None
+
+
 def _sudo_banner_bullets(text: str) -> list[str]:
     """The bullet lines between the banner header and the password prompt."""
     begin = text.index("This installer needs sudo access for")

--- a/pylauncher/yulon/catalog/catalog.json
+++ b/pylauncher/yulon/catalog/catalog.json
@@ -200,6 +200,7 @@
         ],
         "script": "wow-tortoise/install-tortoise-wow-wsl.sh",
         "default_server_dir": "tortoise-wow-server",
+        "db_root_password_file": ".db_password",
         "requires_client_dir": true
       },
       "containers": {

--- a/pylauncher/yulon/catalog/catalog.py
+++ b/pylauncher/yulon/catalog/catalog.py
@@ -134,6 +134,33 @@ class Install(_Strict):
         default=False,
         description="The script asks for the user's client folder and loops until given one.",
     )
+
+    def db_password(self, server_dir: Path) -> str | None:
+        """The database root password for an install at `server_dir`, if knowable.
+
+        Not every game has a fixed one: the TBC and Vanilla installers GENERATE
+        a password (`tbc$(openssl rand -hex 8)`) and write it to a file under the
+        server dir, which is what `db_root_password_file` names. That field was
+        declared here and read NOWHERE, so every caller fell back to the shared
+        default and authenticated as root with the literal string "password".
+        Start and Stop need no database, which is why it would have surfaced
+        later - on Create account, Backup and Restore.
+
+        Returns None when the entry names a file that cannot be read. That is
+        deliberately not the same answer as the default: it means this install's
+        password is not knowable from here, and a caller should decide what to
+        do about that rather than be handed a guess.
+        """
+        if self.db_root_password:
+            return self.db_root_password
+        if self.db_root_password_file:
+            try:
+                text = (server_dir / self.db_root_password_file).read_text(encoding="utf-8")
+            except OSError:
+                return None
+            return text.strip() or None
+        return None
+
     platforms: tuple[PlatformId, ...] = Field(
         default=("linux",),
         min_length=1,

--- a/pylauncher/yulon/catalog/catalog.py
+++ b/pylauncher/yulon/catalog/catalog.py
@@ -156,7 +156,11 @@ class Install(_Strict):
         if self.db_root_password_file:
             try:
                 text = (server_dir / self.db_root_password_file).read_text(encoding="utf-8")
-            except OSError:
+            except (OSError, ValueError):
+                # ValueError covers UnicodeDecodeError, which is what a file
+                # written in another encoding raises - it is not an OSError, so
+                # it used to escape this handler and crash the caller rather
+                # than being reported as "not knowable from here".
                 return None
             return text.strip() or None
         return None

--- a/pylauncher/yulon/catalog/installer.py
+++ b/pylauncher/yulon/catalog/installer.py
@@ -46,6 +46,39 @@ logger = get_logger(__name__)
 
 # Where `catalog.json`'s install scripts resolve from (roadmap 6.0).
 DEFAULT_INSTALLERS_ROOT = resources.installers_dir()
+
+# Every filename Docker Compose accepts for a project's compose file, in its own
+# precedence order.
+#
+# Not ours to shorten: the app only ever looked for `docker-compose.yml`, which
+# is what the WotLK and Tortoise scripts write - while the TBC and Vanilla ones
+# write `compose.yml`. The result was that a finished install of those two was
+# invisible to "Use existing..." AND was thrown away by the remember check at
+# the end of a multi-hour install, both reporting that nothing was installed.
+# Being stricter than the tool we drive buys nothing and costs exactly that.
+COMPOSE_FILENAMES: tuple[str, ...] = (
+    "compose.yaml",
+    "compose.yml",
+    "docker-compose.yaml",
+    "docker-compose.yml",
+)
+
+
+def compose_file(server_dir: Path) -> Path | None:
+    """The folder's compose file, or None if it holds no install.
+
+    Answers what Compose itself would answer, in the same order, so a folder
+    holding two spellings resolves to the one the daemon will actually load.
+    `is_file()` rather than `exists()`: a directory named `compose.yml` is not
+    an install.
+    """
+    for name in COMPOSE_FILENAMES:
+        candidate = server_dir / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 # How many of the script's last output lines a failure message carries (roadmap 6.1).
 _ERROR_TAIL_LINES = 12
 # What the scripts see as their terminal when the app was not started from one.
@@ -316,7 +349,7 @@ def cancelled_install_message(entry_name: str, server_dir: Path) -> str:
         "that is deliberate, and the finished pieces are what make a second attempt much "
         "faster, so do not clear Docker's build cache to tidy up."
     )
-    if (server_dir / "docker-compose.yml").is_file():
+    if compose_file(server_dir) is not None:
         return (
             f"{lead} The source is there. If the build had already finished, the server may "
             f'be built and even running: press "Use existing…", choose '
@@ -326,7 +359,8 @@ def cancelled_install_message(entry_name: str, server_dir: Path) -> str:
             f"so it exits having done nothing. Delete {server_dir} first in that case."
         )
     return (
-        f"{lead} The installer had not got as far as writing a docker-compose.yml, so there "
+        f"{lead} The installer had not got as far as writing a compose file "
+        f"(compose.yml or docker-compose.yml), so there "
         "is nothing there for the app to manage and nothing to resume. Pressing Install again "
         f"will not pick up where it stopped — delete {server_dir} if it still exists, then "
         "start over."

--- a/pylauncher/yulon/catalog/installer.py
+++ b/pylauncher/yulon/catalog/installer.py
@@ -59,8 +59,8 @@ DEFAULT_INSTALLERS_ROOT = resources.installers_dir()
 COMPOSE_FILENAMES: tuple[str, ...] = (
     "compose.yaml",
     "compose.yml",
-    "docker-compose.yaml",
     "docker-compose.yml",
+    "docker-compose.yaml",
 )
 
 
@@ -69,6 +69,11 @@ def compose_file(server_dir: Path) -> Path | None:
 
     Answers what Compose itself would answer, in the same order, so a folder
     holding two spellings resolves to the one the daemon will actually load.
+    The order is measured, not guessed: with all four present, Compose v5.3.1
+    reports "Found multiple config files with supported names: compose.yaml,
+    compose.yml, docker-compose.yml, docker-compose.yaml" and uses the first.
+    Note the last two - `.yml` before `.yaml`, the opposite way round from the
+    first pair, which is why an earlier version of this tuple had them swapped.
     `is_file()` rather than `exists()`: a directory named `compose.yml` is not
     an install.
     """

--- a/pylauncher/yulon/ui/catalog_view.py
+++ b/pylauncher/yulon/ui/catalog_view.py
@@ -33,6 +33,7 @@ from yulon.catalog.installer import (
     InstallEngine,
     InstallOptions,
     cancelled_install_message,
+    compose_file,
     platform_names,
     unsupported_platform_message,
 )
@@ -205,7 +206,9 @@ class CatalogView(QWidget):
         Installs made by the shell scripts or the CLI harness (or before the app
         was reinstalled) never pass through `start_install()`, so this is how
         they get a controller tab. The only check is the one thing every install
-        has: a `docker-compose.yml` in the chosen folder.
+        has: a compose file in the chosen folder, under any of the names Compose
+        itself accepts (`installer.COMPOSE_FILENAMES`) - the TBC and Vanilla
+        scripts write `compose.yml`, not `docker-compose.yml`.
         """
         server_dir = self._pick_dir(
             self,
@@ -214,11 +217,12 @@ class CatalogView(QWidget):
         )
         if server_dir is None:
             return False
-        if not (server_dir / "docker-compose.yml").is_file():
+        if compose_file(server_dir) is None:
             QMessageBox.warning(
                 self,
                 "Not a server folder",
-                f"{server_dir} has no docker-compose.yml — pick the folder the installer created.",
+                f"{server_dir} has no compose file (compose.yml or docker-compose.yml) — "
+                "pick the folder the installer created.",
             )
             return False
         client_dir: Path | None = None
@@ -332,7 +336,7 @@ class CatalogView(QWidget):
             QMessageBox.information(self, "Install cancelled", note)
             self.install_finished.emit(game_id, False, note)
             return
-        if ok and not (server_dir / "docker-compose.yml").is_file():
+        if ok and compose_file(server_dir) is None:
             # A clean exit is not proof of an install. The scripts exit 0 for
             # "Keeping existing install — exiting." too, which is what a user
             # gets by pressing Install a second time on a folder the previous
@@ -348,7 +352,8 @@ class CatalogView(QWidget):
             ok = False
             message = (
                 f"The installer exited without error, but {server_dir} has no "
-                "docker-compose.yml — so there is nothing installed there to remember. "
+                "compose file (compose.yml or docker-compose.yml) — so there is nothing "
+                "installed there to remember. "
                 "That is what the scripts do when they find an existing folder and are "
                 "told not to replace it: delete the folder and install again, or pick a "
                 "different one."

--- a/pylauncher/yulon/ui/controller_view.py
+++ b/pylauncher/yulon/ui/controller_view.py
@@ -88,7 +88,22 @@ class ControllerServices:
         # Create account and Backup. The default stays as a last resort so an
         # install whose password file has gone missing still gets a tab that can
         # start and stop, rather than no tab at all.
-        password = entry.install.db_password(server_dir) or wotlk_modules.DEFAULT_DB_ROOT_PASSWORD
+        password = entry.install.db_password(server_dir)
+        if password is None:
+            # `db_password()` says None when the entry NAMES a password file and
+            # that file cannot be read - which is not the same as "use the
+            # default", and silently defaulting here would rebuild the bug this
+            # seam exists to close. The tab is still built, because Start and
+            # Stop need no database and no tab at all is worse; but the reason
+            # every SQL-backed control is about to fail is written down once,
+            # here, instead of arriving as "access denied" six clicks later.
+            if entry.install.db_root_password_file:
+                logger.warning(
+                    f"{entry.id}: cannot read {entry.install.db_root_password_file} in "
+                    f"{server_dir}, so the database password is unknown - accounts, backup "
+                    f"and restore will fail until that file is restored"
+                )
+            password = wotlk_modules.DEFAULT_DB_ROOT_PASSWORD
         sql = DockerSql(spec.db, password)
         # Bound to this entry's own db container, not `mysql_for()`'s
         # `docker_ctl.SPEC.db`, so a catalog entry that names a different one

--- a/pylauncher/yulon/ui/controller_view.py
+++ b/pylauncher/yulon/ui/controller_view.py
@@ -81,7 +81,14 @@ class ControllerServices:
     ) -> ControllerServices:
         """The real WotLK wiring for an install at `server_dir`."""
         spec = entry.container_spec()
-        password = entry.install.db_root_password or wotlk_modules.DEFAULT_DB_ROOT_PASSWORD
+        # The entry may carry the password, or name a file the installer generated
+        # it into; `db_password()` knows both. TBC and Vanilla generate one, so
+        # before this they authenticated as root with the literal "password" -
+        # Start and Stop need no database, which is why it surfaced later, on
+        # Create account and Backup. The default stays as a last resort so an
+        # install whose password file has gone missing still gets a tab that can
+        # start and stop, rather than no tab at all.
+        password = entry.install.db_password(server_dir) or wotlk_modules.DEFAULT_DB_ROOT_PASSWORD
         sql = DockerSql(spec.db, password)
         # Bound to this entry's own db container, not `mysql_for()`'s
         # `docker_ctl.SPEC.db`, so a catalog entry that names a different one


### PR DESCRIPTION
Two consent/detection defects in the Linux install path, plus the three things
review found in my own first attempt at fixing them.

## 1. The password prompt asked for work the installer never does

All three WotLK installers printed this immediately before `sudo -v`:

```
⚠️  This installer needs sudo access for:
   • Installing Docker (if not present)
   • Fixing file ownership after build
```

There is **no executable `chown`** in any of them — the only match per file is a
comment. So a password was asked for work that never happens, while what sudo
really does went unmentioned.

**The Fedora installer reboots your computer.** `sudo systemctl reboot` at five
sites; four have no confirmation, only `sleep 10`, and two do not even print a
Ctrl+C hint. Review proved reachability by *running* it — stub
`sudo`/`sleep`/`rpm-ostree`, set `FEDORA_IMMUTABLE=true`, call the real
`install_docker`, and it ends at `>>> REACHED: sudo systemctl reboot`. Immutable
Fedora is not fringe: `check_system` accepts Bazzite by name as a supported type.

Also undisclosed: ubuntu's `sudo snap remove docker` (uninstalls the user's
existing Docker), the generic script's `sudo steamos-devmode enable`, and
fedora's own Docker repo write — while ubuntu's *identical* action did get a
bullet in my first commit.

This is the privilege-transparency rule read the other way round. That rule is
written against silent escalation; this is its mirror.

## 2. A finished TBC or Vanilla install was invisible to the app that ran it

They write `compose.yml`; WotLK and Tortoise write `docker-compose.yml`. Every
"is there an install here?" check asked only for the second, so:

- **"Use existing…" refused the folder outright**, naming a file that installer
  was never going to write;
- **`start_install()` discarded the install at the finish line** — a TBC compile
  could run to completion and the app would say there was nothing to remember.

`installer.compose_file()` now answers what Compose answers. Only the three
**detection** sites changed; `composegen` still writes one canonical name.

## What review then found in my fix

**The test could not have caught the reboot.** It iterated a hand-written dict,
so a privileged action with no entry was silently exempt — the exact failure
mode the change exists to prevent, rebuilt one level up. It also matched regexes
against the whole file, so a **comment** could satisfy a claim, while its
docstring claimed it asserted on argv.

Both directions now run off one table of verbs extracted from **executable lines
only**, iterating over what the script does. A verb the table has never heard of
fails by name. `sudo` inside an `echo` is advice being printed, not an action —
excluded, with its own test, because that exclusion is where the next hole would
hide.

**Compose precedence was wrong.** The last two entries were swapped. Measured
against Compose v5.3.1: with all four present it names its own order —
`compose.yaml, compose.yml, docker-compose.yml, docker-compose.yaml` — so `.yml`
before `.yaml`, the opposite way round from the first pair. No effect today
(every call site only asks `is None`), but the docstring claimed a measured fact
that was false, under a test whose name promised the order and never checked
that pair.

**And the wall fix 2 would have walked users into.** Making TBC/Vanilla visible
lands them on a controller that authenticates as root with the literal string
`"password"`: `db_root_password_file` was declared in the schema and **read
nowhere**, while those installers generate `tbc$(openssl rand -hex 8)` into
`.db_password`. Start and Stop need no database, so it would have surfaced on
Create account, Backup and Restore. `Install.db_password()` now reads it.

The invariant added for that then caught a fourth game: **wow-tortoise**
generated a password, interpolated it into its compose file, and kept no other
copy — unrecoverable by anything. It now persists `.db_password` like the other
two (reloaded on a rerun so a second run cannot lock itself out), and the
catalog declares it.

## Evidence

| | |
|---|---|
| suite | **829 passed, 27 skipped** (14 new) |
| ruff / black / mypy | clean |
| all three installers | `bash -n` clean |
| mutation: delete the reboot bullet | fails **by name** |
| mutation: remove tortoise's declaration | fails the catalog invariant |
| mutation: narrow `COMPOSE_FILENAMES` | 5 tests fail |

`__pycache__` purged on both sides of every mutation.

## Scope

TBC and Vanilla still hardcode `SERVER_DIR` and ignore the picker, so a *fresh*
install still lands where the user didn't choose. That belongs to the
shell-to-Python conversion. This makes "Use existing…" work on the folder they
do write, where today it is refused.
