### PR TITLE
hasattr(os, "getuid") is a test for Windows, not for Docker Desktop

### DIFF
--- a/pylauncher/tests/test_git.py
+++ b/pylauncher/tests/test_git.py
@@ -200,6 +200,54 @@ def test_container_git_mounts_the_destination_and_clones_into_it(
     assert "@sha256:" in " ".join(argv), "the image must be pinned by digest, not by a moving tag"
 
 
+def test_docker_desktop_never_gets_a_user_flag(
+    monkeypatch: pytest.MonkeyPatch, seen: list[list[str]], tmp_path: Path
+) -> None:
+    """The class docstring's own rule, applied to the platform it was wrong about.
+
+    It reads: "On Linux the container's root would own every cloned file, so
+    the current uid/gid is passed through; on Docker Desktop the file-sharing
+    layer already maps ownership to the logged-in user and `os.getuid` does not
+    exist, which is the same condition."
+
+    `os.getuid` does not exist on WINDOWS. It exists on macOS, so every Mac got
+    `--user <uid>:<gid>` that the design says Docker Desktop must not get — and
+    the condition the sentence relies on, the file-sharing layer doing the
+    mapping, is exactly what a `--user` overrides. The tester's container sees
+    the bind mount as `root:root` (2026-08-27):
+
+        $ docker run --rm --entrypoint ls -v /Users/js/wow3:/git ... -la /git
+        drwxr-xr-x    2 root     root            64 ...
+
+    A container running as 501 cannot create `.git` in that, and failing to
+    create `.git` is how every macOS install has ended.
+
+    Pinned per platform rather than on `hasattr(os, "getuid")`, because that is
+    the test that read "Windows" and answered "not macOS".
+    """
+    dest = tmp_path / "core"
+    spec = git.CloneSpec(url="https://example/core.git", dest=dest, depth=None)
+    # Present for every case, so the PLATFORM is the only thing deciding. Without
+    # this the test passes on a Windows dev box for the wrong reason — no
+    # `os.getuid` there, so no branch is exercised and macOS looks fixed while
+    # it is not. That is the same blind spot the code had.
+    monkeypatch.setattr(git.os, "getuid", lambda: 501, raising=False)
+    monkeypatch.setattr(git.os, "getgid", lambda: 20, raising=False)
+
+    monkeypatch.setattr(git.platform, "detect", lambda: "macos")
+    git.ContainerGit().clone(spec)
+    assert "--user" not in seen[-1], "Docker Desktop maps ownership; a --user overrides it"
+
+    monkeypatch.setattr(git.platform, "detect", lambda: "windows")
+    git.ContainerGit().clone(spec)
+    assert "--user" not in seen[-1]
+
+    monkeypatch.setattr(git.platform, "detect", lambda: "linux")
+    git.ContainerGit().clone(spec)
+    argv = seen[-1]
+    assert argv[argv.index("--user") + 1] == "501:20", "Linux still needs it, or root owns all"
+
+
 def test_is_unmodified_tells_upstreams_own_file_from_one_somebody_edited(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/pylauncher/yulon/git.py
+++ b/pylauncher/yulon/git.py
@@ -327,8 +327,14 @@ class ContainerGit:
 
     On Linux the container's root would own every cloned file, so the current
     uid/gid is passed through; on Docker Desktop the file-sharing layer already
-    maps ownership to the logged-in user and `os.getuid` does not exist, which
-    is the same condition.
+    maps ownership to the logged-in user, so no `--user` is passed and one must
+    not be — it overrides the mapping this relies on.
+
+    That second half read "and `os.getuid` does not exist, which is the same
+    condition" until 2026-08-27, and `_user_args()` implemented it that way.
+    `os.getuid` does not exist on Windows; it exists on macOS. So every Mac got
+    a `--user` the rule excludes, the container saw the bind mount as
+    `root:root`, and git could not create `.git`.
     """
 
     image: str = _CONTAINER_GIT_IMAGE
@@ -486,6 +492,24 @@ class ContainerGit:
 
     @staticmethod
     def _user_args() -> list[str]:
+        """`--user <uid>:<gid>` on Linux only. Docker Desktop must not get one.
+
+        The rule is the class docstring's, and this is the line that did not
+        obey it. `hasattr(os, "getuid")` is a test for WINDOWS wearing the name
+        of a test for Docker Desktop: macOS has `os.getuid`, so every Mac was
+        handed a `--user` — and a `--user` overrides the very file-sharing
+        mapping the docstring relies on to make the flag unnecessary there.
+
+        What that cost: the tester's container sees the bind mount as
+        `root:root` (2026-08-27), so git running as 501 could not create `.git`
+        and every macOS install ended in `/git/.git: No such file or directory`.
+
+        Asking `platform.detect()` says what is meant. The old spelling was
+        right about Windows by accident and wrong about macOS for the same
+        reason — one question that happened to answer a different one.
+        """
+        if platform.detect() != "linux":
+            return []
         getuid = getattr(os, "getuid", None)
         getgid = getattr(os, "getgid", None)
         if getuid is None or getgid is None:


### PR DESCRIPTION
`ContainerGit`'s own docstring has always carried the rule:

> On Linux the container's root would own every cloned file, so the current uid/gid is passed through; on Docker Desktop the file-sharing layer already maps ownership to the logged-in user **and `os.getuid` does not exist, which is the same condition.**

`os.getuid` does not exist on **Windows**. It exists on macOS. `_user_args()` implemented that sentence literally, so every Mac was handed `--user <uid>:<gid>` — and a `--user` overrides the very file-sharing mapping the rule depends on to make the flag unnecessary. One question that happened to answer a different one: right about Windows by accident, wrong about macOS for the same reason.

## What it cost

The tester's container, listing the directory the app had just created (2026-08-27):

```
$ docker run --rm --entrypoint ls -v /Users/js/wow3:/git … -la /git
total 4
drwxr-xr-x    2 root     root            64 …
```

Root-owned, mode 755, inside the container. git running as `501:20` cannot create `.git` in that — and `/git/.git: No such file or directory` is the line every macOS install has ended on since the first report, five days and three releases ago.

The gate is `platform.detect() != "linux"` now, which says what is meant. Linux keeps its `--user`; without it the container's root owns every cloned file.

## The test

RED before this — and RED for the right reason only because it patches `os.getuid` into existence for all three platforms first. Without that it passes on a Windows dev box, which is the same blind spot the code had.

## Honesty about confirmation

This is the **seventh** hypothesis for this failure, and the first with the design's own words behind it rather than a mechanism I reasoned my way to. The other six were refuted by the tester's own runs:

| # | Hypothesis | Refuted by |
|---|---|---|
| 1 | `--user <uid>:<gid>` | his manual run "looked like it worked" — **never actually verified, and this PR is that hypothesis returning with evidence** |
| 2 | `~/Documents` (TCC) | he had moved off it before the first report |
| 3 | inode staleness from rmtree | `rm -rf` + recreate + clone works on his Mac |
| 4 | image pull failure | fixed separately (#113); failure persisted |
| 5 | the argv differing | he ran the logged argv by hand; it cloned |
| 6 | the environment / docker binary | `env -i` + the bundle's own docker; it cloned |

Confirmation is still owed: a write into that directory as uid 501 from a container is what proves it. The fix is correct regardless — the flag was never meant to be on that platform.

Suite 946 passed, 27 skipped; `ruff`, `black`, `mypy` clean.