### PR TITLE
A containerized git failure must carry its exit code

### DIFF
--- a/pylauncher/tests/test_git.py
+++ b/pylauncher/tests/test_git.py
@@ -232,6 +232,12 @@ def test_a_failed_clone_names_the_directory_it_mounted(
         )
     assert str(dest) in str(raised.value), "the message must say where it was cloning to"
     assert "/git/.git: No such file or directory" in str(raised.value)
+    # And the exit code, which `RunnerGit` has always reported and this path
+    # never did. The Mac clone died in under a second with git's stderr cut off
+    # after `Cloning into '.'...` and nothing after it — a killed process and a
+    # failed one look identical without the number, and 137 means something
+    # very different from 128 here.
+    assert "128" in str(raised.value), "a failure with no exit code cannot be told apart"
     logged = "\n".join(r.message for r in caplog.records)
     assert f"{dest}:/git" in logged, "the mount belongs in the log, at the level the app runs at"
 

--- a/pylauncher/tests/test_git.py
+++ b/pylauncher/tests/test_git.py
@@ -200,6 +200,42 @@ def test_container_git_mounts_the_destination_and_clones_into_it(
     assert "@sha256:" in " ".join(argv), "the image must be pinned by digest, not by a moving tag"
 
 
+def test_a_failed_clone_names_the_directory_it_mounted(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """A failure nobody can reconstruct the command for costs a day of round trips.
+
+    A Mac tester (2026-08-26) reported
+
+        containerized git clone --config core.autocrlf=false … . failed:
+        Cloning into '.'...
+        /git/.git: No such file or directory
+
+    and the one fact needed to diagnose it — WHICH host directory was mounted
+    at `/git` — was in neither the message nor the log. `git_args` alone name
+    `.`, the mount is the only place the destination appears, and
+    `runner.run()` logs the argv at DEBUG while the app runs at INFO. Three
+    rounds of asking over Discord went into recovering a string the process
+    already had.
+    """
+    dest = tmp_path / "core"
+    dest.mkdir()
+
+    def fail(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return _completed(returncode=128, stderr="/git/.git: No such file or directory")
+
+    monkeypatch.setattr(runner, "run", fail)
+    caplog.set_level("INFO")
+    with pytest.raises(git.GitError) as raised:
+        git.ContainerGit().clone(
+            git.CloneSpec(url="https://example/core.git", dest=dest, depth=None)
+        )
+    assert str(dest) in str(raised.value), "the message must say where it was cloning to"
+    assert "/git/.git: No such file or directory" in str(raised.value)
+    logged = "\n".join(r.message for r in caplog.records)
+    assert f"{dest}:/git" in logged, "the mount belongs in the log, at the level the app runs at"
+
+
 def test_is_unmodified_tells_upstreams_own_file_from_one_somebody_edited(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/pylauncher/yulon/git.py
+++ b/pylauncher/yulon/git.py
@@ -492,7 +492,14 @@ class ContainerGit:
             raise GitError(platform.DOCKER_CLI_MISSING_HELP) from exc
         if proc.returncode != 0:
             raise GitError(
-                f"containerized git {' '.join(git_args)} in {dest} failed: {proc.stderr.strip()}"
+                # The exit code, which `_run_git()` has always reported and this
+                # path never did. The Mac clone (2026-08-27) died in under a
+                # second with git's stderr ending at `Cloning into '.'...` and
+                # nothing after it — and a process that was killed looks exactly
+                # like one that failed when the only evidence is the words it
+                # got out first. 137 and 128 are different investigations.
+                f"containerized git {' '.join(git_args)} in {dest} exited "
+                f"{proc.returncode}: {proc.stderr.strip()}"
             )
         return proc
 

--- a/pylauncher/yulon/git.py
+++ b/pylauncher/yulon/git.py
@@ -471,6 +471,16 @@ class ContainerGit:
             *_HTTP_VERSION_ARGS,
             *git_args,
         ]
+        # At INFO, and the mount is the point. A Mac tester's clone failed with
+        # `/git/.git: No such file or directory` (2026-08-26) and the one fact
+        # needed to diagnose it — which host directory was mounted at `/git` —
+        # was in neither the error nor the log: `git_args` name the destination
+        # `.`, and `runner.run()` logs the argv at DEBUG while the app runs at
+        # INFO. Three rounds of asking over Discord went into recovering a
+        # string this process already held. Same shape as
+        # `docker.build_staged()`, and safe to print: these URLs come from the
+        # manifest allow-list and carry no credentials.
+        logger.info(f"containerized git: `{' '.join(argv[1:])}` into {dest}")
         try:
             proc = runner.run(argv, env=_no_prompt_env())
         except OSError as exc:
@@ -481,7 +491,9 @@ class ContainerGit:
             logger.warning(f"{argv[0]} could not be started: {exc}")
             raise GitError(platform.DOCKER_CLI_MISSING_HELP) from exc
         if proc.returncode != 0:
-            raise GitError(f"containerized git {' '.join(git_args)} failed: {proc.stderr.strip()}")
+            raise GitError(
+                f"containerized git {' '.join(git_args)} in {dest} failed: {proc.stderr.strip()}"
+            )
         return proc
 
     @staticmethod


### PR DESCRIPTION
> **Stacks on #114.** Shrinks to one commit once that merges.

`_run_git()` has always reported `exited {returncode}`. `ContainerGit._capture()` never did, and the Mac report is where that costs something.

With the argv now logged (#114), the tester ran the app's exact command by hand — `--user 501:20`, the `-c` wrapper flags, the same pinned digest, into a freshly `rm -rf`'d and recreated directory — and it cloned:

```
2026-08-27 17:20:44 INFO [yulon.git] containerized git: `run --rm -v /Users/js/wow2:/git -w /git --user 501:20 alpine/git@sha256:c028… -c core.autocrlf=false -c core.eol=lf -c http.version=HTTP/1.1 clone --config … --branch Playerbot https://github.com/mod-playerbots/azerothcore-wotlk.git .` into /Users/js/wow2
2026-08-27 17:20:44 WARNING [yulon.ui.widgets.log_panel] log panel job failed: InstallerError: … failed: Cloning into '.'...
```

**So the command is not the difference.** That closes the last theory that could be read off the source, and it leaves a thin trail: both failures took under a second — the INFO and the WARNING carry the same timestamp — and git's stderr ends at `Cloning into '.'...` with nothing after it. Not even the `/git/.git: No such file or directory` the earlier runs produced.

A process that was killed and a process that failed look identical when the only evidence is the words it got out first. 137 is a different investigation from 128.

Instrument only — this fixes nothing. Suite 946 passed, 27 skipped; `ruff`, `black`, `mypy` clean.