### PR TITLE
The Console tab can type again, when the server lives in WSL

### DIFF
--- a/pylauncher/tests/test_console.py
+++ b/pylauncher/tests/test_console.py
@@ -94,6 +94,133 @@ def test_send_command_explains_itself_where_there_is_no_pty() -> None:
         console.send_command("server info", container="ac-worldserver")
 
 
+class _FakePipeProc:
+    """A `docker attach` whose stdin is a pipe, the way the in-distro path runs it.
+
+    Records every byte written, so a test can tell a command from the detach
+    keys, and exits when it is sent them — which is what the real client does
+    (`read escape sequence`, measured 2026-08-27). `ignores_detach=True` models
+    the one that does not.
+    """
+
+    def __init__(self, argv: list[str], **kwargs: Any) -> None:
+        self.argv = argv
+        self.written = b""
+        self.killed = False
+        self.ignores_detach = False
+        self.stdin = self
+        self.stdout = io.BytesIO(b"AC> \r\nAccount created: dad\r\n")
+        self._rc: int | None = None
+
+    # -- the stdin pipe --------------------------------------------------
+    def write(self, data: bytes) -> int:
+        self.written += data
+        if console.DETACH_SEQUENCE in data and not self.ignores_detach:
+            self._rc = 1  # docker attach exits 1 after `read escape sequence`
+        return len(data)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    # -- the process -----------------------------------------------------
+    def kill(self) -> None:
+        self.killed = True
+        self._rc = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self._rc is None:
+            raise subprocess.TimeoutExpired("docker attach", timeout or 0)
+        return self._rc
+
+    def poll(self) -> int | None:
+        return self._rc
+
+
+def _distro_send(command: str = "server info", **kwargs: Any) -> tuple[Any, _FakePipeProc]:
+    """`send_command()` against a WSL-resident server, with the client faked."""
+    made: list[_FakePipeProc] = []
+
+    def popen(argv: list[str], **kw: Any) -> _FakePipeProc:
+        proc = _FakePipeProc(argv, **kw)
+        for name, value in kwargs.items():
+            setattr(proc, name, value)
+        made.append(proc)
+        return proc
+
+    reply = console.send_command(
+        command,
+        container="ac-worldserver",
+        wsl_distro="dml-arch",
+        window=0.01,
+        popen=popen,  # type: ignore[arg-type]
+    )
+    return reply, made[0]
+
+
+def test_a_wsl_console_allocates_its_pty_inside_the_distro() -> None:
+    """Windows has no pty to give docker; the distro does, and script(1) opens it.
+
+    Measured 2026-08-27 against a real tty container, from Windows: a plain
+    `wsl -d D -- docker attach` answers "cannot attach stdin to a TTY-enabled
+    container because stdin is not a terminal", and this argv answers the
+    command. `--detach-keys` is pinned rather than left to docker's default
+    because the teardown depends on it and a `detachKeys` in the distro's own
+    ~/.docker/config.json would otherwise change it out from under us.
+    """
+    _reply, proc = _distro_send()
+    assert proc.argv[1:4] == ["-d", "dml-arch", "--"], proc.argv
+    assert proc.argv[4] == "script"
+    assert proc.argv[5] == "-qec"
+    assert proc.argv[7] == "/dev/null"
+    assert proc.argv[6] == (
+        "docker attach --sig-proxy=false --detach-keys=ctrl-p,ctrl-q ac-worldserver"
+    )
+
+
+def test_a_wsl_console_detaches_and_never_kills_its_client() -> None:
+    """The teardown that the POSIX path uses would stop the worldserver here.
+
+    Measured 2026-08-27, Windows -> WSL, on a container whose PID 1 reads its
+    tty: killing the client stopped the container even when nothing had been
+    written to it, while the detach keys left it running on the same PID. So
+    this path detaches, and `kill()` is the fallback rather than the method.
+    """
+    _reply, proc = _distro_send("server info")
+    assert proc.written == b"server info\n" + console.DETACH_SEQUENCE, proc.written
+    assert proc.killed is False, "killing the client can stop the worldserver"
+
+
+def test_a_wsl_console_that_will_not_detach_is_killed_and_says_so(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A client that ignores the detach keys is still let go of, loudly.
+
+    Leaving it attached is not the safer option it looks like: a second client
+    on the same tty puts foreign prompts and echoes inside the next reply's
+    window (see `console._PROMPT`). So it is killed - and because that can take
+    the container with it, the log says which risk was taken.
+    """
+    with caplog.at_level(logging.WARNING):
+        _reply, proc = _distro_send(ignores_detach=True)
+    assert proc.killed is True
+    assert any("did not detach" in r.message for r in caplog.records), caplog.text
+
+
+def test_a_wsl_console_still_parses_the_reply_out_of_the_window() -> None:
+    """The transport changed; what counts as an answer did not."""
+    reply, _proc = _distro_send("account create dad pw")
+    assert reply.lines == ("Account created: dad",)
+
+
+def test_a_distro_console_is_available_where_no_pty_is() -> None:
+    """The Send button asks this, and on Windows the answer used to be no."""
+    assert console.can_send("dml-arch") is True
+    assert console.can_send(None) is console.pty_supported()
+
+
 def test_send_command_rejects_multiline_or_empty() -> None:
     with pytest.raises(ValueError):
         console.send_command("a\nb", popen=_FakeProc)  # type: ignore[arg-type]

--- a/pylauncher/tests/test_controller_view.py
+++ b/pylauncher/tests/test_controller_view.py
@@ -374,6 +374,26 @@ def test_the_console_says_why_it_is_disabled_where_there_is_no_pty(
     assert view.follow_button.isEnabled(), "following the log needs no pty"
 
 
+def test_a_wsl_console_is_usable_on_a_host_that_has_no_pty_of_its_own(
+    qapp: object, ps: _Ps, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows + a server inside WSL: no pty here, and Send still works.
+
+    The tab used to ask `pty_supported()`, which is a fact about THIS process
+    and not about whether the console can be reached. The distro can open a
+    terminal even where Windows cannot (measured 2026-08-27), so the question
+    the button asks had to change with the transport - otherwise the fix ships
+    behind a button that is still greyed out.
+    """
+    monkeypatch.setattr(console, "pty_supported", lambda: False)
+    services = _services(ps, tmp_path, [])
+    services.controller = Controller(WOTLK.container_spec(), tmp_path, wsl_distro="dml-arch")
+    view = ControllerView(WOTLK, services, status_poll_ms=0)
+    assert view.send_button.isEnabled()
+    assert view.command_edit.isEnabled()
+    assert view.console_note.text() == "", view.console_note.text()
+
+
 def test_a_restore_will_not_run_without_a_plan(qapp: object, ps: _Ps, tmp_path: Path) -> None:
     """The button is disabled, and the slot refuses anyway.
 

--- a/pylauncher/yulon/controller_wow_wotlk/console.py
+++ b/pylauncher/yulon/controller_wow_wotlk/console.py
@@ -30,6 +30,7 @@ answer, and this one was handing back several times more log noise than reply.
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 import threading
 import time
@@ -123,6 +124,84 @@ NO_TTY_HELP = (
 )
 
 
+DETACH_KEYS = "ctrl-p,ctrl-q"
+"""Docker's default detach sequence, pinned rather than assumed.
+
+The in-distro transport DEPENDS on it: that path leaves the console by typing
+these keys, so a `detachKeys` set in the distro's own ~/.docker/config.json
+would otherwise mean the keys we send are not the keys that detach, and the
+fallback below is `kill()` - which stops the container.
+"""
+
+DETACH_SEQUENCE = b""
+"""Ctrl+P, Ctrl+Q as bytes: what `DETACH_KEYS` spells on the wire."""
+
+_DETACH_GRACE_SECONDS = 5.0
+"""How long the client gets to leave on its own before it is killed.
+
+Measured 2026-08-27: a real client answered the keys within a second
+(`read escape sequence`, exit 1). The margin is for a loaded host, not for a
+client that is going to ignore them.
+"""
+
+NO_SCRIPT_HELP = (
+    "The worldserver console needs `script` inside {distro}, and there is none. "
+    "It comes with util-linux (`sudo apt install bsdutils` on Debian/Ubuntu, "
+    "`sudo pacman -S util-linux` on Arch). Until then use the console in a "
+    "terminal: `wsl -d {distro} -- docker attach --sig-proxy=false {container}` "
+    "(Ctrl+P then Ctrl+Q to leave it running)."
+)
+
+
+def can_send(wsl_distro: str | None = None) -> bool:
+    """Can this host type at that server's console?
+
+    Two ways to satisfy docker's "stdin must be a terminal": open a pty here
+    (POSIX), or have the distro open one (`distro_attach_argv()`). The second
+    is why this is not simply `pty_supported()` — a Windows box managing a
+    WSL-resident server has no pty of its own and can still send.
+    """
+    return wsl_distro is not None or pty_supported()
+
+
+def distro_attach_argv(container: str, wsl_distro: str) -> list[str]:
+    """`docker attach`, with the pseudo-terminal allocated INSIDE the distro.
+
+    Windows cannot hand docker a terminal, so it borrows the distro's:
+    `script(1)` opens a pty there, runs `docker attach` on it, and relays this
+    process's ordinary pipe through it. Measured 2026-08-27 against a tty
+    container, from Windows: the bare `wsl -d D -- docker attach` answers
+    "cannot attach stdin to a TTY-enabled container because stdin is not a
+    terminal", and this argv answers the command.
+
+    `/dev/null` is `script`'s transcript file — the typescript is not wanted,
+    only the terminal it has to create in order to write one.
+
+    The container name is `shlex.quote`d because it lands inside a string that
+    the distro's shell parses, which is a different place than the argv list
+    every other docker call in this app builds.
+
+    Raises:
+        ConsoleError: no wsl.exe on this host, so the distro cannot be reached
+            at all — the same sentence `attach_argv()` raises, for the same
+            reason (it is `docker_prefix()`'s None, one layer down).
+    """
+    prefix = platform.wsl_prefix(wsl_distro)
+    if prefix is None:
+        raise ConsoleError(platform.DOCKER_CLI_MISSING_HELP)
+    inner = " ".join(
+        shlex.quote(part)
+        for part in (
+            "docker",
+            "attach",
+            "--sig-proxy=false",
+            f"--detach-keys={DETACH_KEYS}",
+            container,
+        )
+    )
+    return [*prefix, "script", "-qec", inner, "/dev/null"]
+
+
 def attach_argv(container: str, *, wsl_distro: str | None = None) -> list[str]:
     """The exact `docker attach` invocation used (pinned by tests).
 
@@ -180,8 +259,18 @@ def send_command(
     if any(ch in command.strip("\n") for ch in ("\n", "\r")) or not command.strip():
         raise ValueError("send_command() takes exactly one non-empty command line")
     logger.info(f"console → {container}: {command.split(' ', 2)[0:2]}")  # never log passwords
-    if not pty_supported():
+    if not can_send(wsl_distro):
         raise ConsoleError(NO_TTY_HELP.format(container=container))
+    if wsl_distro is not None:
+        # A pty this process cannot open, opened where it can be: inside the
+        # distro. Everything after the transport — the window, the prompt, the
+        # parse — is shared with the pty path below.
+        raw = _send_inside_distro(
+            command, container=container, wsl_distro=wsl_distro, window=window, popen=popen
+        )
+        return _parse_reply(
+            raw, command, prompt=prompt, prompt_precedes_answer=prompt_precedes_answer
+        )
     # Resolve the CLI BEFORE the pty exists. `attach_argv()` can raise, and the
     # `except OSError` below would not catch a ConsoleError — the master/slave
     # pair would leak one fd per attempt.
@@ -221,16 +310,7 @@ def send_command(
         logger.warning(f"{argv[0]} could not be started: {exc}")
         raise ConsoleError(platform.DOCKER_CLI_MISSING_HELP) from exc
     os.close(slave)  # the child holds its own copy
-    assert proc.stdout is not None
-    out: list[str] = []
-
-    def _pump() -> None:
-        assert proc.stdout is not None
-        for raw in proc.stdout:
-            out.append(raw.decode("utf-8", errors="replace").rstrip("\r\n"))
-
-    reader = threading.Thread(target=_pump, daemon=True)
-    reader.start()
+    out, reader = _pump(proc)
     # Give docker a moment to attach, or the first command is written into the
     # void before the console is listening.
     time.sleep(_ATTACH_SETTLE_SECONDS)
@@ -253,6 +333,122 @@ def send_command(
     return _parse_reply(
         list(out), command, prompt=prompt, prompt_precedes_answer=prompt_precedes_answer
     )
+
+
+def _pump(proc: subprocess.Popen[bytes]) -> tuple[list[str], threading.Thread]:
+    """Drain the client's output into a list on a daemon thread.
+
+    Shared by both transports: nothing here reads the stream while it is
+    arriving, so the window is a clock either way (see `_parse_reply()`).
+    """
+    assert proc.stdout is not None
+    out: list[str] = []
+
+    def _drain() -> None:
+        assert proc.stdout is not None
+        for raw in proc.stdout:
+            out.append(raw.decode("utf-8", errors="replace").rstrip("\r\n"))
+
+    reader = threading.Thread(target=_drain, daemon=True)
+    reader.start()
+    return out, reader
+
+
+def _send_inside_distro(
+    command: str,
+    *,
+    container: str,
+    wsl_distro: str,
+    window: float,
+    popen: type[subprocess.Popen[bytes]],
+) -> list[str]:
+    """One command through a pty the distro opens; returns the raw window.
+
+    Stdin here is an ordinary pipe, not a pty — `script(1)` on the other side
+    of wsl.exe is what makes docker see a terminal, and it relays this pipe
+    into it. That is the whole reason this path works on a host with no
+    `os.openpty()`.
+    """
+    argv = distro_attach_argv(container, wsl_distro)
+    try:
+        proc = popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=0,
+            env=runner.child_env(),
+            creationflags=runner.creationflags(),
+        )
+    except OSError as exc:
+        logger.warning(f"{argv[0]} could not be started: {exc}")
+        raise ConsoleError(platform.DOCKER_CLI_MISSING_HELP) from exc
+    out, reader = _pump(proc)
+    time.sleep(_ATTACH_SETTLE_SECONDS)
+    try:
+        _write(proc, (command.strip("\n") + "\n").encode("utf-8"))
+    except OSError as exc:
+        _detach_console(proc, reader)
+        raise ConsoleError(f"could not write to the worldserver console: {exc}") from exc
+    time.sleep(window)
+    _detach_console(proc, reader)
+    lines = list(out)
+    # The one failure this transport has that the pty path does not: a distro
+    # with no util-linux. Recognised rather than handed back as a reply,
+    # because "script: command not found" in the console panel reads as the
+    # SERVER refusing something.
+    if any("script" in line and "not found" in line for line in lines):
+        raise ConsoleError(NO_SCRIPT_HELP.format(distro=wsl_distro, container=container))
+    return lines
+
+
+def _write(proc: subprocess.Popen[bytes], data: bytes) -> None:
+    """Write to the client's stdin pipe and flush it (raises `OSError`)."""
+    assert proc.stdin is not None
+    proc.stdin.write(data)
+    proc.stdin.flush()
+
+
+def _detach_console(proc: subprocess.Popen[bytes], reader: threading.Thread) -> None:
+    """Leave the console by typing docker's detach keys — never by killing it.
+
+    This is the opposite of `_close_console()` below, and the difference was
+    measured rather than reasoned about (2026-08-27, Windows → WSL, against a
+    container whose PID 1 reads its tty): killing the client stopped the
+    container, even on a run that had written nothing to it at all, while the
+    detach keys left it running on the same PID. The same kill is harmless on
+    Linux, where the pty path still uses it — which is exactly why this had to
+    be measured on the platform it ships to rather than reasoned from the one
+    it was written on.
+
+    `kill()` stays as the fallback, because leaving a client attached is not
+    the safer option it looks like: a second client on the same tty puts
+    foreign prompts and echoes inside the next command's window (see
+    `_PROMPT`). The warning names the risk that is then being taken.
+    """
+    if proc.poll() is None:
+        try:
+            _write(proc, DETACH_SEQUENCE)
+        except OSError as exc:  # pragma: no cover - the pipe is already gone
+            logger.warning(f"the detach keys could not be sent: {exc}")
+    try:
+        proc.wait(timeout=_DETACH_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "the console client did not detach; killing it, which through wsl.exe has been "
+            "measured to stop the container as well"
+        )
+        proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:  # pragma: no cover - kill() not honoured
+            logger.warning("docker attach did not exit after kill()")
+    if proc.stdin is not None:
+        try:
+            proc.stdin.close()
+        except OSError:  # pragma: no cover - already closed
+            pass
+    reader.join(timeout=2)
 
 
 def _close_console(proc: subprocess.Popen[bytes], master: int, reader: threading.Thread) -> None:

--- a/pylauncher/yulon/platform.py
+++ b/pylauncher/yulon/platform.py
@@ -1036,20 +1036,38 @@ def docker_prefix(
     if wsl_distro is None:
         program = docker_program()
         return (program,) if program is not None else None
-    launcher = _which(WSL_PROGRAM)
-    if launcher is None:
-        logger.debug(f"no {WSL_PROGRAM} on this host; cannot reach docker in {wsl_distro!r}")
+    prefix = wsl_prefix(wsl_distro, inside=inside)
+    if prefix is None:
         return None
-    # `--cd` is an argument to wsl.exe and MUST precede the `--` separator:
-    # everything after `--` is the command line handed to the distro's shell, so
-    # a `--cd` placed there arrives at bash, which answers "--: invalid option".
-    # Measured against a real distro, which is the only reason this is right -
-    # the first version put it after the separator, and the unit test, which
-    # asserted only that `--cd` was present, passed a command that could not run.
-    location = ("--cd", inside) if inside else ()
     # `docker` unqualified on purpose: it is resolved by the distro's own PATH,
     # by its own shell, where this process's PATH means nothing.
-    return (launcher, "-d", wsl_distro, *location, "--", "docker")
+    return (*prefix, "docker")
+
+
+def wsl_prefix(wsl_distro: str, *, inside: str | None = None) -> tuple[str, ...] | None:
+    """The argv that runs ANY command inside `wsl_distro`, or None without wsl.exe.
+
+        wsl_prefix("dml-arch") -> ("wsl", "-d", "dml-arch", "--")
+
+    Split out of `docker_prefix()` because docker is no longer the only thing
+    the app runs in there. The worldserver console needs a pseudo-terminal that
+    Windows cannot provide, and the distro can: `script(1)` opens one INSIDE it
+    (`console.distro_attach_argv()`). That command is not `docker <args>`, so it
+    cannot use a prefix ending in `docker`.
+
+    `--cd` is an argument to wsl.exe and MUST precede the `--` separator:
+    everything after `--` is the command line handed to the distro's shell, so
+    a `--cd` placed there arrives at bash, which answers "--: invalid option".
+    Measured against a real distro, which is the only reason this is right -
+    the first version put it after the separator, and the unit test, which
+    asserted only that `--cd` was present, passed a command that could not run.
+    """
+    launcher = _which(WSL_PROGRAM)
+    if launcher is None:
+        logger.debug(f"no {WSL_PROGRAM} on this host; cannot reach {wsl_distro!r}")
+        return None
+    location = ("--cd", inside) if inside else ()
+    return (launcher, "-d", wsl_distro, *location, "--")
 
 
 def wsl_env(extra: dict[str, str] | None = None) -> dict[str, str]:

--- a/pylauncher/yulon/ui/controller_view.py
+++ b/pylauncher/yulon/ui/controller_view.py
@@ -805,7 +805,7 @@ class ControllerView(QWidget):
         self.console_note.setWordWrap(True)
         self.console_note.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         self.console_note.setVisible(False)
-        if not wotlk_console.pty_supported():
+        if not self._console_available():
             # Checklist 6.5 asks for this gap to be re-scoped, "not left silently
             # broken". Refusing on click and printing the error afterwards is not
             # the same as saying so up front: the catalog tile already disables
@@ -866,10 +866,22 @@ class ControllerView(QWidget):
             self._console_failed,
         )
 
+    def _console_available(self) -> bool:
+        """Can this host type at this server's console?
+
+        Not `pty_supported()` any more, and the difference is a whole platform.
+        A Windows box managing a WSL-resident server has no pty of its own and
+        can still send: the distro opens one (`console.distro_attach_argv()`).
+        Asked of the controller because that is where the distro is already
+        recorded — a second copy on `ControllerServices` would be one more
+        thing that can disagree with the seam actually doing the work.
+        """
+        return wotlk_console.can_send(wsl_distro=self.services.controller.wsl_distro)
+
     def _console_idle(self) -> None:
-        """Re-arm Send — never where there is no pty (see `_build_console_tab()`)."""
+        """Re-arm Send — never where it cannot send (see `_build_console_tab()`)."""
         self._console_pending = False
-        self.send_button.setEnabled(wotlk_console.pty_supported())
+        self.send_button.setEnabled(self._console_available())
 
     @Slot(object)
     def _console_reply(self, result: object) -> None:


### PR DESCRIPTION
Windows has no `os.openpty()`, docker refuses `docker attach` unless its stdin is a terminal, and so the Send button has been greyed out with `NO_TTY_HELP` on every Windows install. For a WSL-resident server that is now fixable: the distro has a pty even where Windows does not, and `script(1)` opens one there.

```
wsl -d D -- script -qec "docker attach --sig-proxy=false
                         --detach-keys=ctrl-p,ctrl-q <container>" /dev/null
```

Measured before it was written (2026-08-27, Windows -> WSL, against a tty container): the bare `wsl -d D -- docker attach` answers *"cannot attach stdin to a TTY-enabled container because stdin is not a terminal"*, and this argv answers the command.

## The teardown had to change with it, and that is the part with teeth

`send_command()` detaches by killing its client. Through `wsl.exe` that killed the **container** — measured on a run that wrote nothing to it at all — while docker's detach keys left it running on the same PID. The same kill is harmless on Linux, where the pty path still uses it, which is exactly why this had to be measured on the platform it ships to.

So the in-distro path types Ctrl+P Ctrl+Q, `--detach-keys` is pinned rather than left to a distro's own `~/.docker/config.json`, and `kill()` is the fallback that says in the log which risk it is taking.

## Live-gated in two halves, because no single box has both

* **The real console** — `send_command()` itself against the live CMaNGOS worldserver on m910q: `script(1)`, detach keys and the parser. `server info` returned its four lines, `gm list` its table, `flurbleblarg` came back as "There is no such command" rather than silence, and the container held PID 515342 with RestartCount 0 across all of it, no client left behind.
* **The real transport** — the same `send_command()` through the real `wsl.exe` from Windows into `dml-arch`: three commands, container PID unchanged, every detach clean.

## Two smaller changes that the fix needs

* The Send button asks `console.can_send(wsl_distro=...)` now instead of `pty_supported()`, which is a fact about *this process* rather than about whether the console can be reached — otherwise the fix would ship behind a button that is still disabled.
* `platform.wsl_prefix()` is split out of `docker_prefix()`: docker is no longer the only thing the app runs inside a distro, and a prefix ending in `docker` cannot run `script`.

## Gates

Rebased onto `Yulon` and re-run there: **951 passed, 27 skipped**; `ruff` and `black --check` clean; `mypy yulon main.py` clean on all three CI platforms (native, `--platform win32`, `--platform darwin`).
