### PR TITLE
"Use existing…" accepted a folder Docker cannot mount

### DIFF
--- a/pylauncher/tests/test_catalog_view.py
+++ b/pylauncher/tests/test_catalog_view.py
@@ -273,6 +273,75 @@ def test_an_install_that_wrote_compose_yml_is_remembered(
     assert "finished:True" in events
 
 
+def test_use_existing_refuses_a_folder_docker_cannot_mount(
+    qapp: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The folder rule was wired to Install and not to the button users press.
+
+    Reported by a tester on 2026-08-26: a WotLK server installed by the DML
+    Launcher lives INSIDE a WSL distro, at `\\\\wsl.localhost\\dml-arch\\...`. They
+    could reach it by pasting the path into the picker's address bar, and
+    "Use existing..." accepted it - because this path only ever checked for a
+    compose file. `start_install()` refuses such a folder through
+    `server_dir_problem()`; attaching one did not, so the failure would arrive
+    later as a container that mounted nothing.
+
+    Measured on Windows 11 with Docker running: `docker run -v
+    \\\\wsl.localhost\\...:/probe` fails with "is not a valid Windows path".
+    """
+    from PySide6.QtWidgets import QMessageBox
+
+    ran: list[list[str]] = []
+    monkeypatch.setattr(
+        runner, "run", lambda cmd, cwd=None, timeout=None: ran.append(cmd) or _completed()  # type: ignore[func-returns-value]
+    )
+    warned: list[str] = []
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: warned.append(a[2]))  # type: ignore[attr-defined]
+
+    # A real compose file, so the ONLY thing that can refuse it is the folder rule.
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+
+    panel = LogPanel()
+    view = CatalogView(
+        CATALOG,
+        lambda e: _FakeInstaller(e, []),
+        panel,
+        pick_dir=lambda *_: tmp_path,
+        home=tmp_path,
+        dir_problem=lambda _p: "that folder is inside WSL and Docker cannot mount it",
+    )
+    got: list[object] = []
+    view.installed.connect(lambda *a: got.append(a))
+
+    assert view.attach_existing(CATALOG.get("wow-wotlk")) is False
+    assert got == [], "a folder Docker cannot mount was attached anyway"
+    assert warned and "Docker cannot mount" in warned[0]
+    assert ran == [], f"it shelled out before refusing: {ran}"
+
+
+def test_use_existing_still_accepts_a_folder_with_no_problem(
+    qapp: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard must not refuse the ordinary case it was added around."""
+    monkeypatch.setattr(
+        runner, "run", lambda cmd, cwd=None, timeout=None: _completed()  # type: ignore[arg-type]
+    )
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    panel = LogPanel()
+    view = CatalogView(
+        CATALOG,
+        lambda e: _FakeInstaller(e, []),
+        panel,
+        pick_dir=lambda *_: tmp_path,
+        home=tmp_path,
+        dir_problem=lambda _p: None,
+    )
+    got: list[object] = []
+    view.installed.connect(lambda *a: got.append(a))
+    assert view.attach_existing(CATALOG.get("wow-wotlk")) is True
+    assert len(got) == 1
+
+
 def test_use_existing_does_not_pin_the_compose_project(
     qapp: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/pylauncher/tests/test_platform.py
+++ b/pylauncher/tests/test_platform.py
@@ -422,3 +422,27 @@ def test_a_symlink_onto_a_reserved_directory_is_refused_too() -> None:
             pytest.skip("symlinks are not resolved on this filesystem")
         problem = platform.server_dir_problem(link)
         assert problem is not None and "system directory" in problem
+
+
+def test_a_wsl_path_is_refused_in_words_that_fit_what_happened() -> None:
+    """`\\\\wsl.localhost\\...` is a network path to Windows, but not to the user.
+
+    A tester's server, installed by the DML Launcher, lives inside a WSL distro.
+    The generic refusal told them to "pick a folder on this machine's own disk" -
+    which it IS. Docker Desktop cannot bind-mount it ("is not a valid Windows
+    path", measured on Windows 11), so the refusal is right and only the wording
+    was wrong.
+    """
+    for text in (r"\\wsl.localhost\dml-arch\home\dml\games\srv", r"\\wsl$\Ubuntu\srv"):
+        problem = platform.server_dir_problem(Path(text))
+        assert problem is not None, f"{text} was accepted"
+        assert "WSL" in problem, f"the WSL case is not named in: {problem}"
+        assert "own disk" not in problem, "the generic network wording leaked into the WSL case"
+
+
+def test_an_ordinary_unc_path_keeps_the_network_wording() -> None:
+    """A real file share is still a file share."""
+    problem = platform.server_dir_problem(Path(r"\\nas\media\srv"))
+    assert problem is not None
+    assert "network path" in problem
+    assert "WSL" not in problem

--- a/pylauncher/yulon/platform.py
+++ b/pylauncher/yulon/platform.py
@@ -2502,6 +2502,22 @@ def server_dir_problem(server_dir: Path) -> str | None:
     """
     text = str(server_dir)
     if text.startswith("\\\\") or text.startswith("//"):
+        # A WSL path is a network path to Windows and emphatically not one to
+        # the user - it is their own machine, one virtualisation layer over.
+        # Telling them to "pick a folder on this machine's own disk" answers a
+        # question they did not ask, so this case gets its own words (tester
+        # report, 2026-08-26). Docker Desktop refuses it either way: measured on
+        # Windows 11, `docker run -v \\\\wsl.localhost\\...:/probe` fails with
+        # "is not a valid Windows path".
+        head = text.replace("/", "\\").lower()
+        if head.startswith("\\\\wsl.localhost\\") or head.startswith("\\\\wsl$\\"):
+            return (
+                f"{server_dir} is inside WSL. Docker Desktop cannot bind-mount a WSL path from "
+                "Windows, so the containers would see an empty folder. If that server was "
+                "installed by the DML Launcher it already has its own Docker inside that "
+                "distro - manage it from there, or install a separate server here with a "
+                "folder on the Windows side."
+            )
         return (
             f"{server_dir} is a network path. Docker Desktop cannot share one with its Linux "
             "VM, so the install would appear to work and the containers would see an empty "

--- a/pylauncher/yulon/ui/catalog_view.py
+++ b/pylauncher/yulon/ui/catalog_view.py
@@ -123,10 +123,12 @@ class CatalogView(QWidget):
         pick_dir: DirPicker = _qt_dir_picker,
         home: Path | None = None,
         platform_id: Callable[[], str] = platform.detect,
+        dir_problem: Callable[[Path], str | None] = platform.server_dir_problem,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self._platform_id = platform_id
+        self._dir_problem = dir_problem
         self._catalog = catalog
         self._make_installer = installer_factory
         self._log = log_panel
@@ -205,10 +207,14 @@ class CatalogView(QWidget):
 
         Installs made by the shell scripts or the CLI harness (or before the app
         was reinstalled) never pass through `start_install()`, so this is how
-        they get a controller tab. The only check is the one thing every install
-        has: a compose file in the chosen folder, under any of the names Compose
-        itself accepts (`installer.COMPOSE_FILENAMES`) - the TBC and Vanilla
-        scripts write `compose.yml`, not `docker-compose.yml`.
+        they get a controller tab. Two checks: a compose file in the chosen
+        folder, under any of the names Compose itself accepts
+        (`installer.COMPOSE_FILENAMES`) - the TBC and Vanilla scripts write
+        `compose.yml`, not `docker-compose.yml` - and the same folder rule
+        `start_install()` applies, because a folder Docker cannot mount is no
+        more attachable than it is installable. That second one was missing
+        until a tester attached a server living inside WSL (2026-08-26): the
+        rule existed and simply was not wired to the button they pressed.
         """
         server_dir = self._pick_dir(
             self,
@@ -224,6 +230,13 @@ class CatalogView(QWidget):
                 f"{server_dir} has no compose file (compose.yml or docker-compose.yml) — "
                 "pick the folder the installer created.",
             )
+            return False
+        # Asked second, so "there is no server here" beats "this folder would
+        # not work anyway" - the first is the likelier mistake and the easier
+        # one to act on.
+        folder_problem = self._dir_problem(server_dir)
+        if folder_problem is not None:
+            QMessageBox.warning(self, "That folder will not work", folder_problem)
             return False
         client_dir: Path | None = None
         if entry.install.requires_client_dir:


### PR DESCRIPTION
**Found by a tester on a real machine**, not by us: their WotLK server —
installed by the DML Launcher — lives **inside a WSL distro** at
`\wsl.localhost\dml-arch\home\dml\games\wow-server-playerbots`, with Docker CE
running *inside* that distro rather than Docker Desktop on Windows. The picker's
tree doesn't offer WSL, but pasting the path into its address bar works — and
**"Use existing…" then accepted the folder.**

It shouldn't have. `start_install()` runs `server_dir_problem()`, which refuses a
UNC path because Docker Desktop cannot bind-mount one. `attach_existing()`
checked only for a compose file. **The rule existed and simply wasn't wired to
the path users take** — the same shape as the GUI folder check that was dead code
on Linux, and found the same way: by someone running the product.

Confirmed on Windows 11 with Docker running, rather than argued from docs:

```
docker run -v \wsl.localhost\docker-desktop\tmp:/probe alpine ls /probe
→ Error response from daemon: is not a valid Windows path
```

The check is asked **second**, after "there is no server here" — that's the
likelier mistake and the easier one to act on.

## The refusal also said the wrong thing

Its advice was *"pick a folder on this machine's own disk"* — and a WSL path **is**
on their own disk, one virtualisation layer over. Paths under `\wsl.localhost\`
or `\wsl$\` now get their own wording: Docker Desktop cannot mount it from
Windows, and a DML Launcher server already has its own Docker inside that
distro, so it's managed from there rather than from here.

## Evidence

| | |
|---|---|
| suite | **839 passed, 27 skipped** (4 new) |
| ruff / black / mypy | clean |
| mutation: remove the guard | attach test fails |
| mutation: remove the WSL branch | wording test fails |

`__pycache__` purged on both sides of each mutation.

## Not fixed here

Adopting a WSL-resident server properly — running compose *inside* the distro —
is a different execution model and a scope call, not a bug fix. This makes the
refusal honest and immediate instead of a failure hours later.
