### PR TITLE
Finding docker was only half of it: its credential helper is on PATH too

### DIFF
--- a/pylauncher/tests/test_console.py
+++ b/pylauncher/tests/test_console.py
@@ -342,6 +342,8 @@ def test_attach_argv_reaches_the_distros_own_docker(monkeypatch: pytest.MonkeyPa
     assert argv[:5] == ["wsl.exe", "-d", "dml-arch", "--", "docker"]
     assert argv[-1] == "ac-worldserver"
     assert "--sig-proxy=false" in argv
+
+
 def test_a_mangos_console_is_parsed_by_its_own_prompt() -> None:
     """Captured from a real mangosd, not hand-written (m910q, 2026-08-26).
 

--- a/pylauncher/tests/test_controller_view.py
+++ b/pylauncher/tests/test_controller_view.py
@@ -1198,6 +1198,8 @@ def test_for_wotlk_defaults_to_no_distro(qapp: object, tmp_path: Path) -> None:
     """An ordinary local install is unchanged by any of this."""
     entry = load_catalog().get("wow-wotlk")
     assert ControllerServices.for_wotlk(entry, tmp_path).controller.wsl_distro is None
+
+
 def test_a_cmangos_install_s_account_path_addresses_its_own_schema(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/pylauncher/tests/test_docker.py
+++ b/pylauncher/tests/test_docker.py
@@ -2812,11 +2812,91 @@ def test_the_bind_mount_probe_mounts_the_folder_and_tells_no_from_no_answer(
         "/probe",
     ]
     assert not server_dir.exists()
-    monkeypatch.setattr(docker.runner, "run", answer(1, stderr="invalid mount config"))
+
+    def refuse_the_mount(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        # The image is in hand — `docker run` pulls before it mounts — so this
+        # non-zero exit really is Docker answering about the folder. Without
+        # that half the fake, a failure the probe never reached the mount for
+        # would be indistinguishable from this one; see
+        # `test_a_probe_that_never_reached_the_mount_is_unchecked_not_a_refusal`.
+        if argv[1:3] == ["image", "inspect"]:
+            return _completed(stdout="sha256:abc")
+        return _completed(returncode=1, stderr="invalid mount config")
+
+    monkeypatch.setattr(docker.runner, "run", refuse_the_mount)
     assert docker.bind_mount_ok(server_dir, "alpine/git") is False
     # 124 is what `runner.run()` reports for a command that never answered.
     monkeypatch.setattr(docker.runner, "run", answer(124, stderr="timed out after 30.0s"))
     assert docker.bind_mount_ok(server_dir, "alpine/git") is None
+
+
+def test_a_probe_that_never_reached_the_mount_is_unchecked_not_a_refusal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`docker run` also fails BEFORE it mounts anything, and that is not an answer.
+
+    Reported from a Mac (2026-08-26), where every failure mode below was the
+    same one: the app found `docker` inside Docker Desktop's bundle but ran it
+    with launchd's PATH, so the CLI could not exec `docker-credential-desktop`,
+    so the probe's first-ever pull of `alpine/git` died at authentication:
+
+        docker: error getting credentials - err: exec:
+        "docker-credential-desktop": executable file not found in $PATH
+
+    A non-zero exit was read as "Docker says it cannot see that folder", and
+    preflight refused the install with "a container could not see
+    /Users/js/wow-wotlk" — a folder that WAS in Docker Desktop's file-sharing
+    list, on a machine where the same `docker run` worked from Terminal. The
+    user re-added the folder, tried others, and verified read/write inside a
+    container before sending the log that named the real error.
+
+    The exit code cannot tell the two apart — a denied mount and a failed pull
+    both exit non-zero — so the daemon is asked a second question: is the image
+    here? `docker run` pulls before it mounts, so an image that never arrived
+    proves the mount was never attempted. Present means the failure really was
+    the mount, and the refusal stands.
+    """
+    (tmp_path / "already-here.txt").write_text("x", encoding="utf-8")
+    server_dir = tmp_path / "wow"
+    asked: list[list[str]] = []
+
+    def run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        asked.append(argv)
+        if argv[1:3] == ["image", "inspect"]:
+            return _completed(returncode=1, stderr="Error: No such image: alpine/git")
+        return _completed(
+            returncode=125,
+            stderr=(
+                "Unable to find image 'alpine/git' locally\n"
+                "docker: error getting credentials - err: exec: "
+                '"docker-credential-desktop": executable file not found in $PATH'
+            ),
+        )
+
+    monkeypatch.setattr(docker.runner, "run", run)
+    assert docker.bind_mount_ok(server_dir, "alpine/git") is None
+    assert [a[1:3] for a in asked] == [["run", "--rm"], ["image", "inspect"]]
+
+
+def test_a_mount_the_daemon_refused_with_the_image_in_hand_is_still_a_refusal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The case the check exists for must survive the fix above.
+
+    Docker Desktop answers an unshared path with a non-zero exit and a "mounts
+    denied" line. The image is local by then — `docker run` pulls first — so the
+    second question separates it from the pull failure without either of them
+    having to match on error wording.
+    """
+    (tmp_path / "already-here.txt").write_text("x", encoding="utf-8")
+
+    def run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if argv[1:3] == ["image", "inspect"]:
+            return _completed(stdout="sha256:abc")
+        return _completed(returncode=125, stderr="Mounts denied: the path is not shared from OS X")
+
+    monkeypatch.setattr(docker.runner, "run", run)
+    assert docker.bind_mount_ok(tmp_path / "wow", "alpine/git") is False
 
 
 def test_the_bind_mount_probe_catches_the_silently_empty_mount_it_exists_for(

--- a/pylauncher/tests/test_docker.py
+++ b/pylauncher/tests/test_docker.py
@@ -3291,6 +3291,8 @@ def test_an_ordinary_streamed_failure_keeps_its_output(
     result = docker.run_attached(["compose", "build"], Path("/srv"), wsl_distro="dml-arch")
     assert result.returncode == 2
     assert result.tail == ("error: undefined reference",)
+
+
 def test_the_diagnostic_it_offers_is_a_command_that_actually_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/pylauncher/tests/test_main.py
+++ b/pylauncher/tests/test_main.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import json
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -233,49 +233,48 @@ def test_headless_provisioning_never_hands_over_a_prompter(
 # --------------------------------------------------------------- window tabs
 
 
-@pytest.fixture
-def window_builder(
-    monkeypatch: pytest.MonkeyPatch, qapp: object, tmp_path: Any
-) -> Iterator[Callable[..., Any]]:
-    """Build real windows through `main.build_window()` and stop their threads after.
+@pytest.fixture(scope="module")
+def _app_window(qapp: object) -> Iterator[Any]:
+    """ONE real window, built through `main.build_window()`, shared by this module.
+
+    Repeatedly building windows is what made this file crash. Measured on Linux
+    with offscreen Qt (PySide6 6.11.2), 25 runs per count:
+
+        1 window  0/25   2 windows  2/25   3 windows  3/25
+        4 windows 8/25   5 windows  9/25
+
+    A dose-response, not a bug in any one test: each of the five passed 25/25
+    alone. It surfaced as a SEGFAULT (and sometimes SIGBUS) inside whichever
+    test happened to be allocating at the time - `state.remember()`, a signal
+    emit - which is why three attempts at making teardown safer all measured as
+    noise. Only the count matters, so there is one window and the tests share
+    it.
+
+    Sharing is safe because tabs are keyed by (game, server_dir): every test
+    below uses its own directory, creates its own tab through the real signals,
+    and cannot see another's. Nothing is pre-seeded into `state.json` - a tab
+    arrives the way a user's does.
 
     Three things `build_window()` does are unacceptable in a unit test and are
-    neutralised here rather than in each test: it reads the user's real
-    `state.json` on the way in, writes it back every time a tab is added, and
-    starts a background thread that asks GitHub for the latest release.
-
-    The teardown is `main._stop_background_threads()` itself, not a hand-rolled
-    equivalent: a QThread destroyed while running ABORTS the process
-    (0xC0000409), and a test that leaks one takes the whole run down with it.
-
-    **Every window built here is destroyed here, by hand.** Twice now CI has
-    died with a SEGFAULT (exit 139) inside a LATER test than the one that
-    caused it - once on py3.11 while py3.13 passed the same commit, then the
-    other way round after a first attempt at this. A crash that swaps
-    interpreters between runs is a lifetime bug whose only variable is when the
-    garbage collector ran, so nothing here is left to Python's refcount or to
-    whenever Qt next happens to pump events:
-
-    * the poll timer is off, so no window is running `docker ps` on a 5-second
-      QTimer into a worker thread while the suite moves on to other tests;
-    * `processEvents()` runs the deferred deletes that `drop_controller()`
-      queues, at a moment this fixture picked, with every thread already joined;
-    * `shiboken6.delete()` then destroys the C++ side outright, rather than
-      leaving a window alive until some later collection frees it under
-      whichever test is running by then.
+    neutralised here: it reads the user's real `state.json`, writes it back
+    whenever a tab is added, and starts a thread that asks GitHub for the
+    latest release.
     """
     from PySide6.QtWidgets import QApplication
-    from shiboken6 import delete as delete_cpp
 
     from yulon.ui.controller_view import ControllerView
 
+    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(update, "check_for_update", lambda: None)
-    monkeypatch.setattr(state, "save_state", lambda _state, path=None: tmp_path / "state.json")
+    monkeypatch.setattr(state, "load_state", lambda path=None: state.AppState(installs=[]))
+    # Captured here rather than in the test that reads it: `build_window()`
+    # imports `save_state` into its own namespace on the way in, so a patch
+    # applied after the window exists is never seen by the window.
+    saved: list[Any] = []
+    monkeypatch.setattr(state, "save_state", lambda app_state, path=None: saved.append(app_state))
 
-    # A test about which tab exists must not also be shelling out to docker.
-    # `build_window()` takes the default 5000ms, and each poll runs
-    # `controller.status()` on a worker thread - real subprocesses, outliving
-    # the assertions that finished long before they did.
+    # A test about which tab exists must not also be shelling out to docker on a
+    # 5-second timer, into a worker thread that outlives the assertions.
     real_init = ControllerView.__init__
 
     def _no_polling(self: Any, entry: Any, services: Any, **kwargs: Any) -> None:
@@ -284,25 +283,22 @@ def window_builder(
 
     monkeypatch.setattr(ControllerView, "__init__", _no_polling)
 
-    windows: list[Any] = []
+    window = main.build_window()
+    window.saved_states = saved
+    yield window
 
-    def build(*installs: state.KnownInstall) -> Any:
-        monkeypatch.setattr(
-            state, "load_state", lambda path=None: state.AppState(installs=list(installs))
-        )
-        window = main.build_window()
-        windows.append(window)
-        return window
-
-    yield build
-
-    for window in windows:
-        main._stop_background_threads(window)
-        window.close()
+    # `_stop_background_threads` itself, not a hand-rolled equivalent: a QThread
+    # destroyed while running ABORTS the process, and a leaked one takes the
+    # whole run down with it.
+    main._stop_background_threads(window)
     QApplication.processEvents()
-    for window in windows:
-        delete_cpp(window)
-    windows.clear()
+    monkeypatch.undo()
+
+
+@pytest.fixture
+def window(_app_window: Any, monkeypatch: pytest.MonkeyPatch) -> Any:
+    """The shared window, with `save_state` captured for the test that reads it."""
+    return _app_window
 
 
 def _catalog_view(window: Any) -> Any:
@@ -318,46 +314,54 @@ def _catalog_view(window: Any) -> Any:
     return view
 
 
+def _tab_for(window: Any, server_dir: Any) -> Any:
+    """The controller tab this test owns, by the key tabs are stored under."""
+    for view in window.yulon_controllers:
+        if view.services.controller.server_dir == server_dir:
+            return view
+    raise AssertionError(f"no tab for {server_dir}")
+
+
 def test_adopting_a_server_that_already_has_a_tab_rebuilds_it_for_the_new_distro(
-    window_builder: Callable[..., Any], tmp_path: Any
+    window: Any, tmp_path: Any
 ) -> None:
     """Otherwise every button on that tab keeps driving the LOCAL docker daemon.
 
-    The server was remembered as an ordinary local install, so its tab was built
-    with no distro; adopting it from WSL wrote the distro to `state.json` and
-    stopped there, leaving the open tab wired to a daemon the server is not in.
-    Nothing reports an error: Start finds nothing to start, Stop stops nothing,
-    and Status says "not running" about a server that is - until the app is
-    restarted.
+    The tab was opened as an ordinary local install, so it was built with no
+    distro; adopting the same server from WSL wrote the distro to `state.json`
+    and stopped there, leaving the open tab wired to a daemon the server is not
+    in. Nothing reports an error: Start finds nothing to start, Stop stops
+    nothing, and Status says "not running" about a server that is - until the
+    app is restarted.
 
     The whole services bundle has to be new, not just the `Controller`:
     `ControllerServices.for_wotlk()` bakes the distro into `DockerSql`,
     `DockerMysql` and the `Controller`, and captures it a fourth time in the
     `logs_source` lambda.
     """
-    server_dir = tmp_path / "wotlk-server"
-    window = window_builder(state.KnownInstall(game="wow-wotlk", server_dir=server_dir))
-    tabs = window.property("tabs")
-    stale = window.yulon_controllers[0]
+    server_dir = tmp_path / "rebuild-me"
+    catalog = _catalog_view(window)
+    catalog.installed.emit("wow-wotlk", server_dir, None)
+    stale = _tab_for(window, server_dir)
     assert stale.services.controller.wsl_distro is None
 
-    _catalog_view(window).adopted.emit("wow-wotlk", server_dir, None, "Ubuntu-24.04")
+    catalog.adopted.emit("wow-wotlk", server_dir, None, "Ubuntu-24.04")
 
-    live = window.yulon_controllers
-    assert len(live) == 1, "the torn-down tab was left in the shutdown list"
-    assert live[0] is not stale, "the tab was patched in place instead of rebuilt"
-    assert live[0].services is not stale.services
-    assert live[0].services.controller.wsl_distro == "Ubuntu-24.04"
-    assert tabs.count() == 2, "Catalog plus exactly one server tab"
+    live = _tab_for(window, server_dir)
+    assert live is not stale, "the tab was patched in place instead of rebuilt"
+    assert live.services is not stale.services
+    assert live.services.controller.wsl_distro == "Ubuntu-24.04"
+    assert stale not in window.yulon_controllers, "the torn-down tab is still in the shutdown list"
+    tabs = window.property("tabs")
     assert tabs.indexOf(stale) == -1, "the stale tab is still in the tab bar"
-    assert tabs.currentWidget() is live[0]
+    assert tabs.currentWidget() is live
     # The panel list is what `_stop_background_threads()` joins at exit. A stale
     # console panel left in it is a `wait()` on a widget nothing owns any more.
-    assert len(window.yulon_log_panels) == 2, "the shared app log plus one console"
+    assert stale.console_log not in window.yulon_log_panels
 
 
 def test_re_adopting_a_server_from_the_same_distro_only_focuses_its_tab(
-    window_builder: Callable[..., Any], tmp_path: Any
+    window: Any, tmp_path: Any
 ) -> None:
     """Adopting twice is an ordinary thing to do, and must not cost the tab its state.
 
@@ -366,61 +370,28 @@ def test_re_adopting_a_server_from_the_same_distro_only_focuses_its_tab(
     behind - give one server two tabs that disagree. The distro changing is the
     only thing that justifies one.
     """
-    server_dir = tmp_path / "wotlk-server"
-    window = window_builder(
-        state.KnownInstall(game="wow-wotlk", server_dir=server_dir, wsl_distro="Ubuntu-24.04")
-    )
+    server_dir = tmp_path / "same-distro"
+    catalog = _catalog_view(window)
+    catalog.adopted.emit("wow-wotlk", server_dir, None, "Ubuntu-24.04")
+    existing = _tab_for(window, server_dir)
     tabs = window.property("tabs")
-    existing = window.yulon_controllers[0]
     tabs.setCurrentIndex(0)  # so "it focused the tab" is a real change, not the status quo
+    before = len(window.yulon_controllers)
 
-    _catalog_view(window).adopted.emit("wow-wotlk", server_dir, None, "Ubuntu-24.04")
+    catalog.adopted.emit("wow-wotlk", server_dir, None, "Ubuntu-24.04")
 
-    assert window.yulon_controllers == [existing], "the tab was rebuilt for nothing"
-    assert tabs.count() == 2
+    assert _tab_for(window, server_dir) is existing, "the tab was rebuilt for nothing"
+    assert len(window.yulon_controllers) == before, "adopting twice made a second tab"
     assert tabs.currentWidget() is existing
 
 
-def test_a_tab_opened_after_startup_is_still_joined_when_the_window_closes(
-    window_builder: Callable[..., Any], tmp_path: Any
-) -> None:
-    """A running console on such a tab used to abort the process on close.
-
-    `build_window()` handed its panel list to `setProperty()`, which stores a
-    QVariant COPY: the exit path then walked the list as it stood when the
-    window was built, and every tab opened during the session - each install,
-    each adopt - was missing from it. So "Follow worldserver log" on a tab the
-    user opened themselves left a QThread running while Qt was torn down, which
-    aborts (0xC0000409) rather than warns. Both registries are checked here,
-    because the same copy silently froze the controller list too.
-    """
-    server_dir = tmp_path / "wotlk-server"
-    window = window_builder()  # nothing remembered: the tab arrives later, as a user's does
-    _catalog_view(window).adopted.emit("wow-wotlk", server_dir, None, "Ubuntu-24.04")
-    view = window.yulon_controllers[-1]
-
-    def endless() -> Iterator[str]:
-        while True:
-            yield "worldserver line"
-            time.sleep(0.005)
-
-    # What "Follow worldserver log" leaves running, without a real `docker logs`.
-    assert view.console_log.run(endless, title="worldserver log") is True
-    process_events(50)
-    assert view.console_log.running is True, "the job under test was not running to begin with"
-
-    main._stop_background_threads(window)
-
-    assert view.console_log.running is False, "the new tab's console thread outlived the window"
-
-
 def test_use_existing_on_a_wsl_server_does_not_demote_its_tab_to_the_local_daemon(
-    window_builder: Callable[..., Any], tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    window: Any, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     r""" "I was not told a distro" is not the same fact as "this server is local".
 
     `installed` carries no distro, and "Use existing…" accepts a
-    `\\wsl.localhost\...` folder - which is exactly the spelling an adopted
+    `\wsl.localhost\...` folder - which is exactly the spelling an adopted
     server is stored under, so the two paths collide on the same key. Reading
     that silence as a change rebuilt a working WSL tab against the local docker
     daemon: this feature's own failure mode, running backwards.
@@ -429,36 +400,25 @@ def test_use_existing_on_a_wsl_server_does_not_demote_its_tab_to_the_local_daemo
     the next launch: the live tab keeps its distro, and so does what is written
     to `state.json` - `remember()` REPLACES the entry for a game + dir, so an
     install rebuilt from the signal's own arguments erases what adoption learnt.
-
-    `save_state` is captured BEFORE the window is built, deliberately:
-    `build_window()` imports it into its own namespace on the way in, so a
-    patch applied afterwards would never be seen.
     """
-    saved: list[Any] = []
-    monkeypatch.setattr(
-        state,
-        "save_state",
-        lambda app_state, path=None: saved.append(app_state) or (tmp_path / "state.json"),
-    )
-    server_dir = tmp_path / "wotlk-server"
-    window = window_builder(
-        state.KnownInstall(game="wow-wotlk", server_dir=server_dir, wsl_distro="Ubuntu-24.04")
-    )
-    existing = window.yulon_controllers[0]
+    server_dir = tmp_path / "keep-my-distro"
+    catalog = _catalog_view(window)
+    catalog.adopted.emit("wow-wotlk", server_dir, None, "Ubuntu-24.04")
+    existing = _tab_for(window, server_dir)
 
-    _catalog_view(window).installed.emit("wow-wotlk", server_dir, None)
+    catalog.installed.emit("wow-wotlk", server_dir, None)
 
-    assert window.yulon_controllers == [existing], "the WSL tab was rebuilt as a local one"
+    assert _tab_for(window, server_dir) is existing, "the WSL tab was rebuilt as a local one"
     assert existing.services.controller.wsl_distro == "Ubuntu-24.04"
-    assert saved, "nothing was written back at all"
-    remembered = saved[-1].find("wow-wotlk", server_dir)
+    assert window.saved_states, "nothing was written back at all"
+    remembered = window.saved_states[-1].find("wow-wotlk", server_dir)
     assert (
         remembered is not None and remembered.wsl_distro == "Ubuntu-24.04"
     ), "the distro was erased from what would be saved"
 
 
 def test_a_tab_that_is_mid_import_is_not_torn_down_to_change_its_distro(
-    window_builder: Callable[..., Any], tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    window: Any, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A rebuild is a teardown, and one kind of work cannot survive one.
 
@@ -476,15 +436,54 @@ def test_a_tab_that_is_mid_import_is_not_torn_down_to_change_its_distro(
     """
     from PySide6.QtWidgets import QMessageBox
 
-    server_dir = tmp_path / "wotlk-server"
-    window = window_builder(state.KnownInstall(game="wow-wotlk", server_dir=server_dir))
-    busy = window.yulon_controllers[0]
+    server_dir = tmp_path / "mid-import"
+    catalog = _catalog_view(window)
+    catalog.installed.emit("wow-wotlk", server_dir, None)
+    busy = _tab_for(window, server_dir)
+
     monkeypatch.setattr(type(busy), "busy_reason", lambda _self: "The database import is running.")
     told: list[str] = []
     monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: told.append(a[2]))
 
-    _catalog_view(window).adopted.emit("wow-wotlk", server_dir, None, "Ubuntu-24.04")
+    catalog.adopted.emit("wow-wotlk", server_dir, None, "Ubuntu-24.04")
 
-    assert window.yulon_controllers == [busy], "a tab mid-import was torn down"
+    assert _tab_for(window, server_dir) is busy, "a tab mid-import was torn down"
     assert told and "import" in told[0], f"the refusal was silent: {told}"
     assert "next time" in told[0], "the user was not told when it will take effect"
+
+
+def test_a_tab_opened_after_startup_is_still_joined_when_the_window_closes(
+    window: Any, tmp_path: Any
+) -> None:
+    """A running console on such a tab used to abort the process on close.
+
+    `build_window()` handed its panel list to `setProperty()`, which stores a
+    QVariant COPY: the exit path then walked the list as it stood when the
+    window was built, and every tab opened during the session - each install,
+    each adopt - was missing from it. So "Follow worldserver log" on a tab the
+    user opened themselves left a QThread running while Qt was torn down, which
+    aborts (0xC0000409) rather than warns.
+
+    This one stops the window's threads itself, which is the behaviour under
+    test, so it is deliberately LAST in the file: the window is shared, and
+    nothing may run against it afterwards.
+    """
+    server_dir = tmp_path / "following-a-log"
+    _catalog_view(window).adopted.emit("wow-wotlk", server_dir, None, "Ubuntu-24.04")
+    view = _tab_for(window, server_dir)
+    assert view in window.yulon_controllers, "a tab opened after startup is missing from the list"
+    assert view.console_log in window.yulon_log_panels, "so is its console panel"
+
+    def endless() -> Iterator[str]:
+        while True:
+            yield "worldserver line"
+            time.sleep(0.005)
+
+    # What "Follow worldserver log" leaves running, without a real `docker logs`.
+    assert view.console_log.run(endless, title="worldserver log") is True
+    process_events(50)
+    assert view.console_log.running is True, "the job under test was not running to begin with"
+
+    main._stop_background_threads(window)
+
+    assert view.console_log.running is False, "the new tab's console thread outlived the window"

--- a/pylauncher/tests/test_main.py
+++ b/pylauncher/tests/test_main.py
@@ -247,9 +247,43 @@ def window_builder(
     The teardown is `main._stop_background_threads()` itself, not a hand-rolled
     equivalent: a QThread destroyed while running ABORTS the process
     (0xC0000409), and a test that leaks one takes the whole run down with it.
+
+    **Every window built here is destroyed here, by hand.** Twice now CI has
+    died with a SEGFAULT (exit 139) inside a LATER test than the one that
+    caused it - once on py3.11 while py3.13 passed the same commit, then the
+    other way round after a first attempt at this. A crash that swaps
+    interpreters between runs is a lifetime bug whose only variable is when the
+    garbage collector ran, so nothing here is left to Python's refcount or to
+    whenever Qt next happens to pump events:
+
+    * the poll timer is off, so no window is running `docker ps` on a 5-second
+      QTimer into a worker thread while the suite moves on to other tests;
+    * `processEvents()` runs the deferred deletes that `drop_controller()`
+      queues, at a moment this fixture picked, with every thread already joined;
+    * `shiboken6.delete()` then destroys the C++ side outright, rather than
+      leaving a window alive until some later collection frees it under
+      whichever test is running by then.
     """
+    from PySide6.QtWidgets import QApplication
+    from shiboken6 import delete as delete_cpp
+
+    from yulon.ui.controller_view import ControllerView
+
     monkeypatch.setattr(update, "check_for_update", lambda: None)
     monkeypatch.setattr(state, "save_state", lambda _state, path=None: tmp_path / "state.json")
+
+    # A test about which tab exists must not also be shelling out to docker.
+    # `build_window()` takes the default 5000ms, and each poll runs
+    # `controller.status()` on a worker thread - real subprocesses, outliving
+    # the assertions that finished long before they did.
+    real_init = ControllerView.__init__
+
+    def _no_polling(self: Any, entry: Any, services: Any, **kwargs: Any) -> None:
+        kwargs["status_poll_ms"] = 0
+        real_init(self, entry, services, **kwargs)
+
+    monkeypatch.setattr(ControllerView, "__init__", _no_polling)
+
     windows: list[Any] = []
 
     def build(*installs: state.KnownInstall) -> Any:
@@ -261,19 +295,13 @@ def window_builder(
         return window
 
     yield build
-    from PySide6.QtWidgets import QApplication
 
     for window in windows:
         main._stop_background_threads(window)
         window.close()
-    # Flush the deferred deletes BEFORE this test ends, with every thread
-    # already joined. `drop_controller()` uses `deleteLater()`, and a test has
-    # no event loop to run it - so without this the delete fired at whatever
-    # later moment Qt next pumped events, inside an unrelated test, tearing
-    # down widgets while that test held them. It crashed as a SEGFAULT on
-    # CI's py3.11 and passed on py3.13, which is what a lifetime bug looks like
-    # when the only difference is when the garbage collector ran.
     QApplication.processEvents()
+    for window in windows:
+        delete_cpp(window)
     windows.clear()
 
 

--- a/pylauncher/tests/test_maintenance.py
+++ b/pylauncher/tests/test_maintenance.py
@@ -966,6 +966,8 @@ def test_backup_runs_mysqldump_in_the_distro_and_announces_the_password(
     env = seen["env"]
     assert env.get("MYSQL_PWD") == "hunter2"
     assert "MYSQL_PWD" in env.get("WSLENV", "").split(":")
+
+
 def test_a_cmangos_backup_is_not_told_its_databases_are_missing(tmp_path: Path) -> None:
     """The alarm names the schemas THIS core has, not AzerothCore's three.
 

--- a/pylauncher/tests/test_platform.py
+++ b/pylauncher/tests/test_platform.py
@@ -568,6 +568,8 @@ def test_wsl_linux_path_is_none_for_a_path_that_is_not_in_wsl() -> None:
 def test_wsl_linux_path_keeps_the_distro_root_itself() -> None:
     """The share root is the distro's `/`."""
     assert platform.wsl_linux_path(Path(r"\\wsl.localhost\dml-arch")) == "/"
+
+
 def test_a_wsl_path_is_refused_in_words_that_fit_what_happened() -> None:
     """`\\\\wsl.localhost\\...` is a network path to Windows, but not to the user.
 

--- a/pylauncher/tests/test_provision.py
+++ b/pylauncher/tests/test_provision.py
@@ -8,6 +8,7 @@ silent), and the early exit when a daemon already answers.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import threading
@@ -657,6 +658,76 @@ def test_a_healthy_machine_still_gets_the_plain_name(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(platform.sys, "platform", "win32")
     monkeypatch.setattr(platform, "_which", lambda name, path=None: r"C:\bin\docker.exe")
     assert platform.docker_program() == "docker"
+
+
+def _off_path_which(name: str, path: str | None = None) -> str | None:
+    """`docker` resolves nowhere; any absolute candidate confirms itself."""
+    return None if name == "docker" else name
+
+
+def test_the_found_cli_puts_its_own_directory_on_this_processs_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """argv[0] was only half the fix: the CLI shells out to helpers BY NAME.
+
+    Reported from a Mac (2026-08-26). `docker` was found inside the bundle and
+    every command started; the first one that had to reach a registry died:
+
+        the bind-mount probe of /Users/js/Documents failed: Unable to find
+        image 'alpine/git@sha256:c028...' locally
+        docker: error getting credentials - err: exec:
+        "docker-credential-desktop": executable file not found in $PATH
+
+    `docker` resolves its credential helper through PATH, and the PATH a
+    Finder-launched .app inherits from launchd is the same one that could not
+    name `docker` in the first place. So no pull could authenticate, the
+    bind-mount probe read the failed pull as a failed mount, and preflight
+    refused the install with "a container could not see <folder>" — about a
+    folder that was shared, on a machine where the same command worked from
+    Terminal.
+    """
+    bin_dir = tmp_path / "Docker.app" / "Contents" / "Resources" / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "docker").write_text("", encoding="utf-8")
+    _unresolved(monkeypatch)
+    monkeypatch.setattr(platform.sys, "platform", "darwin")
+    monkeypatch.setattr(platform, "_which", _off_path_which)
+    monkeypatch.setattr(platform, "_macos_docker_bins", lambda: (bin_dir,))
+    monkeypatch.setenv("PATH", os.pathsep.join(["/usr/bin", "/bin", "/usr/sbin", "/sbin"]))
+
+    assert platform.docker_program() == str(bin_dir / "docker")
+    entries = os.environ["PATH"].split(os.pathsep)
+    assert entries[0] == str(bin_dir)
+    assert "/usr/bin" in entries, "the inherited PATH was replaced instead of extended"
+
+
+def test_a_plain_docker_leaves_the_path_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare name has no directory to adopt, and a working PATH nothing to fix."""
+    _unresolved(monkeypatch)
+    monkeypatch.setattr(platform.sys, "platform", "darwin")
+    monkeypatch.setattr(platform, "_which", lambda name, path=None: "/usr/local/bin/docker")
+    monkeypatch.setenv("PATH", os.pathsep.join(["/usr/local/bin", "/usr/bin"]))
+
+    assert platform.docker_program() == "docker"
+    assert os.environ["PATH"] == os.pathsep.join(["/usr/local/bin", "/usr/bin"])
+
+
+def test_a_directory_already_on_the_path_is_not_added_twice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Resolution re-runs on every miss; the PATH must not grow an entry per call."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "docker").write_text("", encoding="utf-8")
+    _unresolved(monkeypatch)
+    monkeypatch.setattr(platform.sys, "platform", "darwin")
+    monkeypatch.setattr(platform, "_which", _off_path_which)
+    monkeypatch.setattr(platform, "_macos_docker_bins", lambda: (bin_dir,))
+    before = os.pathsep.join([str(bin_dir), "/usr/bin"])
+    monkeypatch.setenv("PATH", before)
+
+    platform.docker_program()
+    assert os.environ["PATH"] == before
 
 
 def test_a_host_with_no_docker_at_all_says_so(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/pylauncher/yulon/apply.py
+++ b/pylauncher/yulon/apply.py
@@ -66,7 +66,6 @@ class ApplyError(RuntimeError):
     """A step failed in a way that must stop the run (missing template value, git failure, ...)."""
 
 
-def mysql_env(root_password: str, wsl_distro: str | None = None) -> dict[str, str]:
 _CLIENT_NAMES: dict[str, tuple[str, ...]] = {
     "mysql": ("mysql", "mariadb"),
     "mysqldump": ("mysqldump", "mariadb-dump"),
@@ -149,7 +148,7 @@ def _probe_client(db_container: str, candidates: tuple[str, ...]) -> str | None:
     return found[0].rsplit("/", 1)[-1]
 
 
-def mysql_env(root_password: str) -> dict[str, str]:
+def mysql_env(root_password: str, wsl_distro: str | None = None) -> dict[str, str]:
     """This process's environment plus `MYSQL_PWD`, so the password never enters argv.
 
     `docker exec -e MYSQL_PWD` (no `=value`) forwards the variable from OUR

--- a/pylauncher/yulon/docker.py
+++ b/pylauncher/yulon/docker.py
@@ -2398,10 +2398,12 @@ def bind_mount_ok(
     pass and never a refusal — a caller that read it as False would refuse an
     install that would have worked.
 
-    Unverified on macOS, and this is the check most in need of the first gate:
-    that Docker Desktop mounts an unshared folder as empty rather than failing
-    is inherited from the Rust launcher, and what a Mac actually does with an
-    unshared path is exactly what nobody here can run.
+    Still unverified on macOS in the way that matters: that Docker Desktop
+    mounts an unshared folder as empty rather than failing is inherited from
+    the Rust launcher, and what a Mac actually does with an unshared path is
+    exactly what nobody here can run. What a Mac HAS now produced (2026-08-26)
+    is the other half — this function refusing a folder that was shared —
+    which is what the second question below exists for.
     """
     mount = _first_populated_ancestor(server_dir)
     if mount is None:
@@ -2438,7 +2440,29 @@ def bind_mount_ok(
         logger.warning(f"the bind-mount probe of {mount} did not answer within {timeout:.0f}s")
         return None
     if proc.returncode != 0:
+        # A non-zero exit is Docker answering "no" only if Docker got as far as
+        # the mount. It also fails BEFORE that — and on the first install of a
+        # first run, the way it fails there is the probe's own image pull. A Mac
+        # (2026-08-26) ran the CLI out of Docker Desktop's bundle with launchd's
+        # PATH, so `docker` could not exec `docker-credential-desktop`, so every
+        # pull died at authentication; this line read that as an unshared folder
+        # and preflight refused an install whose folder WAS shared, on a machine
+        # where the same command worked from Terminal.
+        #
+        # The exit code cannot separate them: a denied mount and a failed pull
+        # are both non-zero, and matching on error wording would be a list of
+        # every message Docker has ever printed. So the daemon is asked a second
+        # question instead, and one it answers unambiguously. `docker run` pulls
+        # before it mounts, so an image that is not here proves the mount was
+        # never reached, which is `None` — preflight's *unchecked*, never a
+        # refusal. An image in hand means the failure really was the mount.
         logger.warning(f"the bind-mount probe of {mount} failed: {proc.stderr.strip()}")
+        if images_built((image,)) is not True:
+            logger.warning(
+                f"{image} could not be confirmed on this daemon, so that failure was the "
+                "probe's own pull rather than an answer about the folder"
+            )
+            return None
         return False
     if any(line.strip() for line in proc.stdout.splitlines()):
         return True

--- a/pylauncher/yulon/platform.py
+++ b/pylauncher/yulon/platform.py
@@ -944,9 +944,57 @@ def docker_program() -> str | None:
         return _resolved_docker_cli
     for candidate in docker_programs():
         if _which(candidate) is not None:
+            _adopt_cli_directory(candidate)
             _resolved_docker_cli = candidate
             return candidate
     return None
+
+
+def _adopt_cli_directory(program: str) -> None:
+    """Put the directory an off-PATH `docker` was found in onto this process's PATH.
+
+    Naming the binary is only half of the fix, and the missing half cost a Mac
+    tester an evening (2026-08-26). `docker` is not one program: it resolves
+    `docker-credential-<store>` and its `cli-plugins` **by name, through the
+    PATH of the process that started it**. A `.app` opened from Finder is a
+    child of launchd, whose PATH is `/usr/bin:/bin:/usr/sbin:/sbin`, so
+    `/usr/local/bin/docker-credential-desktop` is exactly as invisible as the
+    `docker` symlink beside it. Every command that touched a registry died:
+
+        docker: error getting credentials - err: exec:
+        "docker-credential-desktop": executable file not found in $PATH
+
+    and because the first such command is the bind-mount probe's image pull,
+    preflight reported it as "a container could not see <your folder>" and
+    refused an install on a machine where the identical command worked in
+    Terminal. Prepending the directory here fixes every docker invocation at
+    once — `os.environ` is what `subprocess` hands a child — instead of
+    threading an environment through the nine call sites that spell a docker
+    command, one of which a tenth would forget.
+
+    Prepended, not appended, for the same reason the candidate was preferred
+    over the bare name: this directory is the one Docker Desktop actually
+    installed. The rest of the inherited PATH is kept, because git, the shell
+    and everything else a child may want still live on it.
+
+    A bare `docker` has no directory to adopt (`dirname` is empty) and needs
+    none — it resolved on the PATH we already have. Windows gets the same
+    treatment for the same reason: `docker-credential-desktop.exe` sits next to
+    the `docker.exe` the registry lookup found, and neither is on the PATH the
+    running process inherited.
+    """
+    parent = Path(program).parent
+    if parent == Path("."):
+        # A bare `docker`, or anything else with no directory part. `Path` is
+        # the house rule for paths (style-guide §2) and `os.pathsep` is the
+        # exception it cannot cover: PATH is a string of them, not one path.
+        return
+    directory = str(parent)
+    entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
+    if directory in entries:
+        return
+    os.environ["PATH"] = os.pathsep.join([directory, *entries])
+    logger.info(f"added {directory} to this process's PATH so docker's own helpers resolve too")
 
 
 # ------------------------------------------------------------ WSL-resident servers

--- a/pylauncher/yulon/ui/controller_view.py
+++ b/pylauncher/yulon/ui/controller_view.py
@@ -108,11 +108,12 @@ class ControllerServices:
                     f"and restore will fail until that file is restored"
                 )
             password = wotlk_modules.DEFAULT_DB_ROOT_PASSWORD
-        sql = DockerSql(spec.db, password, wsl_distro=wsl_distro)
         # `schemas=` is what keeps a CMaNGOS install off AzerothCore's `acore_*`
         # names. This factory is the only place that holds both the entry and the
         # seam, so it is the only place that can say which schemas exist here.
-        sql = DockerSql(spec.db, password, schemas=entry.schema_map())
+        # `wsl_distro=` is the other half of the same sentence: the schemas say
+        # WHICH databases, the distro says which daemon they are inside.
+        sql = DockerSql(spec.db, password, schemas=entry.schema_map(), wsl_distro=wsl_distro)
         # Bound to this entry's own db container, not `mysql_for()`'s
         # `docker_ctl.SPEC.db`, so a catalog entry that names a different one
         # cannot end up backing up somebody else's database.
@@ -142,19 +143,19 @@ class ControllerServices:
         return cls(
             controller=controller,
             logs_source=lambda: docker.follow_logs(spec.world, wsl_distro=wsl_distro),
-            # The distro travels with the command because `send_command()` shells
-            # into the world container, and on a WSL-resident server that
-            # container exists only inside the distro. Without it the attach goes
-            # to the local daemon, which has never heard of `ac-worldserver` - so
-            # every console line came back as a docker error rather than a reply.
-            send_console=lambda cmd: wotlk_console.send_command(
-                cmd, container=spec.world, wsl_distro=wsl_distro
-            logs_source=lambda: docker.follow_logs(spec.world),
+            # Three facts, from three different places, and the command needs
+            # all of them: WHICH container (the spec), how to recognise this
+            # server's console prompt (the entry - CMaNGOS does not print
+            # AzerothCore's), and which daemon that container is inside (the
+            # distro). Without the last one the attach goes to the local daemon,
+            # which has never heard of `ac-worldserver`, so every console line
+            # came back as a docker error rather than as a reply.
             send_console=lambda cmd: wotlk_console.send_command(
                 cmd,
                 container=spec.world,
                 prompt=entry.console.prompt,
                 prompt_precedes_answer=entry.console.prompt_precedes_answer,
+                wsl_distro=wsl_distro,
             ),
             store=wotlk_modules.store() if entry.has_manifests else None,
             applier=(

--- a/pyplan/checklist.md
+++ b/pyplan/checklist.md
@@ -655,6 +655,57 @@ not answering, that setup can take a few minutes with no output. Still unverifie
 run-sheet's remaining steps, and whether `xcode-select -p` on Baerthe's box makes the clone go through
 the container git. Ask for `~/Library/Application Support/yulon/yulon.log` on the next run.
 
+### The second macOS run: finding the CLI was only half of it (2026-08-26)
+
+A tester on Discord ran the release on a Mac and preflight refused the install with
+
+> sharing the folder with Docker: a container could not see /Users/j/wow-wotlk, so the server
+> files would be invisible to it
+
+He added the folder to Docker Desktop's file sharing, verified it, added its parent too, created
+and read a file inside a container against that exact path, and tried several other folders. All
+of it worked; the app kept refusing. `~/Library/Application Support/yulon/yulon.log` named the
+real failure in one line:
+
+```
+INFO  [yulon.platform] docker is not on this process's PATH; found it at
+      /Applications/Docker.app/Contents/Resources/bin/docker
+WARNING [yulon.docker] the bind-mount probe of /Users/js/Documents failed: Unable to find image
+      'alpine/git@sha256:c028...' locally
+docker: error getting credentials - err: exec: "docker-credential-desktop": executable file not
+      found in $PATH
+```
+
+**Root cause: the 2026-08-25 fix above resolved argv[0] and stopped there.** `docker` is not one
+program. It execs `docker-credential-<store>` and its `cli-plugins` **by name, through the PATH of
+the process that started it** — and that PATH is launchd's `/usr/bin:/bin:/usr/sbin:/sbin`, in
+which `/usr/local/bin/docker-credential-desktop` is exactly as invisible as the `docker` symlink
+beside it. So every command that had to reach a registry died at authentication. Confirmed by the
+tester: launching the same `.app` as `PATH="/usr/local/bin:…" open /Applications/Yulon.app` got
+past preflight and into the install.
+
+`docker_program()` now adopts the directory it resolved the CLI from into `os.environ["PATH"]`
+(`_adopt_cli_directory()`), which fixes every docker invocation at once rather than threading an
+environment through the nine call sites that spell one. Windows gets it too, for the same reason:
+`docker-credential-desktop.exe` sits next to the `docker.exe` the registry lookup found.
+
+**Second defect, found while reading that log: `bind_mount_ok()` reported a failed pull as an
+unshared folder.** Any non-zero exit from the probe was `False`, and `False` is a hard refusal. The
+exit code cannot separate the two — a denied mount and a failed pull are both non-zero — and
+matching on error wording would be a list of every message Docker has ever printed. It now asks the
+daemon a second question on the failure path: `docker run` pulls before it mounts, so an image that
+is not on the daemon proves the mount was never reached, and that is `None` (*unchecked*), never a
+refusal. With the image in hand the refusal stands, which is the case the check exists for.
+
+**Still open, from the same tester, once past preflight:** the containerized clone failed with
+`Cloning into '.'... /git/.git: No such file or directory`, while the identical `docker run` he
+typed by hand succeeded. The one difference we know of is `ContainerGit._user_args()`, which passes
+`--user <uid>:<gid>` whenever `os.getuid` exists — and its docstring's premise ("on Docker Desktop
+… `os.getuid` does not exist, which is the same condition") is simply false on macOS, so Darwin
+gets the Linux branch the author meant to exclude. Not yet fixed: nobody has confirmed that the
+flag is what breaks it, and the isolating run (his working command plus `--user $(id -u):$(id -g)`)
+is what would.
+
 ### Two things the first button-driven install found (2026-08-24)
 
 **1. A first-run failure whose diagnosis did not survive being tested, and a message that sends


### PR DESCRIPTION
> **Stacks on #112.** That PR fixes two files `Yulon` cannot currently parse, so this branch is based on it; the diff here shrinks to one commit once #112 merges.

A Mac tester's install was refused by preflight with

> sharing the folder with Docker: a container could not see /Users/j/wow-wotlk, so the server files would be invisible to it

He added the folder to Docker Desktop's file sharing, added its parent, verified both, created and read a file inside a container against that exact path, and tried several other folders. All of it worked. The app kept refusing.

## What the log said

```
INFO    [yulon.platform] docker is not on this process's PATH; found it at
        /Applications/Docker.app/Contents/Resources/bin/docker
WARNING [yulon.docker] the bind-mount probe of /Users/js/Documents failed:
        Unable to find image 'alpine/git@sha256:c028...' locally
docker: error getting credentials - err: exec: "docker-credential-desktop":
        executable file not found in $PATH
```

## Defect 1 — `docker_program()` resolved argv[0] and stopped there

`docker` is not one program. It execs `docker-credential-<store>` and its `cli-plugins` **by name, through the PATH of the process that started it**. A `.app` opened from Finder is a child of launchd, whose PATH is `/usr/bin:/bin:/usr/sbin:/sbin` — in which `/usr/local/bin/docker-credential-desktop` is exactly as invisible as the `docker` symlink beside it. So every command that had to reach a registry died at authentication. Confirmed by the tester: the same `.app` opened as `PATH="/usr/local/bin:…" open /Applications/Yulon.app` got past preflight and into the install.

`docker_program()` now adopts the directory it resolved the CLI from into `os.environ["PATH"]` (`_adopt_cli_directory()`). That fixes every docker invocation at once rather than threading an environment through the nine call sites that spell one, and it cannot be forgotten by a tenth. Windows gets it for the same reason: `docker-credential-desktop.exe` sits next to the `docker.exe` the registry lookup found.

## Defect 2 — `bind_mount_ok()` read a failed pull as an unshared folder

Any non-zero exit from the probe was `False`, and `False` is a hard refusal. The exit code cannot separate the two cases — a denied mount and a failed pull are both non-zero — and matching on error wording would be a list of every message Docker has ever printed. So the daemon is asked a second question on the failure path: `docker run` pulls before it mounts, so an image that is not on the daemon proves the mount was never reached, which is `None` — preflight's *unchecked*, never a refusal. With the image in hand the refusal stands, which is the case the check exists for.

## Tests

Three RED before this change: the PATH adoption, the pull failure that must not refuse, and the denied mount that still must. One existing test's fake was extended to answer the second question, since "the mount was denied" implies the image is local.

Suite 945 passed, 27 skipped; `ruff`, `black`, `mypy` clean.

## Still open

The same tester, once past preflight, hit `Cloning into '.'... /git/.git: No such file or directory`, while the identical `docker run` typed by hand succeeded. The one known difference is `ContainerGit._user_args()`, which passes `--user <uid>:<gid>` whenever `os.getuid` exists — and its docstring's premise ("on Docker Desktop … `os.getuid` does not exist, which is the same condition") is false on macOS, so Darwin gets the Linux branch the author meant to exclude. Not fixed here: nobody has confirmed the flag is what breaks it, and the isolating run is what would. Recorded in `pyplan/checklist.md`.