### PR TITLE
Four console tests that could only pass on the machine they were written on

### DIFF
--- a/pylauncher/tests/test_console.py
+++ b/pylauncher/tests/test_console.py
@@ -94,6 +94,25 @@ def test_send_command_explains_itself_where_there_is_no_pty() -> None:
         console.send_command("server info", container="ac-worldserver")
 
 
+@pytest.fixture
+def reachable_distro(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend this box can reach a distro, whatever OS the suite is running on.
+
+    `wsl_prefix()` looks for `wsl.exe` on PATH and finds none on CI's Ubuntu,
+    so without this the four tests below pass on Windows and fail on Linux with
+    "Docker could not be found on this machine" - before the fake client is
+    ever reached. That is not what they are about: the transport is the subject,
+    and whether THIS host has wsl.exe is `wsl_prefix()`'s own business, tested
+    in `test_platform.py`. `test_docker.py::_wsl_prefix` pins the same fact for
+    the same reason (found by CI, 2026-08-28).
+    """
+    monkeypatch.setattr(
+        console.platform,
+        "wsl_prefix",
+        lambda wsl_distro, inside=None: ("wsl.exe", "-d", wsl_distro, "--"),
+    )
+
+
 class _FakePipeProc:
     """A `docker attach` whose stdin is a pipe, the way the in-distro path runs it.
 
@@ -160,7 +179,7 @@ def _distro_send(command: str = "server info", **kwargs: Any) -> tuple[Any, _Fak
     return reply, made[0]
 
 
-def test_a_wsl_console_allocates_its_pty_inside_the_distro() -> None:
+def test_a_wsl_console_allocates_its_pty_inside_the_distro(reachable_distro: None) -> None:
     """Windows has no pty to give docker; the distro does, and script(1) opens it.
 
     Measured 2026-08-27 against a real tty container, from Windows: a plain
@@ -180,7 +199,7 @@ def test_a_wsl_console_allocates_its_pty_inside_the_distro() -> None:
     )
 
 
-def test_a_wsl_console_detaches_and_never_kills_its_client() -> None:
+def test_a_wsl_console_detaches_and_never_kills_its_client(reachable_distro: None) -> None:
     """The teardown that the POSIX path uses would stop the worldserver here.
 
     Measured 2026-08-27, Windows -> WSL, on a container whose PID 1 reads its
@@ -194,6 +213,7 @@ def test_a_wsl_console_detaches_and_never_kills_its_client() -> None:
 
 
 def test_a_wsl_console_that_will_not_detach_is_killed_and_says_so(
+    reachable_distro: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A client that ignores the detach keys is still let go of, loudly.
@@ -209,7 +229,7 @@ def test_a_wsl_console_that_will_not_detach_is_killed_and_says_so(
     assert any("did not detach" in r.message for r in caplog.records), caplog.text
 
 
-def test_a_wsl_console_still_parses_the_reply_out_of_the_window() -> None:
+def test_a_wsl_console_still_parses_the_reply_out_of_the_window(reachable_distro: None) -> None:
     """The transport changed; what counts as an answer did not."""
     reply, _proc = _distro_send("account create dad pw")
     assert reply.lines == ("Account created: dad",)

--- a/pylauncher/tests/test_git.py
+++ b/pylauncher/tests/test_git.py
@@ -246,6 +246,8 @@ def test_docker_desktop_never_gets_a_user_flag(
     git.ContainerGit().clone(spec)
     argv = seen[-1]
     assert argv[argv.index("--user") + 1] == "501:20", "Linux still needs it, or root owns all"
+
+
 def test_a_failed_clone_names_the_directory_it_mounted(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
`Yulon` is red, for two independent reasons. This fixes both.

## 1. My four console tests only pass where wsl.exe exists (from #118)

```
FAILED tests/test_console.py::test_a_wsl_console_allocates_its_pty_inside_the_distro
FAILED tests/test_console.py::test_a_wsl_console_detaches_and_never_kills_its_client
FAILED tests/test_console.py::test_a_wsl_console_that_will_not_detach_is_killed_and_says_so
FAILED tests/test_console.py::test_a_wsl_console_still_parses_the_reply_out_of_the_window
```

`distro_attach_argv()` asks `platform.wsl_prefix()`, which looks for `wsl.exe` on PATH. My laptop has one, so they passed there; CI's Ubuntu does not, so `wsl_prefix()` answered None and the argv could not be built - the tests died with *"Docker could not be found on this machine"* before the fake client was ever reached.

Nothing about the transport is wrong. The tests were asserting a fact about the host they ran on without meaning to.

Pinned the way `test_docker.py::_wsl_prefix` already pins it for the same reason: a `reachable_distro` fixture supplies a fixed prefix whatever OS runs the suite. Whether THIS host can find wsl.exe stays `wsl_prefix()`'s own question, tested in `test_platform.py`.

Reproduced before fixing, not fixed by inspection: a pytest plugin that hides wsl.exe from `platform._which()` turns a Windows box into CI's. Under it the merged test file fails exactly the four CI named, and the fixed one passes 21/21.

## 2. `black --check` fails on `tests/test_git.py`

Not mine, and included here for one reason: black is the second CI step, so while it fails nothing after it runs and every PR against `Yulon` reports red for a file it never touched. `Yulon`'s last three runs all stopped there, which is also why the pytest failures above were never printed.

`black tests/test_git.py`, nothing else - no logic, no test content.

## Checks (local)

- `pytest -q` -> 955 passed, 27 skipped
- the four tests again with wsl.exe hidden -> 21 passed, 2 skipped
- `black --check .` / `ruff check .` -> clean
- `mypy yulon main.py` linux / win32 / darwin -> clean

## Heads-up on a separate flake

Unrelated to this PR: the GUI suite segfaults (exit 139) on roughly one CI run in three, inside `main.build_window()`'s fixture in `test_main.py`. It is heap corruption from Qt teardown detonating at the next large allocation - the same shape `_app_window`'s docstring records from #112 - not a fault in whatever PR is running at the time. 55 consecutive runs on an Ubuntu box here would not reproduce it, so I have a repeat-the-suite experiment running on CI to catch it. If a check here comes back red with exit 139, that is this, and a re-run clears it.