### PR TITLE
The Console tab knew which Docker to ask, and Back up now did not

### DIFF
--- a/pylauncher/tests/test_controller_view.py
+++ b/pylauncher/tests/test_controller_view.py
@@ -18,6 +18,7 @@ from yulon.controller_wow_wotlk.console import ConsoleReply
 from yulon.controller_wow_wotlk.maintenance import (
     BackupReport,
     InterruptedRestore,
+    MaintenanceError,
     RestorePlan,
     RestoreReport,
 )
@@ -1128,6 +1129,50 @@ def test_for_wotlk_wires_the_distro_into_every_seam_that_talks_to_docker(
     )
     services.network_plan("lan")
     assert asked == ["dml-arch"], f"the port scan addressed the wrong daemon: {asked}"
+
+
+def test_the_maintenance_tab_asks_the_distro_s_docker_what_is_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Backup and restore census the containers, and that census has a daemon too.
+
+    Reported from a WSL-resident install (2026-08-27): the Console tab attached
+    and its log streamed, while `Maintenance -> Back up now` answered "could not
+    ask Docker what is running ... Docker could not be found on this machine".
+    One machine, one daemon, two answers - because the census went to the
+    Windows host, which is exactly the box with no Docker on it.
+
+    The seam scan below walked past this: `maintenance` spells "which daemon"
+    as an injectable `running` callable rather than as `wsl_distro`, so three
+    call sites that pass neither were invisible to a scan that looks for the
+    name. Asked here through the callables the view really calls, down to the
+    argv the census would have run.
+    """
+    asked: list[str | None] = []
+
+    def fake_prefix(wsl_distro: str | None = None, *, inside: str | None = None) -> tuple[str, ...]:
+        asked.append(wsl_distro)
+        return ("wsl.exe", "-d", str(wsl_distro), "--", "docker")
+
+    monkeypatch.setattr(docker.platform, "docker_prefix", fake_prefix)
+    monkeypatch.setattr(
+        docker.runner,
+        "run",
+        lambda cmd, cwd=None, timeout=None: subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+    services = ControllerServices.for_wotlk(WOTLK, tmp_path, None, "dml-arch")
+
+    # Nothing is running in this fake, so both calls end in their own ordinary
+    # refusal ("ac-database is not running"). What is under test is which
+    # daemon was asked before they got there.
+    with pytest.raises(MaintenanceError):
+        services.backup()
+    assert asked == ["dml-arch"], f"the backup census addressed the wrong daemon: {asked}"
+
+    asked.clear()
+    plan = services.plan_restore(tmp_path / "there-is-no-such-dump.sql")
+    assert asked == ["dml-arch"], f"the restore census addressed the wrong daemon: {asked}"
+    assert not any("could not be found on this machine" in r for r in plan.refusals), plan.refusals
 
 
 def test_every_seam_for_wotlk_builds_says_which_daemon_it_means() -> None:

--- a/pylauncher/yulon/controller_wow_wotlk/maintenance.py
+++ b/pylauncher/yulon/controller_wow_wotlk/maintenance.py
@@ -428,6 +428,7 @@ def backup(
     spec: docker.ContainerSpec = docker_ctl.SPEC,
     core_databases: Sequence[str] = CORE_DATABASES,
     running: RunningNames | None = None,
+    wsl_distro: str | None = None,
     now: datetime | None = None,
 ) -> BackupReport:
     """Dump every database this install has into `backups_dir(server_dir)`.
@@ -447,6 +448,9 @@ def backup(
             the copy taken automatically before a restore is not mistaken for
             one the user asked for (`wow-manage.sh` does the same with
             `pre_restore`).
+        wsl_distro: Which daemon holds this install's containers, for the
+            census. `mysql` carries the same fact for the dump itself; both are
+            needed, because they are two different questions asked of docker.
         now: The timestamp in the filenames; defaults to the clock.
 
     Raises:
@@ -457,7 +461,7 @@ def backup(
             they are complete and verified, and deleting them would be the
             second mistake.
     """
-    names = _census(running)
+    names = _census(running, wsl_distro=wsl_distro)
     if spec.db not in names:
         raise MaintenanceError(
             f"{spec.db} is not running, so there is no database to back up. Start the server "
@@ -759,6 +763,7 @@ def plan_restore(
     *,
     spec: docker.ContainerSpec = docker_ctl.SPEC,
     running: RunningNames | None = None,
+    wsl_distro: str | None = None,
 ) -> RestorePlan:
     """Work out what restoring `backup_file` would do, without doing any of it.
 
@@ -809,7 +814,7 @@ def plan_restore(
                 )
 
     try:
-        names = _census(running)
+        names = _census(running, wsl_distro=wsl_distro)
     except MaintenanceError as exc:
         refusals.append(str(exc))
     else:
@@ -848,6 +853,7 @@ def restore(
     confirm: str,
     spec: docker.ContainerSpec = docker_ctl.SPEC,
     running: RunningNames | None = None,
+    wsl_distro: str | None = None,
     now: datetime | None = None,
 ) -> RestoreReport:
     """Overwrite the databases `plan.backup` names. This destroys player data.
@@ -890,7 +896,9 @@ def restore(
         raise MaintenanceError(
             "the restore was not confirmed against this backup, so nothing was changed"
         )
-    fresh = plan_restore(plan.backup, plan.server_dir, spec=spec, running=running)
+    fresh = plan_restore(
+        plan.backup, plan.server_dir, spec=spec, running=running, wsl_distro=wsl_distro
+    )
     if fresh.refusals:
         raise MaintenanceError(f"restore refused: {' '.join(fresh.refusals)}")
     if fresh.token != plan.token:
@@ -915,7 +923,9 @@ def restore(
             "only copy there would otherwise be."
         )
     kept = _usable_copies(earlier)
-    safety = _safety_backup(plan, mysql, kept, spec=spec, running=running, now=now)
+    safety = _safety_backup(
+        plan, mysql, kept, spec=spec, running=running, wsl_distro=wsl_distro, now=now
+    )
     unresolved = _still_unresolved(earlier, plan, kept)
 
     # The record carries what this restore is doing AND whatever an earlier
@@ -1025,6 +1035,7 @@ def _safety_backup(
     *,
     spec: docker.ContainerSpec,
     running: RunningNames | None,
+    wsl_distro: str | None,
     now: datetime | None,
 ) -> tuple[Path, ...]:
     """A copy of every database this restore will overwrite, so it can be put back.
@@ -1066,6 +1077,7 @@ def _safety_backup(
             label="pre-restore",
             spec=spec,
             running=running,
+            wsl_distro=wsl_distro,
             now=now,
         )
         covered.update({dump.database: dump.path for dump in report.dumps})
@@ -1164,7 +1176,7 @@ def _databases_named_in_bytes(data: bytes) -> list[str]:
     return found
 
 
-def _census(running: RunningNames | None) -> set[str]:
+def _census(running: RunningNames | None, *, wsl_distro: str | None = None) -> set[str]:
     """What is running, by container name; a Docker that will not answer is fatal.
 
     `docker.status()` raises rather than degrading, which is what this wants:
@@ -1172,13 +1184,26 @@ def _census(running: RunningNames | None) -> set[str]:
     and "Docker did not say" must never read as "nothing is running" (that
     mistake is written up in `docker._refuse_without_an_identity()`).
     """
+
     # `docker_ctl.status`, not `docker.status`: this package re-exports the
     # shared operations so its callers have one entry point, and reaching past
     # that from inside the package would make the rule advice rather than
     # practice (style guide §3/§4; review, 2026-08-23). The two names below are
     # a type and an exception rather than operations, and `docker_ctl` does not
     # re-export those.
-    source = running if running is not None else docker_ctl.status
+    #
+    # `wsl_distro` is the same fact `DockerMysql` already carries, spelled again
+    # because this asks a DIFFERENT question of docker: the dump goes through
+    # `docker exec` into the distro, the census through `docker ps` — and until
+    # 2026-08-27 only the first of those was told where the daemon lives. A user
+    # whose server lives inside WSL, with no Docker Desktop on the Windows side,
+    # therefore had a Console tab that attached and streamed and a Back-up
+    # button that answered "Docker could not be found on this machine"
+    # (Discord report, 2026-08-27).
+    def census() -> list[str]:
+        return docker_ctl.status(wsl_distro=wsl_distro)
+
+    source = running if running is not None else census
     try:
         return set(source())
     except docker.DockerCommandError as exc:

--- a/pylauncher/yulon/ui/controller_view.py
+++ b/pylauncher/yulon/ui/controller_view.py
@@ -174,17 +174,31 @@ class ControllerServices:
             create_account=lambda name, pw, gm: wotlk_accounts.create_account(
                 sql, name, pw, gm_level=gm, scheme=entry.accounts.scheme or "azerothcore"
             ),
+            # `wsl_distro=` as well as the distro-aware `mysql`: the dump goes
+            # through `docker exec`, but before it runs, maintenance censuses
+            # the containers with `docker ps` — a second question, to the same
+            # daemon, that was going to the Windows host. On a machine whose
+            # only Docker is inside the distro that is the one with no Docker on
+            # it, so Back up now answered "Docker could not be found on this
+            # machine" while the Console tab, one seam over, was attached and
+            # streaming (Discord report, 2026-08-27).
             backup=lambda: wotlk_maintenance.backup(
-                server_dir, mysql, spec=spec, core_databases=entry.core_databases()
+                server_dir,
+                mysql,
+                spec=spec,
+                core_databases=entry.core_databases(),
+                wsl_distro=wsl_distro,
             ),
             backups_dir=lambda: wotlk_maintenance.backups_dir(server_dir),
-            plan_restore=lambda path: wotlk_maintenance.plan_restore(path, server_dir, spec=spec),
+            plan_restore=lambda path: wotlk_maintenance.plan_restore(
+                path, server_dir, spec=spec, wsl_distro=wsl_distro
+            ),
             # `confirm=plan.token` is not a rubber stamp: the token can only come
             # from a plan, a plan can only come from a real file, and the human
             # confirmation is the dialog the view puts in front of this call.
             # What the token buys is that no confirmation can be spelled `True`.
             restore=lambda plan: wotlk_maintenance.restore(
-                plan, mysql, confirm=plan.token, spec=spec
+                plan, mysql, confirm=plan.token, spec=spec, wsl_distro=wsl_distro
             ),
             interrupted_restore=lambda: wotlk_maintenance.interrupted_restore(server_dir),
             forget_interrupted=lambda: wotlk_maintenance.forget_interrupted_restore(server_dir),


### PR DESCRIPTION
Reported from a WSL-resident install (2026-08-27): the Console tab attached and streamed its log, while `Maintenance -> Back up now` answered *"could not ask Docker what is running ... Docker could not be found on this machine"*. One machine, one daemon, two answers.

The Windows side of that box has no Docker at all — the daemon lives inside the distro — so the census was asking the one machine with nothing to answer.

## Why the guard did not catch it

`maintenance` spells "which daemon" as an injectable `running` callable, not as `wsl_distro`, and it defaults to the local one. `for_wotlk()` builds a distro-aware `DockerMysql` for the dump and then left that seam unset, so the `docker exec` half of a backup was addressed correctly and the `docker ps` half was not. Restore had the same two call sites.

`test_every_seam_for_wotlk_builds_says_which_daemon_it_means` scans for functions that **accept** `wsl_distro` and calls that do not pass one — so a fact carried under a different name was invisible to it.

## The fix

`backup()`, `plan_restore()` and `restore()` take the same `wsl_distro` parameter every other docker-facing function here already takes, and the view passes it. That also closes the hole in the guard above.

The regression test drives the real path — `for_wotlk(..., "dml-arch").backup()` down to the argv the census would have run — and failed with `[None]` before the fix.

## Gates

Rebased onto `Yulon` and re-run there: **946 passed, 27 skipped**; `ruff` and `black --check` clean; `mypy yulon main.py` clean on all three CI platforms (native, `--platform win32`, `--platform darwin`).

Independent of #118 (the Console/pty fix) — either can merge first.
