### PR TITLE
Start was broken for every CMaNGOS game, and only WotLK could not show it

### DIFF
--- a/pylauncher/tests/test_catalog.py
+++ b/pylauncher/tests/test_catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -156,3 +157,70 @@ def test_every_game_says_how_its_db_password_can_be_known() -> None:
             f"{entry.id} declares neither db_root_password nor db_root_password_file, "
             f"so the app would authenticate to its database with the shared default"
         )
+
+
+def _compose_services_declared(script: Path) -> dict[str, str]:
+    """Map compose SERVICE key -> `container_name:` for every services block in a script.
+
+    The installers write their `docker-compose.yml` from a heredoc, so the file the
+    user ends up with is readable straight out of the script. A service with no
+    `container_name:` maps to "" — compose then names the container itself.
+    """
+    services: dict[str, str] = {}
+    in_services = False
+    current: str | None = None
+    for line in script.read_text(encoding="utf-8").splitlines():
+        if line == "services:":
+            in_services, current = True, None
+            continue
+        if not in_services or not line.strip():
+            continue
+        if not line.startswith(" "):  # `volumes:`, `networks:`, the heredoc terminator
+            in_services, current = False, None
+            continue
+        key = re.match(r"^  ([a-z][a-z0-9_.-]*):\s*$", line)
+        if key:
+            current = key.group(1)
+            services.setdefault(current, "")
+            continue
+        name = re.match(r"^\s+container_name:\s*(\S+)\s*$", line)
+        if name and current:
+            services[current] = name.group(1)
+    return services
+
+
+def test_cmangos_games_select_compose_services_not_container_names() -> None:
+    """Every CMaNGOS installer names its services db/realmd/mangosd (Discord, 2026-08-26).
+
+    Its containers are `<game>-db` and friends, and `docker compose up <container>`
+    answers `no such service`, so the catalog must spell the services out. For
+    AzerothCore the two names coincide and the container names are the answer.
+    """
+    catalog = load_catalog()
+    for game_id in ("wow-tbc", "wow-vanilla", "wow-tortoise"):
+        spec = catalog.get(game_id).container_spec()
+        assert spec.compose_services() == ("db", "realmd", "mangosd"), game_id
+    assert catalog.get("wow-wotlk").container_spec().compose_services() == (
+        "ac-database",
+        "ac-authserver",
+        "ac-worldserver",
+    )
+
+
+def test_no_catalog_compose_service_is_really_a_container_name() -> None:
+    """The invariant behind the bug: what `compose up` selects must be a service key.
+
+    Only decided for compose files this repo writes; WotLK's base file comes from
+    the AzerothCore checkout, so a service missing from the script proves nothing.
+    """
+    installers = resources.installers_dir()
+    for game in load_catalog().games:
+        declared = _compose_services_declared(installers / game.install.script)
+        if not declared:
+            continue
+        container_names = {name for name in declared.values() if name}
+        for service in game.container_spec().compose_services():
+            assert service not in container_names or service in declared, (
+                f"{game.id}: `docker compose up {service}` names a CONTAINER, not a service; "
+                f"this compose file declares {sorted(declared)}"
+            )

--- a/pylauncher/yulon/catalog/catalog.json
+++ b/pylauncher/yulon/catalog/catalog.json
@@ -104,7 +104,8 @@
       "containers": {
         "db": "tbc-db",
         "auth": "tbc-realmd",
-        "world": "tbc-mangosd"
+        "world": "tbc-mangosd",
+        "services": ["db", "realmd", "mangosd"]
       },
       "ports": {
         "auth": 3724,
@@ -158,7 +159,8 @@
       "containers": {
         "db": "vanilla-db",
         "auth": "vanilla-realmd",
-        "world": "vanilla-mangosd"
+        "world": "vanilla-mangosd",
+        "services": ["db", "realmd", "mangosd"]
       },
       "ports": {
         "auth": 3724,
@@ -206,7 +208,8 @@
       "containers": {
         "db": "tortoise-db",
         "auth": "tortoise-realmd",
-        "world": "tortoise-mangosd"
+        "world": "tortoise-mangosd",
+        "services": ["db", "realmd", "mangosd"]
       },
       "ports": {
         "auth": 3724,

--- a/pylauncher/yulon/catalog/catalog.py
+++ b/pylauncher/yulon/catalog/catalog.py
@@ -241,11 +241,22 @@ class Install(_Strict):
 
 
 class Containers(_Strict):
-    """The three container names the controller manages, and the import job's service."""
+    """The three container names the controller manages, their services, and the import job."""
 
     db: str = Field(min_length=1)
     auth: str = Field(min_length=1)
     world: str = Field(min_length=1)
+    services: tuple[str, str, str] | None = Field(
+        default=None,
+        description=(
+            "Compose SERVICE names for db/auth/world, in that order, when they differ from the "
+            "container names above. AzerothCore names a service and its container the same thing "
+            "and may leave this out; every CMaNGOS game does not — its services are "
+            "db/realmd/mangosd while its containers are <game>-db/-realmd/-mangosd — and "
+            "MUST say so. `docker compose up` takes services, and a container name it does not "
+            "know fails outright with `no such service` (Discord report, 2026-08-26)."
+        ),
+    )
     db_import: str | None = Field(
         default=None,
         min_length=1,
@@ -330,6 +341,7 @@ class CatalogEntry(_Strict):
             auth=self.containers.auth,
             world=self.containers.world,
             ports=(self.ports.auth, self.ports.world),
+            services=self.containers.services or (),
             import_service=self.containers.db_import or "",
         )
 

--- a/pyplan/checklist.md
+++ b/pyplan/checklist.md
@@ -1001,3 +1001,20 @@ that build.
      `OsBuildNumber`/`OsName` instead.
 
 - **`pyplan/rust-prior-art.md` (2026-08-21):** what the earlier Rust launcher (`rust-main`) already solved, distilled so nobody has to read Rust — the staged/resumable install machine, the compose three-file split and its build-file trap, preflight floors with the measurements behind them, Windows Docker Desktop specifics, and creating the first GM account via SRP6 (no console/pty needed, which is the open Windows console gap in 6.5 item 3). Sections 1-5 feed Phase 6; section 7 lists what is waiting for Phase 8's feature port.
+- **Start was broken for all three CMaNGOS games, and only the catalog knew (Discord report, 2026-08-26)** —
+  a user with a working WotLK install ("server starting and shutdown without issue, console is running fine")
+  tried an existing Tortoise install from the same family of scripts and got
+  `docker compose up -d --no-deps tortoise-db tortoise-realmd tortoise-mangosd exited 1: no such service:
+  tortoise-db`. Not an attach problem and not specific to that install: **every** Tortoise, TBC and Vanilla
+  install fails the same way, ours included, because their compose files name the services `db`/`realmd`/
+  `mangosd` and give the *containers* the `<game>-` prefix. `ContainerSpec` had modelled that distinction
+  since it was written and `compose_services()` falls back to container names only "for every
+  AzerothCore-derived game"; `catalog.json` simply never filled the `services` field in, so the fallback
+  applied to games it was never true for. WotLK hid it — `ac-database`/`ac-authserver`/`ac-worldserver` are
+  both names at once, so the fallback is right there and only there.
+
+  Two things this says beyond the fix. A data field whose default is right for the one game everyone tests
+  is indistinguishable from a field nobody filled in — the live integration fixture had deliberately used
+  differing service and container names since 2026-08-22, so the *code* was proven and the *catalog* was
+  never checked against the installers it ships. The regression test now reads the compose services straight
+  out of each installer script and refuses any catalog service that is really a container name there.


### PR DESCRIPTION
A Discord report: a working WotLK install — "server starting and shutdown without issue, console is running fine" — then an existing Tortoise install from the same family of scripts, and Start died with

```
docker compose up -d --no-deps tortoise-db tortoise-realmd tortoise-mangosd exited 1: no such service: tortoise-db
```

Not that install, and not attaching. **Every Tortoise, TBC and Vanilla install fails identically**, the ones this app writes included: their compose files name the services `db`/`realmd`/`mangosd` and put the `<game>-` prefix on `container_name:`. `docker compose up` takes services, so it was handed three names it had never heard of.

`ContainerSpec` has carried both names since it was written, and `compose_services()` falls back to container names only because "for every AzerothCore-derived game they happen to be identical". `catalog.json` never filled `services` in, so that fallback ran for three games it was never true for. WotLK is the one game where it *is* true — which is why nothing caught it, and why the reporter's WotLK server works.

## The fix

`Containers.services`, passed through `container_spec()`, spelled out for the three CMaNGOS games. Container names are untouched: every `docker ps` / `inspect` / `logs` / health path in `yulon.docker` already used them correctly and still does.

## Tests

Both RED before the fix:

1. the three games' `compose_services()` is `("db", "realmd", "mangosd")`, WotLK's is its container names;
2. an invariant that reads each installer script's own compose block and refuses any catalog service that is really a `container_name:` there. This is the one that generalises — it reproduced the reported error for TBC unprompted.

The live-Docker fixture had deliberately used differing service and container names since 2026-08-22, so the *code* was proven end-to-end and the *catalog* had never been checked against the installers it ships. That gap is what the second test closes.

Suite 837 passed / 27 skipped; ruff, black, mypy clean.
