### PR TITLE
Every macOS install was refused by an ls that printed the answer

### DIFF
--- a/pylauncher/tests/test_docker.py
+++ b/pylauncher/tests/test_docker.py
@@ -2899,6 +2899,58 @@ def test_a_mount_the_daemon_refused_with_the_image_in_hand_is_still_a_refusal(
     assert docker.bind_mount_ok(tmp_path / "wow", "alpine/git") is False
 
 
+def test_a_listing_with_entries_in_it_is_a_listing_however_ls_exited(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The probe's question is answered by stdout. The exit code is not the answer.
+
+    This refused EVERY macOS install whose chosen folder was new, which is
+    every first install. The chosen folder is empty or absent at preflight
+    time, so the probe walks up to the nearest populated ancestor — routinely
+    the user's home directory — and on a Mac `ls -A` of a home directory prints
+    a full listing AND exits non-zero, because Docker Desktop cannot stat the
+    TCC-protected entries in it. The tester's own run, pasted verbatim
+    (2026-08-26):
+
+        $ docker run --rm --entrypoint ls -v /Users/js:/probe:ro alpine/git@… -A /probe
+        ls: /probe/.Trash: No such file or directory
+        ls: /probe/Documents: No such file or directory
+        .CFUserTextEncoding
+        …
+        wow-wotlk
+
+    busybox `ls` exits non-zero when it could not stat something, so this
+    listing — 15 entries the container plainly saw, including the folder he
+    picked — was read as "Docker cannot see that folder". He re-added the
+    folder to file sharing, added its parent, tried several other folders and
+    read a file back out of a container against that exact path; nothing could
+    have made it pass, because nothing he could do would make `.Trash`
+    stat-able.
+
+    So stdout is asked first. Entries in it mean the container saw the folder,
+    whatever `ls` thought of the parts it could not reach. Only an EMPTY
+    listing sends the question to the exit code — which is the silently-empty
+    mount this check exists for, and it still refuses.
+    """
+    (tmp_path / "already-here.txt").write_text("x", encoding="utf-8")
+    partial = (
+        "ls: /probe/.Trash: No such file or directory\n"
+        "ls: /probe/Documents: No such file or directory\n"
+    )
+
+    def run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if argv[1:3] == ["image", "inspect"]:
+            return _completed(stdout="sha256:abc")
+        return _completed(
+            returncode=1,
+            stdout=".CFUserTextEncoding\nDesktop\nDownloads\nLibrary\nwow-server\n",
+            stderr=partial,
+        )
+
+    monkeypatch.setattr(docker.runner, "run", run)
+    assert docker.bind_mount_ok(tmp_path / "wow-server", "alpine/git") is True
+
+
 def test_the_bind_mount_probe_catches_the_silently_empty_mount_it_exists_for(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/pylauncher/yulon/docker.py
+++ b/pylauncher/yulon/docker.py
@@ -2431,6 +2431,33 @@ def bind_mount_ok(
     )
     if _cli_missing(proc):
         return None
+    # **stdout first, and the exit code second.** The question is whether a
+    # container sees what the host sees, and the answer to that is the listing;
+    # `ls`'s opinion of the parts it could not reach is not the answer.
+    #
+    # Asking the other way round refused EVERY macOS install whose chosen folder
+    # was new — which is every first install. The chosen folder is empty or
+    # absent at preflight time, so the probe walks up to the nearest populated
+    # ancestor, routinely the user's home directory, and on a Mac `ls -A` of a
+    # home directory prints a full listing AND exits non-zero: Docker Desktop
+    # cannot stat the TCC-protected entries in it, busybox `ls` returns failure
+    # when it could not stat something. The tester's own run (2026-08-26) shows
+    # both halves at once — two `No such file or directory` lines for `.Trash`
+    # and `Documents`, then fifteen entries including the folder he had picked.
+    # Nothing he could do would make that pass: he re-added the folder to file
+    # sharing, added its parent, tried other folders and read a file back out of
+    # a container against that exact path, and none of it makes `.Trash`
+    # stat-able.
+    if any(line.strip() for line in proc.stdout.splitlines()):
+        if proc.returncode != 0:
+            logger.info(
+                f"a container listed {mount} and `ls` still exited {proc.returncode}; the "
+                f"listing is the answer. What it could not reach: {proc.stderr.strip()}"
+            )
+        return True
+    # From here the listing was EMPTY, which is the silently-empty mount this
+    # check exists for — and the case where the exit code is worth reading.
+    #
     # A non-zero exit is the daemon answering "no", which IS an answer — unless
     # it never answered at all. `runner.run()` reports a timeout as 124 with the
     # reason in stderr rather than raising, so that case has to be separated out
@@ -2464,8 +2491,6 @@ def bind_mount_ok(
             )
             return None
         return False
-    if any(line.strip() for line in proc.stdout.splitlines()):
-        return True
     logger.warning(
         f"a container saw {mount} as empty although the host sees files in it — Docker is not "
         "sharing that folder"


### PR DESCRIPTION
The tester's fresh run on 0.6.56 pulled `alpine/git` — the credential fix in #113 working — and preflight refused anyway:

> sharing the folder with Docker: a container could not see /Users/js/wow-server, so the server files would be invisible to it

He had already pasted the evidence two hours earlier, in a command he ran by hand:

```
$ docker run --rm --entrypoint ls -v /Users/js:/probe:ro alpine/git@sha256:c028… -A /probe
ls: /probe/.Trash: No such file or directory
ls: /probe/Documents: No such file or directory
.CFUserTextEncoding
.DS_Store
…
wow-wotlk
```

**A full listing AND an error.** Docker Desktop cannot stat the TCC-protected entries in a Mac home directory, and busybox `ls` returns failure when it could not stat something. `bind_mount_ok()` read the exit code before the listing, so fifteen entries the container plainly saw — including the folder he had picked — became "Docker cannot see that folder".

The chosen folder is empty or absent at preflight time by construction, so the probe mounts the nearest *populated ancestor*, which is routinely the home directory. That makes this **every first install on macOS**, and nothing the user can do gets past it: he re-added the folder to file sharing, added its parent, tried several other folders, and read a file back out of a container against that exact path. None of it makes `.Trash` stat-able.

## The change

stdout is asked first. Entries in it mean the container saw the folder, whatever `ls` thought of the parts it could not reach. The exit code is read only when the listing is **empty** — which is the silently-empty mount this check exists for, and which still refuses. A non-zero exit alongside a good listing is logged with what could not be reached, because a listing that needed forgiving is worth seeing.

One test, RED before this, carrying his output verbatim.

## Verification

192 passed across `test_docker.py`, `test_preflight.py`, `test_git.py`; `ruff`, `black`, `mypy` clean on the changed files. The full suite was **not** run: the working tree this was written in also holds another session's in-flight WSL-console work, so only the two files in this commit were touched or verified. CI covers the rest.