### PR TITLE
A failed clone must name the directory it mounted

### DIFF
--- a/pylauncher/tests/test_git.py
+++ b/pylauncher/tests/test_git.py
@@ -200,6 +200,42 @@ def test_container_git_mounts_the_destination_and_clones_into_it(
     assert "@sha256:" in " ".join(argv), "the image must be pinned by digest, not by a moving tag"
 
 
+def test_a_failed_clone_names_the_directory_it_mounted(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """A failure nobody can reconstruct the command for costs a day of round trips.
+
+    A Mac tester (2026-08-26) reported
+
+        containerized git clone --config core.autocrlf=false … . failed:
+        Cloning into '.'...
+        /git/.git: No such file or directory
+
+    and the one fact needed to diagnose it — WHICH host directory was mounted
+    at `/git` — was in neither the message nor the log. `git_args` alone name
+    `.`, the mount is the only place the destination appears, and
+    `runner.run()` logs the argv at DEBUG while the app runs at INFO. Three
+    rounds of asking over Discord went into recovering a string the process
+    already had.
+    """
+    dest = tmp_path / "core"
+    dest.mkdir()
+
+    def fail(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return _completed(returncode=128, stderr="/git/.git: No such file or directory")
+
+    monkeypatch.setattr(runner, "run", fail)
+    caplog.set_level("INFO")
+    with pytest.raises(git.GitError) as raised:
+        git.ContainerGit().clone(
+            git.CloneSpec(url="https://example/core.git", dest=dest, depth=None)
+        )
+    assert str(dest) in str(raised.value), "the message must say where it was cloning to"
+    assert "/git/.git: No such file or directory" in str(raised.value)
+    logged = "\n".join(r.message for r in caplog.records)
+    assert f"{dest}:/git" in logged, "the mount belongs in the log, at the level the app runs at"
+
+
 def test_is_unmodified_tells_upstreams_own_file_from_one_somebody_edited(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/pylauncher/yulon/git.py
+++ b/pylauncher/yulon/git.py
@@ -471,6 +471,16 @@ class ContainerGit:
             *_HTTP_VERSION_ARGS,
             *git_args,
         ]
+        # At INFO, and the mount is the point. A Mac tester's clone failed with
+        # `/git/.git: No such file or directory` (2026-08-26) and the one fact
+        # needed to diagnose it — which host directory was mounted at `/git` —
+        # was in neither the error nor the log: `git_args` name the destination
+        # `.`, and `runner.run()` logs the argv at DEBUG while the app runs at
+        # INFO. Three rounds of asking over Discord went into recovering a
+        # string this process already held. Same shape as
+        # `docker.build_staged()`, and safe to print: these URLs come from the
+        # manifest allow-list and carry no credentials.
+        logger.info(f"containerized git: `{' '.join(argv[1:])}` into {dest}")
         try:
             proc = runner.run(argv, env=_no_prompt_env())
         except OSError as exc:
@@ -481,7 +491,9 @@ class ContainerGit:
             logger.warning(f"{argv[0]} could not be started: {exc}")
             raise GitError(platform.DOCKER_CLI_MISSING_HELP) from exc
         if proc.returncode != 0:
-            raise GitError(f"containerized git {' '.join(git_args)} failed: {proc.stderr.strip()}")
+            raise GitError(
+                f"containerized git {' '.join(git_args)} in {dest} failed: {proc.stderr.strip()}"
+            )
         return proc
 
     @staticmethod


### PR DESCRIPTION
The Mac report has now cost three rounds of Discord for one string the process already held.

The failure:

```
containerized git clone --config core.autocrlf=false --config core.eol=lf --config http.version=HTTP/1.1 --branch Playerbot https://github.com/mod-playerbots/azerothcore-wotlk.git . failed: Cloning into '.'...
/git/.git: No such file or directory
```

The fact that would diagnose it — **which host directory was mounted at `/git`** — is in neither the message nor the log:

- `git_args` name the destination `.`, because the mount point *is* the destination.
- The only place the real path appears is the `-v` argument.
- `runner.run()` logs the argv at `DEBUG`, while `log.configure()` runs the app at `INFO`.

So `yulon.log` from a failed install does not say where the install was going, and the tester had to be asked. Twice.

Two lines: the resolved argv logged at INFO before the run — the same shape `docker.build_staged()` already uses — and the destination in the `GitError`. Nothing here is a secret; clone URLs come from the manifest allow-list and carry no credentials.

**This does not fix the clone failure.** Both hypotheses raised for it are dead: the tester's own run cleared `--user <uid>:<gid>`, and he had moved off `~/Documents` before the first report, which clears the folder Docker demonstrably cannot see on that machine (`ls: /probe/Documents: No such file or directory`). The next failing run will at least say where it was.

Suite 946 passed, 27 skipped; `ruff`, `black`, `mypy` clean.