### PR TITLE
Eight hypotheses, eight refutations, and a brief for the machine we do not have

### DIFF
--- a/pyplan/checklist.md
+++ b/pyplan/checklist.md
@@ -655,6 +655,84 @@ not answering, that setup can take a few minutes with no output. Still unverifie
 run-sheet's remaining steps, and whether `xcode-select -p` on Baerthe's box makes the clone go through
 the container git. Ask for `~/Library/Application Support/yulon/yulon.log` on the next run.
 
+### The Mac clone: eight hypotheses, eight refutations, and the two real bugs found on the way (2026-08-27)
+
+One tester on Discord, one Mac, one failure that is still open:
+
+```
+containerized git clone … --branch Playerbot https://github.com/mod-playerbots/azerothcore-wotlk.git .
+  in /Users/js/wow3 exited 1: Cloning into '.'...
+/git/.git: No such file or directory
+```
+
+Recorded because the refuted list is the useful part. Every hypothesis below
+was plausible, several fit every observation available at the time, and each
+was killed by a **run** rather than by an argument — which is the only reason
+the list is short enough to write down.
+
+**What was actually wrong, and is fixed.** Two real defects surfaced while
+chasing this, neither of them the clone:
+
+1. **The credential helper was not on PATH (#113, merged).** `docker_program()`
+   resolved argv[0] out of Docker Desktop's bundle and stopped there. `docker`
+   execs `docker-credential-<store>` *by name* through its parent's PATH, and a
+   `.app` opened from Finder has launchd's — so every registry pull died at
+   authentication, and the bind-mount probe reported that as an unshared
+   folder. The user was told to add a folder that was already shared.
+2. **The bind-mount probe read `ls`'s exit code instead of its listing
+   (#115).** A Mac home directory has entries Docker Desktop cannot stat
+   (`.Trash`, `Documents`), so busybox `ls` prints a full listing **and** exits
+   non-zero. The chosen folder is empty at preflight time by construction, so
+   the probe walks up to the nearest populated ancestor — home — and every
+   first install on macOS was refused. Nothing the user could do would pass:
+   he re-added the folder to file sharing, added its parent, tried other
+   folders, and read a file back out of a container against that exact path.
+
+Two instruments came out of it as well: #114 logs the resolved `docker run`
+argv and the destination at INFO, and #117 puts the exit code in
+`ContainerGit`'s error the way `_run_git()` always had. Both exist because this
+investigation spent three Discord round trips recovering a string the process
+already held, and a fourth deciding whether the process had been killed.
+
+**The refuted list, for the clone failure itself.**
+
+| # | Hypothesis | Killed by |
+|---|---|---|
+| 1 | `--user <uid>:<gid>` breaks the write | his clone WITH the flag, verified by `ls .git` |
+| 2 | the folder was under `~/Documents` (TCC) | he had moved off it before the first report |
+| 3 | the failed pull was the mount failing | #113 fixed the pull; the clone failure survived |
+| 4 | `rmtree` + `mkdir` hands Docker a stale inode | `rm -rf`, recreate, clone — works on his Mac (#116, closed) |
+| 5 | the app's argv differs from his | #114 logged it; he ran it verbatim; it cloned |
+| 6 | the environment or the docker binary | `env -i` + the bundle's own `docker`; it cloned |
+| 7 | the mount is `root:root`, so 501 cannot create `.git` | `touch` **and** `mkdir /git/.git` as `501:20` both exit 0 |
+| 8 | recreate + `--user` **together** (the last untested cell) | the app's exact argv, recreated folder, `--user 501:20`: exit 0, `.git` present |
+
+Hypothesis 1 is worth its own line. It was raised on day one, dropped on the
+tester's "looks like its working", and returned as #119 five days later with
+what looked like hard evidence — a container listing showing the mount as
+`root:root`. That evidence was itself wrong: Docker Desktop presents that
+ownership and permits the write anyway. **A report of "it worked" that nobody
+verified cost five days**, and the fix for that is in how the tests are asked
+for, not in the code: every request since has ended "paste the exit line and
+the `ls`", and hypothesis 8 died the same hour.
+
+#119 is left open and explicitly labelled not-a-fix. The change it makes is
+still right — `ContainerGit`'s docstring says Docker Desktop must not get a
+`--user`, and `hasattr(os, "getuid")` is a test for *Windows* wearing the name
+of a test for Docker Desktop — but it must be judged as a correctness-of-intent
+change and must not be described in a release as fixing the macOS install.
+
+**Where it stands.** The command is exonerated in every dimension reachable
+from a Discord thread: argv, destination lifecycle, uid, environment, binary,
+and the daemon's view of the mount. The remaining difference is the process
+that spawns it — a frozen PyInstaller `.app`, a launchd child, running the
+subprocess off the GUI thread with `capture_output=True` and an inherited
+stdin. None of that can be bisected without a Mac, and this project has none.
+The handoff brief is `pyplan/macos-clone-handoff.md`; the first thing it asks
+for is the run-sheet's Step 1, because **nothing in this project has ever run
+on a Darwin interpreter**, and a machine that can run the app from source ends
+the four-release-round-trip loop this investigation has been stuck in.
+
 ### The second macOS run: finding the CLI was only half of it (2026-08-26)
 
 A tester on Discord ran the release on a Mac and preflight refused the install with

--- a/pyplan/macos-clone-handoff.md
+++ b/pyplan/macos-clone-handoff.md
@@ -1,0 +1,123 @@
+# macOS clone failure — handoff brief
+
+**For whoever picks this up on a Mac, with or without an agent's help.** Written
+to be read cold. It assumes nothing about the five days behind it, and it asks
+for the cheap thing first.
+
+The bug: every install on macOS dies at the clone stage with
+
+```
+containerized git clone --config core.autocrlf=false --config core.eol=lf \
+  --config http.version=HTTP/1.1 --branch Playerbot \
+  https://github.com/mod-playerbots/azerothcore-wotlk.git . in /Users/js/wow3 \
+  exited 1: Cloning into '.'...
+/git/.git: No such file or directory
+```
+
+**The same command, typed into Terminal on the same machine, clones fine.** That
+is the whole shape of the problem, and it is why this needs a Mac rather than
+more reasoning.
+
+---
+
+## Step 1 — the suite on a Darwin interpreter (10 minutes, do this first)
+
+Worth doing even if you never touch the bug. **Nothing in this project has ever
+run on a Mac's Python.** `pyplan/macos-gate-run-sheet.md` Step 1 has been open
+for weeks purely for want of hardware.
+
+```bash
+git clone https://github.com/DadsMmoLab/dads-mmo-lab.git
+cd dads-mmo-lab/pylauncher
+git checkout Yulon
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+
+pytest -q
+ruff check yulon tests
+black --check yulon tests
+mypy yulon
+```
+
+Send the four result lines. Linux gives roughly `945 passed, 27 skipped`; the
+skips are Windows-only and POSIX-shell tests, so expect *fewer* on macOS, not
+more. A failure here is a finding in its own right — the last time an untested
+platform was assumed fine, `shutil.which`'s win32 branch had grown a `_winapi`
+call that killed the app at startup.
+
+## Step 2 — run the app from source
+
+```bash
+python main.py
+```
+
+This is the part that matters most. Every fix attempted so far has cost a tag,
+a CI build, a `.dmg` download and a reinstall — four round trips for four
+one-line changes. A Mac that can run from source ends that loop.
+
+Install a server into a **brand new empty folder** under your home directory
+(not `~/Documents` — Docker Desktop cannot see inside it on at least one Mac).
+
+## Step 3 — the actual question
+
+The clone runs in `pylauncher/yulon/git.py`, `ContainerGit._capture()`. It
+builds an argv and hands it to `runner.run()`:
+
+```python
+argv = [program, "run", "--rm", "-v", f"{dest}:/git", "-w", "/git",
+        *self._user_args(), self.image, *_LINE_ENDING_ARGS,
+        *_HTTP_VERSION_ARGS, *git_args]
+proc = runner.run(argv, env=_no_prompt_env())
+```
+
+Immediately before that line, dump:
+
+- `argv` — though it is already logged at INFO, and has been verified identical
+  to a command that works by hand
+- `os.getcwd()` — the app is a launchd child; a shell is not
+- `spec.dest.exists()` and `oct(spec.dest.stat().st_mode)` at that instant
+- `sys.stdin` / whether fd 0 is open — `runner.run()` uses
+  `capture_output=True` and leaves stdin inherited, and a GUI process's stdin
+  is not a terminal
+
+Then bisect the one difference that is left: **the same command succeeds from a
+shell and fails from this process.** Everything about the command itself has
+been eliminated (see the table below). Candidates nobody has been able to test:
+the frozen PyInstaller runtime, the launchd process context, the background
+thread the install runs on, and the inherited file descriptors.
+
+---
+
+## What is already ruled out
+
+Do not re-test these. Each was killed by a run on the affected Mac, not by an
+argument:
+
+| Hypothesis | Killed by |
+|---|---|
+| `--user <uid>:<gid>` breaks the write | a clone WITH the flag, verified by `ls .git` |
+| the folder was under `~/Documents` | he had moved off it before the first report |
+| a failed image pull | fixed separately (#113); the clone failure survived |
+| `rmtree` + `mkdir` hands Docker a stale inode | `rm -rf`, recreate, clone — works |
+| the app's argv differs from a manual one | logged (#114), run verbatim by hand, cloned |
+| the environment or the docker binary | `env -i` plus the bundle's own `docker`, cloned |
+| the mount is `root:root`, so 501 cannot write | `touch` and `mkdir /git/.git` as `501:20` both exit 0 |
+| recreate **and** `--user` together | the exact argv, recreated folder, `--user 501:20`: exit 0 |
+
+The full account, including the two real bugs found while chasing this one, is
+in `pyplan/checklist.md` under *"The Mac clone: eight hypotheses, eight
+refutations"*.
+
+## How to report a result
+
+One rule, learned expensively. **A test result is an exit code and a listing,
+never an impression.** Hypothesis 1 above was raised on day one, dropped
+because a manual run "looked like it was working", and came back five days
+later with evidence that was itself wrong. Finish every check with:
+
+```bash
+… ; echo "exit $?"
+ls -lad <the directory>
+```
+
+and paste both lines.


### PR DESCRIPTION
Two documents, no code.

## `checklist.md` — the account of the Mac clone failure

The refuted list is the useful half. Eight hypotheses, each plausible, several fitting every observation available when they were made, each killed by a **run** rather than by an argument.

It also records the two real defects found while chasing this one, neither of them the cause:

- **#113 (merged)** — the credential helper was not on PATH, so every registry pull died at authentication and the bind-mount probe reported that as an unshared folder.
- **#115 (open)** — the probe read `ls`'s exit code instead of its listing, and a Mac home directory makes busybox `ls` print a full listing *and* exit non-zero. That refused **every first install on macOS**.

The line worth keeping is about hypothesis 1. It was raised on day one, dropped on the tester's "looks like its working", and returned five days later as #119 carrying evidence that was itself wrong. An unverified "it worked" cost five days. The fix is in how tests are asked for, not in the code: every request since ends *"paste the exit line and the `ls`"*, and the last surviving hypothesis died the same hour.

## `macos-clone-handoff.md` — new

Written to be read cold by whoever has a Mac, since this project has none.

It asks for `macos-gate-run-sheet.md` Step 1 first — **nothing here has ever run on a Darwin interpreter**, and that box has been open for weeks purely for want of hardware. Then the app from source, which ends the four-release-round-trip loop this investigation has been stuck in: four tags, four CI builds, four `.dmg` downloads, for four one-line changes.

It carries the ruled-out table so nobody re-tests what the tester already killed, and names the instrumentation points in `ContainerGit._capture()`.

`roadmap.md` untouched (style-guide §9).