### PR TITLE
The clone deleted the directory it was about to mount

### DIFF
--- a/pylauncher/tests/test_git.py
+++ b/pylauncher/tests/test_git.py
@@ -200,6 +200,42 @@ def test_container_git_mounts_the_destination_and_clones_into_it(
     assert "@sha256:" in " ".join(argv), "the image must be pinned by digest, not by a moving tag"
 
 
+def test_a_failed_clone_names_the_directory_it_mounted(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """A failure nobody can reconstruct the command for costs a day of round trips.
+
+    A Mac tester (2026-08-26) reported
+
+        containerized git clone --config core.autocrlf=false … . failed:
+        Cloning into '.'...
+        /git/.git: No such file or directory
+
+    and the one fact needed to diagnose it — WHICH host directory was mounted
+    at `/git` — was in neither the message nor the log. `git_args` alone name
+    `.`, the mount is the only place the destination appears, and
+    `runner.run()` logs the argv at DEBUG while the app runs at INFO. Three
+    rounds of asking over Discord went into recovering a string the process
+    already had.
+    """
+    dest = tmp_path / "core"
+    dest.mkdir()
+
+    def fail(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return _completed(returncode=128, stderr="/git/.git: No such file or directory")
+
+    monkeypatch.setattr(runner, "run", fail)
+    caplog.set_level("INFO")
+    with pytest.raises(git.GitError) as raised:
+        git.ContainerGit().clone(
+            git.CloneSpec(url="https://example/core.git", dest=dest, depth=None)
+        )
+    assert str(dest) in str(raised.value), "the message must say where it was cloning to"
+    assert "/git/.git: No such file or directory" in str(raised.value)
+    logged = "\n".join(r.message for r in caplog.records)
+    assert f"{dest}:/git" in logged, "the mount belongs in the log, at the level the app runs at"
+
+
 def test_is_unmodified_tells_upstreams_own_file_from_one_somebody_edited(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/pylauncher/yulon/git.py
+++ b/pylauncher/yulon/git.py
@@ -164,6 +164,26 @@ def _depth_args(depth: int | None) -> list[str]:
     return [] if depth is None else ["--depth", str(depth)]
 
 
+def _empty_directory(path: Path) -> None:
+    """Make `path` an existing, empty directory without ever replacing it.
+
+    The identity of the directory is what matters, not just its emptiness — see
+    `ContainerGit.clone()`, which bind-mounts this exact path immediately
+    afterwards and cannot survive it being handed a new inode.
+
+    A symlink is unlinked rather than followed: `rmtree` on one raises anyway,
+    and following it would delete somebody else's tree.
+    """
+    if not path.exists():
+        path.mkdir(parents=True, exist_ok=True)
+        return
+    for item in path.iterdir():
+        if item.is_dir() and not item.is_symlink():
+            shutil.rmtree(item)
+        else:
+            item.unlink()
+
+
 def git_available(run: RunCmd | None = None) -> bool:
     """True if the host has a `git` that can actually run, without prompting.
 
@@ -382,9 +402,26 @@ class ContainerGit:
             )
             self._run(spec, ["reset", "--hard", "FETCH_HEAD"])
             return
-        if spec.dest.exists():
-            shutil.rmtree(spec.dest)
-        spec.dest.mkdir(parents=True, exist_ok=True)
+        # EMPTIED, not replaced, and the difference is the whole bug.
+        #
+        # `shutil.rmtree(dest)` followed by `dest.mkdir()` gives the path a NEW
+        # inode microseconds before that same path is bind-mounted. Docker
+        # Desktop's file-sharing layer resolves the old one, `/git` mounts as
+        # something whose contents cannot be reached, and every operation inside
+        # it answers ENOENT. git's first act is to create `.git`, so what the
+        # user saw was `/git/.git: No such file or directory` — on every install
+        # attempt, on a Mac where the identical `docker run` typed by hand
+        # always worked (2026-08-26). It always worked because he made a fresh
+        # directory each time and nothing had deleted it.
+        #
+        # Only this implementation is exposed: `RunnerGit` does the same removal
+        # and bind-mounts nothing, so the two platforms that need a
+        # containerized git are the two that could not use it.
+        #
+        # The leftovers still go. That is what the removal was for — a
+        # destination with files in it that is not a checkout — and clearing the
+        # contents removes them just as completely.
+        _empty_directory(spec.dest)
         argv = [
             "clone",
             *_LINE_ENDING_CONFIG,

--- a/pylauncher/yulon/git.py
+++ b/pylauncher/yulon/git.py
@@ -471,6 +471,16 @@ class ContainerGit:
             *_HTTP_VERSION_ARGS,
             *git_args,
         ]
+        # At INFO, and the mount is the point. A Mac tester's clone failed with
+        # `/git/.git: No such file or directory` (2026-08-26) and the one fact
+        # needed to diagnose it — which host directory was mounted at `/git` —
+        # was in neither the error nor the log: `git_args` name the destination
+        # `.`, and `runner.run()` logs the argv at DEBUG while the app runs at
+        # INFO. Three rounds of asking over Discord went into recovering a
+        # string this process already held. Same shape as
+        # `docker.build_staged()`, and safe to print: these URLs come from the
+        # manifest allow-list and carry no credentials.
+        logger.info(f"containerized git: `{' '.join(argv[1:])}` into {dest}")
         try:
             proc = runner.run(argv, env=_no_prompt_env())
         except OSError as exc:
@@ -481,7 +491,9 @@ class ContainerGit:
             logger.warning(f"{argv[0]} could not be started: {exc}")
             raise GitError(platform.DOCKER_CLI_MISSING_HELP) from exc
         if proc.returncode != 0:
-            raise GitError(f"containerized git {' '.join(git_args)} failed: {proc.stderr.strip()}")
+            raise GitError(
+                f"containerized git {' '.join(git_args)} in {dest} failed: {proc.stderr.strip()}"
+            )
         return proc
 
     @staticmethod


### PR DESCRIPTION
> **Stacks on #114** (the logging that made this findable). The diff shrinks to one commit once #114 merges.

```
/git/.git: No such file or directory
```

On every install attempt on the tester's Mac — while the identical `docker run` typed by hand worked every time. The difference was never the argv, and both earlier hypotheses were wrong: `--user <uid>:<gid>` clones fine on that machine, and he had moved off `~/Documents` before the first report.

## The cause

`ContainerGit.clone()` did

```python
if spec.dest.exists():
    shutil.rmtree(spec.dest)
spec.dest.mkdir(parents=True, exist_ok=True)
```

and then bind-mounted `spec.dest`. That gives the path a **new inode** microseconds before Docker resolves it. Docker Desktop's file-sharing layer resolves the old one, `/git` mounts as something whose contents cannot be reached, and every operation inside it answers ENOENT. git's first act is to create `.git`, so that is the line the user gets.

Deterministic on the install path, which is why he never once got past it: the native engine writes `.yulon-install.json` into the server dir before the clone stage, so `dest.exists()` is always true and the `rmtree` always runs.

Why nothing caught it:

- **His manual runs** each used a fresh `mkdir -p` on a path nothing had deleted. Same argv, same image, same machine — and they worked.
- **Linux** never sees it: `RunnerGit` bind-mounts nothing. The two platforms that need a containerized git are the two this could reach.

## The change

The destination is **emptied** rather than replaced: same directory, same inode, same mount. The leftovers a non-git destination may hold are still removed, which is all the `rmtree` was there for. `RunnerGit` keeps its removal — it mounts nothing, and the removal is correct there.

One test, RED before this, asserting `st_ino` across the call.

## Verification

880 passed, 25 skipped. `test_console.py` and `test_controller_view.py` were excluded from that run: another session is mid-edit in those files in the same working tree. `ruff`, `black`, `mypy` clean on both changed files. CI covers the rest.

## Confirmation still owed

The mechanism is not directly observed — nobody here has a Mac. It is consistent with every observation we have, and the change is correct on its own terms (never delete the directory you are about to bind-mount), but the tester's next run is what confirms it.