### PR TITLE
Three installers threw away the folder the user picked

### DIFF
--- a/pylauncher/catalog/installers/wow-tbc/install-wow-tbc.sh
+++ b/pylauncher/catalog/installers/wow-tbc/install-wow-tbc.sh
@@ -238,9 +238,17 @@ check_system() {
     # measured $HOME and then said "Docker images live on the main disk" was
     # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$AVAILABLE_GB" in ''|*[!0-9]*) AVAILABLE_GB="" ;; esac
     DOCKER_DISK="/var/lib/docker"
     [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
     DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$DOCKER_GB" in ''|*[!0-9]*) DOCKER_GB="" ;; esac
 
     # Warnings, not gates. Exiting here refused the very install choose_install_dir()
     # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and
@@ -1151,6 +1159,10 @@ choose_install_dir() {
 
     local avail_gb
     avail_gb=$(df -BG "$_space_probe" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ') || true
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$avail_gb" in ''|*[!0-9]*) avail_gb="" ;; esac
     if [[ -z "$avail_gb" ]]; then
         print_error "Could not determine free space at ${_space_probe}. Cannot verify the 20 GB requirement."
         exit 1

--- a/pylauncher/catalog/installers/wow-tbc/install-wow-tbc.sh
+++ b/pylauncher/catalog/installers/wow-tbc/install-wow-tbc.sh
@@ -232,11 +232,20 @@ check_system() {
     print_success "Linux detected"
 
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # A warning, not a gate. Docker's images land on the main disk whatever the
+    # user picks, so this number still matters — but the server files themselves
+    # may be headed for an SD card or an external drive, and choose_install_dir()
+    # checks free space where they are ACTUALLY going. Exiting here refused the
+    # very install that prompt exists to allow: on a 64 GB Steam Deck the
+    # installer offered the SD card and then quit over the internal disk
+    # (found while fixing the ignored-folder bug, 2026-08-28).
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 20 ] 2>/dev/null; then
-        print_error "Need 20GB free for compile + client data. You have ${AVAILABLE_GB}GB."
-        exit 1
+        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
+        print_info "Docker images always live on the main disk and need several GB."
+        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+    else
+        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
     fi
-    print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
 
     if ! ping -c 1 github.com &>/dev/null; then
         print_error "No internet. Please connect and try again."

--- a/pylauncher/catalog/installers/wow-tbc/install-wow-tbc.sh
+++ b/pylauncher/catalog/installers/wow-tbc/install-wow-tbc.sh
@@ -231,20 +231,34 @@ check_system() {
     fi
     print_success "Linux detected"
 
+    # Two disks, because they are two disks. $HOME is where the server files go
+    # if the user keeps the default; /var/lib/docker is where the images and the
+    # build cache go no matter what they pick. On a Steam Deck those are
+    # different partitions, so one df cannot answer for both — a warning that
+    # measured $HOME and then said "Docker images live on the main disk" was
+    # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
-    # A warning, not a gate. Docker's images land on the main disk whatever the
-    # user picks, so this number still matters — but the server files themselves
-    # may be headed for an SD card or an external drive, and choose_install_dir()
-    # checks free space where they are ACTUALLY going. Exiting here refused the
-    # very install that prompt exists to allow: on a 64 GB Steam Deck the
-    # installer offered the SD card and then quit over the internal disk
-    # (found while fixing the ignored-folder bug, 2026-08-28).
+    DOCKER_DISK="/var/lib/docker"
+    [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
+    DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+
+    # Warnings, not gates. Exiting here refused the very install choose_install_dir()
+    # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and
+    # then quit over the internal disk. The only free-space floors this project has
+    # measured are for WotLK's native build (min_data_root_gb in catalog.py) and do
+    # not transfer to a script that bind-mounts its checkout into the server folder,
+    # so nothing here refuses on a number nobody took.
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 20 ] 2>/dev/null; then
-        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
-        print_info "Docker images always live on the main disk and need several GB."
-        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+        print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
+        print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
     else
-        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+    fi
+    if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 20 ] 2>/dev/null; then
+        print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
+        print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    else
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-tbc/install-wow-tbc.sh
+++ b/pylauncher/catalog/installers/wow-tbc/install-wow-tbc.sh
@@ -47,7 +47,7 @@
 #    - 3-5 hours of wall-clock time (mostly hands-off)
 # ============================================================
 
-INSTALLER_VERSION="1.1.4"
+INSTALLER_VERSION="1.1.5"
 
 set -o pipefail
 
@@ -1018,6 +1018,129 @@ locate_client() {
 # ─────────────────────────────────────────
 # SHOW SUMMARY BEFORE COMPILE
 # ─────────────────────────────────────────
+# ─────────────────────────────────────────
+# INSTALL LOCATION
+# Ported from install-wow-wotlk.sh, which was the only installer that asked.
+# The others hardcoded $HOME/<name>, which silently discarded the folder the
+# Yu'lon launcher's picker had already asked for — reported from a Steam Deck
+# on 2026-08-28 (chose ~/wow-server-tortoise, got ~/tortoise-wow-server, and
+# the app then called the finished install a failure because it looked for the
+# compose file in the folder the user chose). The prompt string "Install path:"
+# is a contract with `PROMPT_RULES` in yulon/catalog/installer.py: that is the
+# line the app watches for, and it types the chosen path in answer.
+# ─────────────────────────────────────────
+choose_install_dir() {
+    print_step "Choose Server Files Location"
+
+    local default_dir="$HOME/wow-tbc-server"
+
+    echo ""
+    echo -e "  ${WHITE}${BOLD}Where should the server files be installed?${NC}"
+    echo ""
+    echo -e "  ${DIM}Default:${NC} ${CYAN}${default_dir}${NC}"
+    echo ""
+    echo -e "  ${WHITE}You can install the server files to a different location,${NC}"
+    echo -e "  ${WHITE}such as an external drive or SD card, to save space on${NC}"
+    echo -e "  ${WHITE}your main disk.${NC}"
+    echo ""
+    echo -e "  ${YELLOW}⚠️  Note: Docker containers (the compiled server images)${NC}"
+    echo -e "  ${YELLOW}always live on your main disk regardless of this choice.${NC}"
+    echo -e "  ${YELLOW}Only the source code, configs, and data files go here.${NC}"
+    echo ""
+    echo -e "  ${DIM}Leave blank and press ENTER to use the default location.${NC}"
+    echo -e "  ${DIM}Example custom path: /run/media/deck/mysd/wow-server${NC}"
+    echo ""
+    echo -ne "  ${WHITE}Install path: ${NC}"
+    read -r user_input
+
+    if [[ -z "$user_input" ]]; then
+        SERVER_DIR="$default_dir"
+        print_info "Using default location: ${SERVER_DIR}"
+    else
+        # Expand ~ and ensure the path is absolute
+        user_input="${user_input/#\~/$HOME}"
+        if [[ "$user_input" != /* ]]; then
+            user_input="$(pwd)/$user_input"
+        fi
+        SERVER_DIR="$user_input"
+        print_info "Using custom location: ${SERVER_DIR}"
+    fi
+
+    # Canonicalize (resolves .., repeated slashes, trailing slash) so the safety
+    # checks below correctly handle /tmp/.., /, /tmp/ etc.
+    SERVER_DIR=$(realpath -m -- "$SERVER_DIR")
+    local _canon_default
+    _canon_default=$(realpath -m -- "$default_dir")
+
+    # Reject dangerous / well-known system roots
+    case "$SERVER_DIR" in
+        /|"$HOME"|/home|/root|/tmp|/var|/etc|/usr|/boot|/proc|/sys|/dev|/media|/mnt|/opt|/srv)
+            print_error "Cannot use '${SERVER_DIR}' as the install location."
+            print_info "Choose a dedicated subdirectory (e.g. ${default_dir})."
+            exit 1
+            ;;
+    esac
+
+    # Reject if the destination already exists and is not a directory (incl. dangling symlinks)
+    if [[ ( -e "$SERVER_DIR" || -L "$SERVER_DIR" ) && ! -d "$SERVER_DIR" ]]; then
+        print_error "Install path exists but is not a directory: $SERVER_DIR"
+        exit 1
+    fi
+
+    # For custom (non-default) paths: require the parent to already exist.
+    # Don't silently mkdir deep paths — if a drive isn't mounted, that would
+    # install onto the main disk instead.
+    local parent_dir
+    parent_dir="$(dirname "$SERVER_DIR")"
+
+    if [[ "$SERVER_DIR" == "$_canon_default" ]]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            print_error "Cannot create directory: $parent_dir"
+            exit 1
+        }
+    elif [[ ! -d "$parent_dir" ]]; then
+        print_error "Parent directory does not exist: $parent_dir"
+        print_info "Make sure your external drive or SD card is mounted first, then re-run."
+        exit 1
+    fi
+
+    # Write probe using mktemp to avoid clobbering any existing user files
+    local _write_probe
+    _write_probe=$(mktemp "$parent_dir/.dml_probe_XXXXXX" 2>/dev/null) || {
+        print_error "Cannot write to: $parent_dir"
+        print_info "Check permissions or ensure the drive is mounted before running the installer."
+        exit 1
+    }
+    rm -f "$_write_probe"
+
+    # Check free space — probe SERVER_DIR if it already exists (may be a separate
+    # mount point with a different filesystem than its parent); otherwise probe parent.
+    local _space_probe
+    [[ -d "$SERVER_DIR" ]] && _space_probe="$SERVER_DIR" || _space_probe="$parent_dir"
+
+    local avail_gb
+    avail_gb=$(df -BG "$_space_probe" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ') || true
+    if [[ -z "$avail_gb" ]]; then
+        print_error "Could not determine free space at ${_space_probe}. Cannot verify the 20 GB requirement."
+        exit 1
+    fi
+    if [[ "$avail_gb" -lt 20 ]]; then
+        print_error "Not enough space at ${_space_probe}. Need at least 20 GB, found ${avail_gb} GB."
+        exit 1
+    fi
+    print_success "Install location OK — ${avail_gb} GB available at ${_space_probe}"
+
+    echo ""
+    echo -e "  ${WHITE}${BOLD}Server files will be installed to:${NC}"
+    echo -e "  ${CYAN}${SERVER_DIR}${NC}"
+    echo ""
+    if ! ask_yes_no "Confirm this install location?"; then
+        echo ""
+        print_info "Re-run the installer to choose a different location."
+        exit 0
+    fi
+}
+
 show_summary() {
     print_header
     print_step "STEP 2/5 — Pre-Compile Summary"
@@ -2269,6 +2392,7 @@ SUDO_KEEPALIVE_PID=$!
 trap "kill $SUDO_KEEPALIVE_PID 2>/dev/null; exit" EXIT INT TERM
 
 locate_client
+choose_install_dir
 show_summary
 preflight_check
 do_compile

--- a/pylauncher/catalog/installers/wow-tbc/install-wow-tbc.sh
+++ b/pylauncher/catalog/installers/wow-tbc/install-wow-tbc.sh
@@ -251,14 +251,22 @@ check_system() {
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 20 ] 2>/dev/null; then
         print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
         print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
+    elif [ -z "$AVAILABLE_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${HOME}."
     else
-        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB}GB available)"
     fi
     if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 20 ] 2>/dev/null; then
         print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
         print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    elif [ -z "$DOCKER_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${DOCKER_DISK}."
     else
-        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
+++ b/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
@@ -35,7 +35,7 @@
 #    step (Step 5) and final in-game connect — watch those first.
 # ============================================================
 
-INSTALLER_VERSION="0.1.0-tortoise"
+INSTALLER_VERSION="0.2.0-tortoise"
 
 set -o pipefail
 
@@ -50,6 +50,7 @@ CYAN='\033[0;36m'
 WHITE='\033[1;37m'
 NC='\033[0m'
 BOLD='\033[1m'
+DIM='\033[2m'
 # Tortoise — deep green accent
 CL='\033[0;32m'
 CLB='\033[1;32m'
@@ -404,6 +405,129 @@ locate_client() {
     else
         DO_MMAPS=0
         print_info "Skipping mmaps. Re-run extraction later if you want them."
+    fi
+}
+
+# ─────────────────────────────────────────
+# INSTALL LOCATION
+# Ported from install-wow-wotlk.sh, which was the only installer that asked.
+# The others hardcoded $HOME/<name>, which silently discarded the folder the
+# Yu'lon launcher's picker had already asked for — reported from a Steam Deck
+# on 2026-08-28 (chose ~/wow-server-tortoise, got ~/tortoise-wow-server, and
+# the app then called the finished install a failure because it looked for the
+# compose file in the folder the user chose). The prompt string "Install path:"
+# is a contract with `PROMPT_RULES` in yulon/catalog/installer.py: that is the
+# line the app watches for, and it types the chosen path in answer.
+# ─────────────────────────────────────────
+choose_install_dir() {
+    print_step "Choose Server Files Location"
+
+    local default_dir="$HOME/tortoise-wow-server"
+
+    echo ""
+    echo -e "  ${WHITE}${BOLD}Where should the server files be installed?${NC}"
+    echo ""
+    echo -e "  ${DIM}Default:${NC} ${CYAN}${default_dir}${NC}"
+    echo ""
+    echo -e "  ${WHITE}You can install the server files to a different location,${NC}"
+    echo -e "  ${WHITE}such as an external drive or SD card, to save space on${NC}"
+    echo -e "  ${WHITE}your main disk.${NC}"
+    echo ""
+    echo -e "  ${YELLOW}⚠️  Note: Docker containers (the compiled server images)${NC}"
+    echo -e "  ${YELLOW}always live on your main disk regardless of this choice.${NC}"
+    echo -e "  ${YELLOW}Only the source code, configs, and data files go here.${NC}"
+    echo ""
+    echo -e "  ${DIM}Leave blank and press ENTER to use the default location.${NC}"
+    echo -e "  ${DIM}Example custom path: /run/media/deck/mysd/wow-server${NC}"
+    echo ""
+    echo -ne "  ${WHITE}Install path: ${NC}"
+    read -r user_input
+
+    if [[ -z "$user_input" ]]; then
+        SERVER_DIR="$default_dir"
+        print_info "Using default location: ${SERVER_DIR}"
+    else
+        # Expand ~ and ensure the path is absolute
+        user_input="${user_input/#\~/$HOME}"
+        if [[ "$user_input" != /* ]]; then
+            user_input="$(pwd)/$user_input"
+        fi
+        SERVER_DIR="$user_input"
+        print_info "Using custom location: ${SERVER_DIR}"
+    fi
+
+    # Canonicalize (resolves .., repeated slashes, trailing slash) so the safety
+    # checks below correctly handle /tmp/.., /, /tmp/ etc.
+    SERVER_DIR=$(realpath -m -- "$SERVER_DIR")
+    local _canon_default
+    _canon_default=$(realpath -m -- "$default_dir")
+
+    # Reject dangerous / well-known system roots
+    case "$SERVER_DIR" in
+        /|"$HOME"|/home|/root|/tmp|/var|/etc|/usr|/boot|/proc|/sys|/dev|/media|/mnt|/opt|/srv)
+            print_error "Cannot use '${SERVER_DIR}' as the install location."
+            print_info "Choose a dedicated subdirectory (e.g. ${default_dir})."
+            exit 1
+            ;;
+    esac
+
+    # Reject if the destination already exists and is not a directory (incl. dangling symlinks)
+    if [[ ( -e "$SERVER_DIR" || -L "$SERVER_DIR" ) && ! -d "$SERVER_DIR" ]]; then
+        print_error "Install path exists but is not a directory: $SERVER_DIR"
+        exit 1
+    fi
+
+    # For custom (non-default) paths: require the parent to already exist.
+    # Don't silently mkdir deep paths — if a drive isn't mounted, that would
+    # install onto the main disk instead.
+    local parent_dir
+    parent_dir="$(dirname "$SERVER_DIR")"
+
+    if [[ "$SERVER_DIR" == "$_canon_default" ]]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            print_error "Cannot create directory: $parent_dir"
+            exit 1
+        }
+    elif [[ ! -d "$parent_dir" ]]; then
+        print_error "Parent directory does not exist: $parent_dir"
+        print_info "Make sure your external drive or SD card is mounted first, then re-run."
+        exit 1
+    fi
+
+    # Write probe using mktemp to avoid clobbering any existing user files
+    local _write_probe
+    _write_probe=$(mktemp "$parent_dir/.dml_probe_XXXXXX" 2>/dev/null) || {
+        print_error "Cannot write to: $parent_dir"
+        print_info "Check permissions or ensure the drive is mounted before running the installer."
+        exit 1
+    }
+    rm -f "$_write_probe"
+
+    # Check free space — probe SERVER_DIR if it already exists (may be a separate
+    # mount point with a different filesystem than its parent); otherwise probe parent.
+    local _space_probe
+    [[ -d "$SERVER_DIR" ]] && _space_probe="$SERVER_DIR" || _space_probe="$parent_dir"
+
+    local avail_gb
+    avail_gb=$(df -BG "$_space_probe" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ') || true
+    if [[ -z "$avail_gb" ]]; then
+        print_error "Could not determine free space at ${_space_probe}. Cannot verify the 15 GB requirement."
+        exit 1
+    fi
+    if [[ "$avail_gb" -lt 15 ]]; then
+        print_error "Not enough space at ${_space_probe}. Need at least 15 GB, found ${avail_gb} GB."
+        exit 1
+    fi
+    print_success "Install location OK — ${avail_gb} GB available at ${_space_probe}"
+
+    echo ""
+    echo -e "  ${WHITE}${BOLD}Server files will be installed to:${NC}"
+    echo -e "  ${CYAN}${SERVER_DIR}${NC}"
+    echo ""
+    if ! ask_yes_no "Confirm this install location?"; then
+        echo ""
+        print_info "Re-run the installer to choose a different location."
+        exit 0
     fi
 }
 
@@ -1025,6 +1149,7 @@ show_completion() {
 check_system
 show_welcome
 locate_client
+choose_install_dir
 show_summary
 install_docker
 clone_source

--- a/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
+++ b/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
@@ -216,11 +216,20 @@ check_system() {
     print_success "Linux detected"
 
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # A warning, not a gate. Docker's images land on the main disk whatever the
+    # user picks, so this number still matters — but the server files themselves
+    # may be headed for an SD card or an external drive, and choose_install_dir()
+    # checks free space where they are ACTUALLY going. Exiting here refused the
+    # very install that prompt exists to allow: on a 64 GB Steam Deck the
+    # installer offered the SD card and then quit over the internal disk
+    # (found while fixing the ignored-folder bug, 2026-08-28).
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
-        print_error "Need ~15GB free (source + build + client data). You have ${AVAILABLE_GB}GB."
-        exit 1
+        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
+        print_info "Docker images always live on the main disk and need several GB."
+        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+    else
+        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
     fi
-    print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
 
     if ! ping -c 1 github.com &>/dev/null; then
         print_error "No internet. Please connect and try again."

--- a/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
+++ b/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
@@ -222,9 +222,17 @@ check_system() {
     # measured $HOME and then said "Docker images live on the main disk" was
     # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$AVAILABLE_GB" in ''|*[!0-9]*) AVAILABLE_GB="" ;; esac
     DOCKER_DISK="/var/lib/docker"
     [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
     DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$DOCKER_GB" in ''|*[!0-9]*) DOCKER_GB="" ;; esac
 
     # Warnings, not gates. Exiting here refused the very install choose_install_dir()
     # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and
@@ -541,6 +549,10 @@ choose_install_dir() {
 
     local avail_gb
     avail_gb=$(df -BG "$_space_probe" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ') || true
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$avail_gb" in ''|*[!0-9]*) avail_gb="" ;; esac
     if [[ -z "$avail_gb" ]]; then
         print_error "Could not determine free space at ${_space_probe}. Cannot verify the 15 GB requirement."
         exit 1

--- a/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
+++ b/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
@@ -215,20 +215,34 @@ check_system() {
     fi
     print_success "Linux detected"
 
+    # Two disks, because they are two disks. $HOME is where the server files go
+    # if the user keeps the default; /var/lib/docker is where the images and the
+    # build cache go no matter what they pick. On a Steam Deck those are
+    # different partitions, so one df cannot answer for both — a warning that
+    # measured $HOME and then said "Docker images live on the main disk" was
+    # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
-    # A warning, not a gate. Docker's images land on the main disk whatever the
-    # user picks, so this number still matters — but the server files themselves
-    # may be headed for an SD card or an external drive, and choose_install_dir()
-    # checks free space where they are ACTUALLY going. Exiting here refused the
-    # very install that prompt exists to allow: on a 64 GB Steam Deck the
-    # installer offered the SD card and then quit over the internal disk
-    # (found while fixing the ignored-folder bug, 2026-08-28).
+    DOCKER_DISK="/var/lib/docker"
+    [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
+    DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+
+    # Warnings, not gates. Exiting here refused the very install choose_install_dir()
+    # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and
+    # then quit over the internal disk. The only free-space floors this project has
+    # measured are for WotLK's native build (min_data_root_gb in catalog.py) and do
+    # not transfer to a script that bind-mounts its checkout into the server folder,
+    # so nothing here refuses on a number nobody took.
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
-        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
-        print_info "Docker images always live on the main disk and need several GB."
-        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+        print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
+        print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
     else
-        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+    fi
+    if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 15 ] 2>/dev/null; then
+        print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
+        print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    else
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
+++ b/pylauncher/catalog/installers/wow-tortoise/install-tortoise-wow-wsl.sh
@@ -235,14 +235,22 @@ check_system() {
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
         print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
         print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
+    elif [ -z "$AVAILABLE_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${HOME}."
     else
-        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB}GB available)"
     fi
     if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 15 ] 2>/dev/null; then
         print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
         print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    elif [ -z "$DOCKER_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${DOCKER_DISK}."
     else
-        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-vanilla/install-wow-vanilla.sh
+++ b/pylauncher/catalog/installers/wow-vanilla/install-wow-vanilla.sh
@@ -244,9 +244,17 @@ check_system() {
     # measured $HOME and then said "Docker images live on the main disk" was
     # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$AVAILABLE_GB" in ''|*[!0-9]*) AVAILABLE_GB="" ;; esac
     DOCKER_DISK="/var/lib/docker"
     [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
     DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$DOCKER_GB" in ''|*[!0-9]*) DOCKER_GB="" ;; esac
 
     # Warnings, not gates. Exiting here refused the very install choose_install_dir()
     # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and
@@ -1152,6 +1160,10 @@ choose_install_dir() {
 
     local avail_gb
     avail_gb=$(df -BG "$_space_probe" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ') || true
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$avail_gb" in ''|*[!0-9]*) avail_gb="" ;; esac
     if [[ -z "$avail_gb" ]]; then
         print_error "Could not determine free space at ${_space_probe}. Cannot verify the 20 GB requirement."
         exit 1

--- a/pylauncher/catalog/installers/wow-vanilla/install-wow-vanilla.sh
+++ b/pylauncher/catalog/installers/wow-vanilla/install-wow-vanilla.sh
@@ -237,20 +237,34 @@ check_system() {
     print_success "Linux detected"
 
     # Need ~20GB for source + build + extracted client data + Docker layers
+    # Two disks, because they are two disks. $HOME is where the server files go
+    # if the user keeps the default; /var/lib/docker is where the images and the
+    # build cache go no matter what they pick. On a Steam Deck those are
+    # different partitions, so one df cannot answer for both — a warning that
+    # measured $HOME and then said "Docker images live on the main disk" was
+    # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
-    # A warning, not a gate. Docker's images land on the main disk whatever the
-    # user picks, so this number still matters — but the server files themselves
-    # may be headed for an SD card or an external drive, and choose_install_dir()
-    # checks free space where they are ACTUALLY going. Exiting here refused the
-    # very install that prompt exists to allow: on a 64 GB Steam Deck the
-    # installer offered the SD card and then quit over the internal disk
-    # (found while fixing the ignored-folder bug, 2026-08-28).
+    DOCKER_DISK="/var/lib/docker"
+    [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
+    DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+
+    # Warnings, not gates. Exiting here refused the very install choose_install_dir()
+    # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and
+    # then quit over the internal disk. The only free-space floors this project has
+    # measured are for WotLK's native build (min_data_root_gb in catalog.py) and do
+    # not transfer to a script that bind-mounts its checkout into the server folder,
+    # so nothing here refuses on a number nobody took.
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 20 ] 2>/dev/null; then
-        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
-        print_info "Docker images always live on the main disk and need several GB."
-        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+        print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
+        print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
     else
-        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+    fi
+    if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 20 ] 2>/dev/null; then
+        print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
+        print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    else
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-vanilla/install-wow-vanilla.sh
+++ b/pylauncher/catalog/installers/wow-vanilla/install-wow-vanilla.sh
@@ -257,14 +257,22 @@ check_system() {
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 20 ] 2>/dev/null; then
         print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
         print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
+    elif [ -z "$AVAILABLE_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${HOME}."
     else
-        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB}GB available)"
     fi
     if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 20 ] 2>/dev/null; then
         print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
         print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    elif [ -z "$DOCKER_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${DOCKER_DISK}."
     else
-        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-vanilla/install-wow-vanilla.sh
+++ b/pylauncher/catalog/installers/wow-vanilla/install-wow-vanilla.sh
@@ -238,11 +238,20 @@ check_system() {
 
     # Need ~20GB for source + build + extracted client data + Docker layers
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # A warning, not a gate. Docker's images land on the main disk whatever the
+    # user picks, so this number still matters — but the server files themselves
+    # may be headed for an SD card or an external drive, and choose_install_dir()
+    # checks free space where they are ACTUALLY going. Exiting here refused the
+    # very install that prompt exists to allow: on a 64 GB Steam Deck the
+    # installer offered the SD card and then quit over the internal disk
+    # (found while fixing the ignored-folder bug, 2026-08-28).
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 20 ] 2>/dev/null; then
-        print_error "Need 20GB free for compile + client data. You have ${AVAILABLE_GB}GB."
-        exit 1
+        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
+        print_info "Docker images always live on the main disk and need several GB."
+        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+    else
+        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
     fi
-    print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
 
     if ! ping -c 1 github.com &>/dev/null; then
         print_error "No internet. Please connect and try again."

--- a/pylauncher/catalog/installers/wow-vanilla/install-wow-vanilla.sh
+++ b/pylauncher/catalog/installers/wow-vanilla/install-wow-vanilla.sh
@@ -47,7 +47,7 @@
 #    - 3-5 hours of wall-clock time (mostly hands-off)
 # ============================================================
 
-INSTALLER_VERSION="1.2.4"
+INSTALLER_VERSION="1.2.5"
 
 set -o pipefail
 
@@ -1019,6 +1019,129 @@ locate_client() {
 # ─────────────────────────────────────────
 # SHOW SUMMARY BEFORE COMPILE
 # ─────────────────────────────────────────
+# ─────────────────────────────────────────
+# INSTALL LOCATION
+# Ported from install-wow-wotlk.sh, which was the only installer that asked.
+# The others hardcoded $HOME/<name>, which silently discarded the folder the
+# Yu'lon launcher's picker had already asked for — reported from a Steam Deck
+# on 2026-08-28 (chose ~/wow-server-tortoise, got ~/tortoise-wow-server, and
+# the app then called the finished install a failure because it looked for the
+# compose file in the folder the user chose). The prompt string "Install path:"
+# is a contract with `PROMPT_RULES` in yulon/catalog/installer.py: that is the
+# line the app watches for, and it types the chosen path in answer.
+# ─────────────────────────────────────────
+choose_install_dir() {
+    print_step "Choose Server Files Location"
+
+    local default_dir="$HOME/wow-vanilla-server"
+
+    echo ""
+    echo -e "  ${WHITE}${BOLD}Where should the server files be installed?${NC}"
+    echo ""
+    echo -e "  ${DIM}Default:${NC} ${CYAN}${default_dir}${NC}"
+    echo ""
+    echo -e "  ${WHITE}You can install the server files to a different location,${NC}"
+    echo -e "  ${WHITE}such as an external drive or SD card, to save space on${NC}"
+    echo -e "  ${WHITE}your main disk.${NC}"
+    echo ""
+    echo -e "  ${YELLOW}⚠️  Note: Docker containers (the compiled server images)${NC}"
+    echo -e "  ${YELLOW}always live on your main disk regardless of this choice.${NC}"
+    echo -e "  ${YELLOW}Only the source code, configs, and data files go here.${NC}"
+    echo ""
+    echo -e "  ${DIM}Leave blank and press ENTER to use the default location.${NC}"
+    echo -e "  ${DIM}Example custom path: /run/media/deck/mysd/wow-server${NC}"
+    echo ""
+    echo -ne "  ${WHITE}Install path: ${NC}"
+    read -r user_input
+
+    if [[ -z "$user_input" ]]; then
+        SERVER_DIR="$default_dir"
+        print_info "Using default location: ${SERVER_DIR}"
+    else
+        # Expand ~ and ensure the path is absolute
+        user_input="${user_input/#\~/$HOME}"
+        if [[ "$user_input" != /* ]]; then
+            user_input="$(pwd)/$user_input"
+        fi
+        SERVER_DIR="$user_input"
+        print_info "Using custom location: ${SERVER_DIR}"
+    fi
+
+    # Canonicalize (resolves .., repeated slashes, trailing slash) so the safety
+    # checks below correctly handle /tmp/.., /, /tmp/ etc.
+    SERVER_DIR=$(realpath -m -- "$SERVER_DIR")
+    local _canon_default
+    _canon_default=$(realpath -m -- "$default_dir")
+
+    # Reject dangerous / well-known system roots
+    case "$SERVER_DIR" in
+        /|"$HOME"|/home|/root|/tmp|/var|/etc|/usr|/boot|/proc|/sys|/dev|/media|/mnt|/opt|/srv)
+            print_error "Cannot use '${SERVER_DIR}' as the install location."
+            print_info "Choose a dedicated subdirectory (e.g. ${default_dir})."
+            exit 1
+            ;;
+    esac
+
+    # Reject if the destination already exists and is not a directory (incl. dangling symlinks)
+    if [[ ( -e "$SERVER_DIR" || -L "$SERVER_DIR" ) && ! -d "$SERVER_DIR" ]]; then
+        print_error "Install path exists but is not a directory: $SERVER_DIR"
+        exit 1
+    fi
+
+    # For custom (non-default) paths: require the parent to already exist.
+    # Don't silently mkdir deep paths — if a drive isn't mounted, that would
+    # install onto the main disk instead.
+    local parent_dir
+    parent_dir="$(dirname "$SERVER_DIR")"
+
+    if [[ "$SERVER_DIR" == "$_canon_default" ]]; then
+        mkdir -p "$parent_dir" 2>/dev/null || {
+            print_error "Cannot create directory: $parent_dir"
+            exit 1
+        }
+    elif [[ ! -d "$parent_dir" ]]; then
+        print_error "Parent directory does not exist: $parent_dir"
+        print_info "Make sure your external drive or SD card is mounted first, then re-run."
+        exit 1
+    fi
+
+    # Write probe using mktemp to avoid clobbering any existing user files
+    local _write_probe
+    _write_probe=$(mktemp "$parent_dir/.dml_probe_XXXXXX" 2>/dev/null) || {
+        print_error "Cannot write to: $parent_dir"
+        print_info "Check permissions or ensure the drive is mounted before running the installer."
+        exit 1
+    }
+    rm -f "$_write_probe"
+
+    # Check free space — probe SERVER_DIR if it already exists (may be a separate
+    # mount point with a different filesystem than its parent); otherwise probe parent.
+    local _space_probe
+    [[ -d "$SERVER_DIR" ]] && _space_probe="$SERVER_DIR" || _space_probe="$parent_dir"
+
+    local avail_gb
+    avail_gb=$(df -BG "$_space_probe" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ') || true
+    if [[ -z "$avail_gb" ]]; then
+        print_error "Could not determine free space at ${_space_probe}. Cannot verify the 20 GB requirement."
+        exit 1
+    fi
+    if [[ "$avail_gb" -lt 20 ]]; then
+        print_error "Not enough space at ${_space_probe}. Need at least 20 GB, found ${avail_gb} GB."
+        exit 1
+    fi
+    print_success "Install location OK — ${avail_gb} GB available at ${_space_probe}"
+
+    echo ""
+    echo -e "  ${WHITE}${BOLD}Server files will be installed to:${NC}"
+    echo -e "  ${CYAN}${SERVER_DIR}${NC}"
+    echo ""
+    if ! ask_yes_no "Confirm this install location?"; then
+        echo ""
+        print_info "Re-run the installer to choose a different location."
+        exit 0
+    fi
+}
+
 show_summary() {
     print_header
     print_step "STEP 2/5 — Pre-Compile Summary"
@@ -2504,6 +2627,7 @@ SUDO_KEEPALIVE_PID=$!
 trap "kill $SUDO_KEEPALIVE_PID 2>/dev/null; exit" EXIT INT TERM
 
 locate_client
+choose_install_dir
 show_summary
 preflight_check
 do_compile

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -540,20 +540,34 @@ check_system() {
         exit 1
     fi
 
+    # Two disks, because they are two disks. $HOME is where the server files go
+    # if the user keeps the default; /var/lib/docker is where the images and the
+    # build cache go no matter what they pick. On a Steam Deck those are
+    # different partitions, so one df cannot answer for both — a warning that
+    # measured $HOME and then said "Docker images live on the main disk" was
+    # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
-    # A warning, not a gate. Docker's images land on the main disk whatever the
-    # user picks, so this number still matters — but the server files themselves
-    # may be headed for an SD card or an external drive, and choose_install_dir()
-    # checks free space where they are ACTUALLY going. Exiting here refused the
-    # very install that prompt exists to allow: on a 64 GB Steam Deck the
-    # installer offered the SD card and then quit over the internal disk
-    # (found while fixing the ignored-folder bug, 2026-08-28).
+    DOCKER_DISK="/var/lib/docker"
+    [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
+    DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+
+    # Warnings, not gates. Exiting here refused the very install choose_install_dir()
+    # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and
+    # then quit over the internal disk. The only free-space floors this project has
+    # measured are for WotLK's native build (min_data_root_gb in catalog.py) and do
+    # not transfer to a script that bind-mounts its checkout into the server folder,
+    # so nothing here refuses on a number nobody took.
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
-        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
-        print_info "Docker images always live on the main disk and need several GB."
-        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+        print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
+        print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
     else
-        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+    fi
+    if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 15 ] 2>/dev/null; then
+        print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
+        print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    else
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -5,7 +5,7 @@
 #
 #  https://github.com/DadsMmoLab/dads-mmo-lab
 #
-#  Version: 1.3.9 - Fedora
+#  Version: 1.4.0 - Fedora
 #
 #  Usage:
 #    chmod +x install-wow.sh
@@ -20,6 +20,15 @@
 #    6. Sets up the Gaming Mode launcher
 #
 #  Changelog:
+#    1.4.0 — Free space is checked where the server files go
+#      - check_system() no longer exits when $HOME is short of space. It probes
+#        $HOME, which is not necessarily where the server files are headed:
+#        choose_install_dir() offers an SD card or external drive and checks
+#        free space at the folder actually chosen. On a 64 GB Steam Deck the
+#        two contradicted each other — the prompt offered the card, the gate
+#        then quit over the internal disk.
+#      - The $HOME figure is now a warning. Docker's images land on the main
+#        disk whatever the user picks, so it is still worth saying.
 #    1.3.7 — Custom server files install location
 #      - Added choose_install_dir(): prompts user for a custom SERVER_DIR
 #        before the install begins (blank = keep default ~/wow-server-playerbots)
@@ -532,11 +541,20 @@ check_system() {
     fi
 
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # A warning, not a gate. Docker's images land on the main disk whatever the
+    # user picks, so this number still matters — but the server files themselves
+    # may be headed for an SD card or an external drive, and choose_install_dir()
+    # checks free space where they are ACTUALLY going. Exiting here refused the
+    # very install that prompt exists to allow: on a 64 GB Steam Deck the
+    # installer offered the SD card and then quit over the internal disk
+    # (found while fixing the ignored-folder bug, 2026-08-28).
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
-        print_error "Not enough disk space. You have ${AVAILABLE_GB}GB free, need at least 15GB."
-        exit 1
+        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
+        print_info "Docker images always live on the main disk and need several GB."
+        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+    else
+        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
     fi
-    print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
 
     if ! ping -c 1 github.com &>/dev/null; then
         print_error "No internet connection. Please connect and try again."

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -560,14 +560,22 @@ check_system() {
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
         print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
         print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
+    elif [ -z "$AVAILABLE_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${HOME}."
     else
-        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB}GB available)"
     fi
     if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 15 ] 2>/dev/null; then
         print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
         print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    elif [ -z "$DOCKER_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${DOCKER_DISK}."
     else
-        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -460,6 +460,10 @@ choose_install_dir() {
 
     local avail_gb
     avail_gb=$(df -BG "$_space_probe" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ') || true
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$avail_gb" in ''|*[!0-9]*) avail_gb="" ;; esac
     if [[ -z "$avail_gb" ]]; then
         print_error "Could not determine free space at ${_space_probe}. Cannot verify the 15 GB requirement."
         exit 1
@@ -547,9 +551,17 @@ check_system() {
     # measured $HOME and then said "Docker images live on the main disk" was
     # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$AVAILABLE_GB" in ''|*[!0-9]*) AVAILABLE_GB="" ;; esac
     DOCKER_DISK="/var/lib/docker"
     [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
     DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$DOCKER_GB" in ''|*[!0-9]*) DOCKER_GB="" ;; esac
 
     # Warnings, not gates. Exiting here refused the very install choose_install_dir()
     # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -489,20 +489,34 @@ check_system() {
         exit 1
     fi
 
+    # Two disks, because they are two disks. $HOME is where the server files go
+    # if the user keeps the default; /var/lib/docker is where the images and the
+    # build cache go no matter what they pick. On a Steam Deck those are
+    # different partitions, so one df cannot answer for both — a warning that
+    # measured $HOME and then said "Docker images live on the main disk" was
+    # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
-    # A warning, not a gate. Docker's images land on the main disk whatever the
-    # user picks, so this number still matters — but the server files themselves
-    # may be headed for an SD card or an external drive, and choose_install_dir()
-    # checks free space where they are ACTUALLY going. Exiting here refused the
-    # very install that prompt exists to allow: on a 64 GB Steam Deck the
-    # installer offered the SD card and then quit over the internal disk
-    # (found while fixing the ignored-folder bug, 2026-08-28).
+    DOCKER_DISK="/var/lib/docker"
+    [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
+    DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+
+    # Warnings, not gates. Exiting here refused the very install choose_install_dir()
+    # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and
+    # then quit over the internal disk. The only free-space floors this project has
+    # measured are for WotLK's native build (min_data_root_gb in catalog.py) and do
+    # not transfer to a script that bind-mounts its checkout into the server folder,
+    # so nothing here refuses on a number nobody took.
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
-        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
-        print_info "Docker images always live on the main disk and need several GB."
-        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+        print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
+        print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
     else
-        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+    fi
+    if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 15 ] 2>/dev/null; then
+        print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
+        print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    else
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -411,6 +411,10 @@ choose_install_dir() {
 
     local avail_gb
     avail_gb=$(df -BG "$_space_probe" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ') || true
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$avail_gb" in ''|*[!0-9]*) avail_gb="" ;; esac
     if [[ -z "$avail_gb" ]]; then
         print_error "Could not determine free space at ${_space_probe}. Cannot verify the 15 GB requirement."
         exit 1
@@ -496,9 +500,17 @@ check_system() {
     # measured $HOME and then said "Docker images live on the main disk" was
     # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$AVAILABLE_GB" in ''|*[!0-9]*) AVAILABLE_GB="" ;; esac
     DOCKER_DISK="/var/lib/docker"
     [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
     DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$DOCKER_GB" in ''|*[!0-9]*) DOCKER_GB="" ;; esac
 
     # Warnings, not gates. Exiting here refused the very install choose_install_dir()
     # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -509,14 +509,22 @@ check_system() {
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
         print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
         print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
+    elif [ -z "$AVAILABLE_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${HOME}."
     else
-        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB}GB available)"
     fi
     if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 15 ] 2>/dev/null; then
         print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
         print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    elif [ -z "$DOCKER_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${DOCKER_DISK}."
     else
-        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -5,7 +5,7 @@
 #
 #  https://github.com/DadsMmoLab/dads-mmo-lab
 #
-#  Version: 1.4.4 - Debian
+#  Version: 1.4.5 - Debian
 #
 #  Usage:
 #    chmod +x install-wow.sh
@@ -20,6 +20,15 @@
 #    6. Sets up the Gaming Mode launcher
 #
 #  Changelog:
+#    1.4.5 — Free space is checked where the server files go
+#      - check_system() no longer exits when $HOME is short of space. It probes
+#        $HOME, which is not necessarily where the server files are headed:
+#        choose_install_dir() offers an SD card or external drive and checks
+#        free space at the folder actually chosen. On a 64 GB Steam Deck the
+#        two contradicted each other — the prompt offered the card, the gate
+#        then quit over the internal disk.
+#      - The $HOME figure is now a warning. Docker's images land on the main
+#        disk whatever the user picks, so it is still worth saying.
 #    1.4.3 — Remove passwordless sudoers rule; add docker group consent
 #      - Removed the /etc/sudoers.d/docker-nopasswd NOPASSWD write. Membership
 #        in the docker group already grants root-equivalent access, so the
@@ -481,11 +490,20 @@ check_system() {
     fi
 
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # A warning, not a gate. Docker's images land on the main disk whatever the
+    # user picks, so this number still matters — but the server files themselves
+    # may be headed for an SD card or an external drive, and choose_install_dir()
+    # checks free space where they are ACTUALLY going. Exiting here refused the
+    # very install that prompt exists to allow: on a 64 GB Steam Deck the
+    # installer offered the SD card and then quit over the internal disk
+    # (found while fixing the ignored-folder bug, 2026-08-28).
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
-        print_error "Not enough disk space. You have ${AVAILABLE_GB}GB free, need at least 15GB."
-        exit 1
+        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
+        print_info "Docker images always live on the main disk and need several GB."
+        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+    else
+        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
     fi
-    print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
 
     if ! ping -c 1 github.com &>/dev/null; then
         print_error "No internet connection. Please connect and try again."

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -459,20 +459,34 @@ check_system() {
     fi
     print_success "Linux detected"
 
+    # Two disks, because they are two disks. $HOME is where the server files go
+    # if the user keeps the default; /var/lib/docker is where the images and the
+    # build cache go no matter what they pick. On a Steam Deck those are
+    # different partitions, so one df cannot answer for both — a warning that
+    # measured $HOME and then said "Docker images live on the main disk" was
+    # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
-    # A warning, not a gate. Docker's images land on the main disk whatever the
-    # user picks, so this number still matters — but the server files themselves
-    # may be headed for an SD card or an external drive, and choose_install_dir()
-    # checks free space where they are ACTUALLY going. Exiting here refused the
-    # very install that prompt exists to allow: on a 64 GB Steam Deck the
-    # installer offered the SD card and then quit over the internal disk
-    # (found while fixing the ignored-folder bug, 2026-08-28).
+    DOCKER_DISK="/var/lib/docker"
+    [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
+    DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+
+    # Warnings, not gates. Exiting here refused the very install choose_install_dir()
+    # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and
+    # then quit over the internal disk. The only free-space floors this project has
+    # measured are for WotLK's native build (min_data_root_gb in catalog.py) and do
+    # not transfer to a script that bind-mounts its checkout into the server folder,
+    # so nothing here refuses on a number nobody took.
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
-        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
-        print_info "Docker images always live on the main disk and need several GB."
-        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+        print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
+        print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
     else
-        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+    fi
+    if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 15 ] 2>/dev/null; then
+        print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
+        print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    else
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -479,14 +479,22 @@ check_system() {
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
         print_warning "Only ${AVAILABLE_GB}GB free on ${HOME}."
         print_info "The server files can go on another drive - you will be asked where in a moment, and that location is checked on its own."
+    elif [ -z "$AVAILABLE_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${HOME}."
     else
-        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB:-unknown}GB available)"
+        print_success "Disk space OK on ${HOME} (${AVAILABLE_GB}GB available)"
     fi
     if [ -n "$DOCKER_GB" ] && [ "$DOCKER_GB" -lt 15 ] 2>/dev/null; then
         print_warning "Only ${DOCKER_GB}GB free on ${DOCKER_DISK}, where Docker keeps its images."
         print_info "That disk fills up wherever you put the server files. Free some space there if the build stops partway."
+    elif [ -z "$DOCKER_GB" ]; then
+        # Unreadable is not OK. Printing "unknownGB available" as a success was
+        # rounding a missing measurement up to a pass (review-of-review, 2026-08-28).
+        print_warning "Could not read free space on ${DOCKER_DISK}."
     else
-        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB:-unknown}GB available, Docker's images)"
+        print_success "Disk space OK on ${DOCKER_DISK} (${DOCKER_GB}GB available, Docker's images)"
     fi
 
     if ! ping -c 1 github.com &>/dev/null; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -5,7 +5,7 @@
 #
 #  https://github.com/DadsMmoLab/dads-mmo-lab
 #
-#  Version: 1.2.8
+#  Version: 1.3.0
 #
 #  Usage:
 #    chmod +x install-wow.sh
@@ -20,6 +20,15 @@
 #    6. Sets up the Gaming Mode launcher
 #
 #  Changelog:
+#    1.3.0 — Free space is checked where the server files go
+#      - check_system() no longer exits when $HOME is short of space. It probes
+#        $HOME, which is not necessarily where the server files are headed:
+#        choose_install_dir() offers an SD card or external drive and checks
+#        free space at the folder actually chosen. On a 64 GB Steam Deck the
+#        two contradicted each other — the prompt offered the card, the gate
+#        then quit over the internal disk.
+#      - The $HOME figure is now a warning. Docker's images land on the main
+#        disk whatever the user picks, so it is still worth saying.
 #    1.2.9 — Remove passwordless sudoers rule; add docker group consent
 #      - Removed the /etc/sudoers.d/docker-nopasswd NOPASSWD write. Membership
 #        in the docker group already grants root-equivalent access, so the
@@ -451,11 +460,20 @@ check_system() {
     print_success "Linux detected"
 
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # A warning, not a gate. Docker's images land on the main disk whatever the
+    # user picks, so this number still matters — but the server files themselves
+    # may be headed for an SD card or an external drive, and choose_install_dir()
+    # checks free space where they are ACTUALLY going. Exiting here refused the
+    # very install that prompt exists to allow: on a 64 GB Steam Deck the
+    # installer offered the SD card and then quit over the internal disk
+    # (found while fixing the ignored-folder bug, 2026-08-28).
     if [ -n "$AVAILABLE_GB" ] && [ "$AVAILABLE_GB" -lt 15 ] 2>/dev/null; then
-        print_error "Not enough disk space. You have ${AVAILABLE_GB}GB free, need at least 15GB."
-        exit 1
+        print_warning "Only ${AVAILABLE_GB}GB free on your main disk (${HOME})."
+        print_info "Docker images always live on the main disk and need several GB."
+        print_info "The server files can go elsewhere - you will be asked where, and that location is checked on its own."
+    else
+        print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
     fi
-    print_success "Disk space OK (${AVAILABLE_GB:-unknown}GB available)"
 
     if ! ping -c 1 github.com &>/dev/null; then
         print_error "No internet connection. Please connect and try again."

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -426,6 +426,10 @@ choose_install_dir() {
 
     local avail_gb
     avail_gb=$(df -BG "$_space_probe" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ') || true
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$avail_gb" in ''|*[!0-9]*) avail_gb="" ;; esac
     if [[ -z "$avail_gb" ]]; then
         print_error "Could not determine free space at ${_space_probe}. Cannot verify the 15 GB requirement."
         exit 1
@@ -466,9 +470,17 @@ check_system() {
     # measured $HOME and then said "Docker images live on the main disk" was
     # describing a number it had not taken (review, 2026-08-28).
     AVAILABLE_GB=$(df -BG "$HOME" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$AVAILABLE_GB" in ''|*[!0-9]*) AVAILABLE_GB="" ;; esac
     DOCKER_DISK="/var/lib/docker"
     [ -d "$DOCKER_DISK" ] || DOCKER_DISK="/"
     DOCKER_GB=$(df -BG "$DOCKER_DISK" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d ' ')
+    # `df` prints `-` for Avail on some filesystems, so "not empty" is not "is a
+    # number". Normalise anything non-numeric to empty, and let the unreadable
+    # branch below own it (review, 2026-08-28).
+    case "$DOCKER_GB" in ''|*[!0-9]*) DOCKER_GB="" ;; esac
 
     # Warnings, not gates. Exiting here refused the very install choose_install_dir()
     # exists to allow: on a 64 GB Steam Deck the installer offered the SD card and

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -1541,3 +1541,47 @@ def _shell_function_bodies(lines: list[str]) -> dict[str, range]:
             bodies[opened[0]] = range(opened[1], number + 1)
             opened = None
     return bodies
+
+
+def test_no_installer_refuses_to_run_over_free_space_on_the_wrong_disk() -> None:
+    """`check_system()` probes $HOME; the server files may not go there.
+
+    `choose_install_dir()` exists so the server files can live on an SD card or
+    an external drive — it says so, in those words, and then probes free space
+    at the folder that was actually chosen. But `check_system()` runs first and
+    hard-exits when $HOME has less than 15-20 GB, so on a 64 GB Steam Deck the
+    installer offers the SD card and then refuses the install because the
+    internal disk is full. The prompt and the gate contradict each other inside
+    one run.
+
+    $HOME is still worth a word — Docker's images go there whatever the user
+    picks — so the check stays and becomes a warning. The authority on whether
+    there is room for the server files is `choose_install_dir()`, which is the
+    only one of the two that knows where they are going.
+    """
+    from yulon import resources
+
+    scripts = sorted(resources.installers_dir().rglob("install-*.sh"))
+    assert len(scripts) >= 5, f"expected the catalog's installers, found {scripts}"
+
+    refusing: list[str] = []
+    for script in scripts:
+        lines = script.read_text(encoding="utf-8").splitlines()
+        probe = next(
+            (n for n, line in enumerate(lines) if 'df -BG "$HOME"' in line),
+            None,
+        )
+        if probe is None:
+            continue
+        # From the probe to the `fi` that closes the branch testing it.
+        for line in lines[probe:]:
+            if line.strip() == "fi":
+                break
+            if re.fullmatch(r"\s*exit\s+\d+", line):
+                refusing.append(f"{script.name}:{probe + 1}")
+                break
+
+    assert not refusing, (
+        "these installers abort on free space in $HOME, which is not where the "
+        f"server files necessarily go: {refusing}"
+    )

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -1084,12 +1084,12 @@ def test_the_generated_override_labels_every_bind_mount_it_shares(script_name: s
     for service in ("ac-worldserver", "ac-authserver", "ac-db-import"):
         assert service in services, f"{script_name}: {service} missing from the override"
         mounts = services[service]
-        assert "${DOCKER_VOL_ETC:-./env/dist/etc}:/azerothcore/env/dist/etc:z" in mounts, (
-            f"{script_name}: {service} has no labelled etc mount, only {mounts}"
-        )
-        assert "${DOCKER_VOL_LOGS:-./env/dist/logs}:/azerothcore/env/dist/logs:z" in mounts, (
-            f"{script_name}: {service} has no labelled logs mount, only {mounts}"
-        )
+        assert (
+            "${DOCKER_VOL_ETC:-./env/dist/etc}:/azerothcore/env/dist/etc:z" in mounts
+        ), f"{script_name}: {service} has no labelled etc mount, only {mounts}"
+        assert (
+            "${DOCKER_VOL_LOGS:-./env/dist/logs}:/azerothcore/env/dist/logs:z" in mounts
+        ), f"{script_name}: {service} has no labelled logs mount, only {mounts}"
     # Spelled with the base file's own default so Compose merges by target path
     # rather than adding a second mount of the same directory.
     assert all(
@@ -1122,9 +1122,9 @@ def test_the_relabel_also_runs_on_the_branch_that_reuses_an_existing_build(
     text = script.read_text(encoding="utf-8")
     reuse = text[text.index("Skipping compile") : text.index("Skipping compile") + 1200]
     reuse = reuse[: reuse.index("return 0")]
-    assert 'selinux_label_for_containers "$SERVER_DIR"' in reuse, (
-        f"{script_name}: the reuse branch brings the stack up without relabelling"
-    )
+    assert (
+        'selinux_label_for_containers "$SERVER_DIR"' in reuse
+    ), f"{script_name}: the reuse branch brings the stack up without relabelling"
     assert reuse.index('selinux_label_for_containers "$SERVER_DIR"') < reuse.index(
         "docker compose up"
     ), f"{script_name}: the relabel must run BEFORE the stack comes up"

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -1437,92 +1437,6 @@ def test_no_installer_escalates_privileges_without_asking() -> None:
     assert not sudoers, f"a passwordless sudo rule is written at: {sudoers}"
 
 
-def test_every_installer_asks_where_to_install() -> None:
-    """The folder the user picked only reaches a script that asks for it.
-
-    `InstallOptions.server_dir` has exactly one channel into a script: the
-    `Install path:` rule in `PROMPT_RULES` types it in when the script asks.
-    `script_env()` does not export it, and `run()` passes no arguments — so a
-    script that never prints that prompt silently installs into its own
-    hardcoded `$HOME/<default>` and the picker is decoration.
-
-    Reported from a Steam Deck (2026-08-28): a tester made
-    `~/wow-server-tortoise`, chose it, and watched Tortoise install into
-    `~/tortoise-wow-server`. TBC and Vanilla had the same hole; only the WotLK
-    scripts had ever grown `choose_install_dir()`. Worse than a wrong folder:
-    `catalog_view._on_run_finished()` then looks for a compose file in the
-    folder the user chose, finds none, and calls a good install failed.
-
-    A grep rather than a run, for the reason the docker-group audit above gives:
-    these scripts install OS packages and cannot be executed in a test.
-    """
-    from yulon import resources
-
-    rule = next(r for r in PROMPT_RULES if "Install path" in r.pattern)
-    prompt = re.compile(rule.pattern, re.IGNORECASE)
-
-    scripts = sorted(resources.installers_dir().rglob("install-*.sh"))
-    assert len(scripts) >= 5, f"expected the catalog's installers, found {scripts}"
-
-    silent = [
-        script.name
-        for script in scripts
-        if not any(prompt.search(line) for line in script.read_text(encoding="utf-8").splitlines())
-    ]
-    assert not silent, (
-        f"these installers never print the prompt {rule.pattern!r}, so the folder "
-        f"the user picked is discarded: {silent}"
-    )
-
-
-def test_every_installer_calls_choose_install_dir_before_it_uses_the_folder() -> None:
-    """Printing the prompt is half of it; the answer has to reach the install.
-
-    The test above is satisfied by a script that defines `choose_install_dir()`
-    and never runs it — the prompt would be in the file, the app would never see
-    it, and `SERVER_DIR` would keep its hardcoded default. So this asserts the
-    call happens in the MAIN block, and that it comes before every other
-    top-level call whose function reads `$SERVER_DIR`. Order is the half with
-    teeth: placed after `show_summary` the summary names the wrong folder, and
-    placed after the existing-install check the script offers to `rm -rf` it.
-
-    Only top-level call order can be checked this way — a `$SERVER_DIR` inside a
-    function definition runs when the function is CALLED, not where it is
-    written, which is what made the first version of this test inert (its
-    ordering branch passed a script whose call had been moved to the end).
-    """
-    from yulon import resources
-
-    scripts = sorted(resources.installers_dir().rglob("install-*.sh"))
-    assert len(scripts) >= 5, f"expected the catalog's installers, found {scripts}"
-
-    problems: list[str] = []
-    for script in scripts:
-        lines = script.read_text(encoding="utf-8").splitlines()
-        bodies = _shell_function_bodies(lines)
-        # The MAIN block: bare top-level calls, in the order bash runs them.
-        in_a_body = {n for span in bodies.values() for n in span}
-        calls = [
-            (n, line.strip())
-            for n, line in enumerate(lines, 1)
-            if re.fullmatch(r"[a-z_][a-z0-9_]*", line.strip()) and n not in in_a_body
-        ]
-        chosen = next((n for n, name in calls if name == "choose_install_dir"), None)
-        if chosen is None:
-            problems.append(f"{script.name}: never calls choose_install_dir")
-            continue
-        for number, name in calls:
-            if number >= chosen or name not in bodies:
-                continue
-            if any("$SERVER_DIR" in lines[n - 1] for n in bodies[name]):
-                problems.append(
-                    f"{script.name}: {name}() uses $SERVER_DIR at line {number}, "
-                    f"before it is chosen at line {chosen}"
-                )
-
-    assert not problems, f"the chosen folder is not in effect where it is used: {problems}"
-
-
 def _shell_function_bodies(lines: list[str]) -> dict[str, range]:
     """`name -> the 1-based line numbers of its body`, for `name() {` at column 0.
 
@@ -1543,41 +1457,152 @@ def _shell_function_bodies(lines: list[str]) -> dict[str, range]:
     return bodies
 
 
-def test_no_installer_refuses_to_run_over_free_space_on_the_wrong_disk() -> None:
-    """`check_system()` probes $HOME; the server files may not go there.
-
-    `choose_install_dir()` exists so the server files can live on an SD card or
-    an external drive — it says so, in those words, and then probes free space
-    at the folder that was actually chosen. But `check_system()` runs first and
-    hard-exits when $HOME has less than 15-20 GB, so on a 64 GB Steam Deck the
-    installer offers the SD card and then refuses the install because the
-    internal disk is full. The prompt and the gate contradict each other inside
-    one run.
-
-    $HOME is still worth a word — Docker's images go there whatever the user
-    picks — so the check stays and becomes a warning. The authority on whether
-    there is room for the server files is `choose_install_dir()`, which is the
-    only one of the two that knows where they are going.
-    """
+def _catalog_installers() -> list[Path]:
     from yulon import resources
 
     scripts = sorted(resources.installers_dir().rglob("install-*.sh"))
     assert len(scripts) >= 5, f"expected the catalog's installers, found {scripts}"
+    return scripts
 
+
+# `$SERVER_DIR` and `${SERVER_DIR}` are the same read, and these scripts use
+# both. A bare `"$SERVER_DIR" in line` sees only the first — which was true of
+# the first version of the ordering test below, and harmless only by accident:
+# every function that touches the variable happens to use the bare form at
+# least once today. Nothing enforces that, and `${SERVER_DIR}` throughout is an
+# ordinary thing to write (review, 2026-08-28).
+SERVER_DIR_READ = re.compile(r"\$\{?SERVER_DIR\}?")
+
+
+def test_every_installer_asks_where_to_install() -> None:
+    """The folder the user picked only reaches a script that asks for it.
+
+    `InstallOptions.server_dir` has exactly one channel into a script: the
+    `Install path:` rule in `PROMPT_RULES` types it in when the script asks.
+    `script_env()` does not export it, and `run()` passes no arguments — so a
+    script that never prints that prompt silently installs into its own
+    hardcoded `$HOME/<default>` and the picker is decoration.
+
+    Reported from a Steam Deck (2026-08-28): a tester made
+    `~/wow-server-tortoise`, chose it, and watched Tortoise install into
+    `~/tortoise-wow-server`. TBC and Vanilla had the same hole; only the WotLK
+    scripts had ever grown `choose_install_dir()`. Worse than a wrong folder:
+    `catalog_view._on_run_finished()` then looks for a compose file in the
+    folder the user chose, finds none, and calls a good install failed.
+
+    The prompt has to be PRINTED, by the function that reads the answer. A grep
+    of the whole file for the string was vacuous: the comment above
+    `choose_install_dir()` quotes `Install path:` to explain the contract, so
+    renaming the real `echo` — a script that would hang forever, since
+    `PROMPT_RULES` would never recognise its prompt — passed it. Proven with
+    that exact mutant before this was rewritten (review, 2026-08-28).
+    """
+    rule = next(r for r in PROMPT_RULES if "Install path" in r.pattern)
+    prompt = re.compile(rule.pattern, re.IGNORECASE)
+
+    silent: list[str] = []
+    for script in _catalog_installers():
+        lines = script.read_text(encoding="utf-8").splitlines()
+        body = _shell_function_bodies(lines).get("choose_install_dir")
+        if body is None:
+            silent.append(f"{script.name}: has no choose_install_dir()")
+            continue
+        asked = next(
+            (
+                n
+                for n in body
+                if prompt.search(lines[n - 1])
+                and not lines[n - 1].lstrip().startswith("#")
+                and re.search(r"\b(echo|printf)\b", lines[n - 1])
+            ),
+            None,
+        )
+        if asked is None:
+            silent.append(f"{script.name}: choose_install_dir() never prints {rule.pattern!r}")
+        elif not any(line.strip().startswith("read -r") for line in lines[asked : body.stop - 1]):
+            silent.append(f"{script.name}: prints the prompt at {asked} and reads no answer")
+
+    assert not silent, (
+        f"the app types the chosen folder in answer to {rule.pattern!r}; these "
+        f"installers will not hear it: {silent}"
+    )
+
+
+def test_every_installer_calls_choose_install_dir_before_it_uses_the_folder() -> None:
+    """Printing the prompt is half of it; the answer has to reach the install.
+
+    The test above is satisfied by a script that defines `choose_install_dir()`
+    and never runs it — the prompt would be in the file, the app would never see
+    it, and `SERVER_DIR` would keep its hardcoded default. So this asserts the
+    call happens in the MAIN block, and that it comes before every other
+    top-level call whose function reads `SERVER_DIR`. Order is the half with
+    teeth: placed after `show_summary` the summary names the wrong folder, and
+    placed after the existing-install check the script offers to `rm -rf` it.
+
+    Only top-level call order can be checked this way — a read inside a function
+    definition happens when the function is CALLED, not where it is written,
+    which is what made the first version of this test inert (its ordering branch
+    passed a script whose call had been moved to the end).
+    """
+    problems: list[str] = []
+    for script in _catalog_installers():
+        lines = script.read_text(encoding="utf-8").splitlines()
+        bodies = _shell_function_bodies(lines)
+        # The MAIN block: bare top-level calls, in the order bash runs them.
+        in_a_body = {n for span in bodies.values() for n in span}
+        calls = [
+            (n, line.strip())
+            for n, line in enumerate(lines, 1)
+            if re.fullmatch(r"[a-z_][a-z0-9_]*", line.strip()) and n not in in_a_body
+        ]
+        chosen = next((n for n, name in calls if name == "choose_install_dir"), None)
+        if chosen is None:
+            problems.append(f"{script.name}: never calls choose_install_dir")
+            continue
+        for number, name in calls:
+            if number >= chosen or name not in bodies:
+                continue
+            if any(SERVER_DIR_READ.search(lines[n - 1]) for n in bodies[name]):
+                problems.append(
+                    f"{script.name}: {name}() reads SERVER_DIR at line {number}, "
+                    f"before it is chosen at line {chosen}"
+                )
+
+    assert not problems, f"the chosen folder is not in effect where it is used: {problems}"
+
+
+def test_no_installer_refuses_to_run_over_free_space_on_the_wrong_disk() -> None:
+    """`check_system()` probes $HOME; the server files may not go there.
+
+    `choose_install_dir()` exists so the server files can live on an SD card or
+    an external drive — it says so, in those words, and then probes free space at
+    the folder that was actually chosen. But `check_system()` runs first and
+    hard-exited when $HOME had less than 15-20 GB, so on a 64 GB Steam Deck the
+    installer offered the SD card and then refused the install because the
+    internal disk was full. The prompt and the gate contradicted each other
+    inside one run.
+
+    $HOME is still worth a word — Docker's images go there whatever the user
+    picks — so the check stays and warns. The authority on whether there is room
+    for the server files is `choose_install_dir()`, which is the only one of the
+    two that knows where they are going.
+    """
     refusing: list[str] = []
-    for script in scripts:
+    for script in _catalog_installers():
         lines = script.read_text(encoding="utf-8").splitlines()
         probe = next(
-            (n for n, line in enumerate(lines) if 'df -BG "$HOME"' in line),
+            (n for n, line in enumerate(lines) if re.search(r'df -BG "\$\{?HOME\}?"', line)),
             None,
         )
         if probe is None:
             continue
-        # From the probe to the `fi` that closes the branch testing it.
+        # From the probe to the `fi` that closes the branch testing it. `exit`
+        # anywhere on the line, not only alone on it: `[ ... ] && exit 1` and
+        # `exit 1  # bail` are the same refusal (review, 2026-08-28).
         for line in lines[probe:]:
             if line.strip() == "fi":
                 break
-            if re.fullmatch(r"\s*exit\s+\d+", line):
+            if re.search(r"\bexit\b", line) and not line.lstrip().startswith("#"):
                 refusing.append(f"{script.name}:{probe + 1}")
                 break
 
@@ -1585,3 +1610,39 @@ def test_no_installer_refuses_to_run_over_free_space_on_the_wrong_disk() -> None
         "these installers abort on free space in $HOME, which is not where the "
         f"server files necessarily go: {refusing}"
     )
+
+
+def test_the_main_disk_warning_measures_the_disk_docker_actually_uses() -> None:
+    """ "Docker images live on the main disk" has to measure that disk.
+
+    `check_system()` probes `$HOME`. `platform.docker_desktop_data_root()` says
+    Docker's disk on Linux is `/var/lib/docker` — and on a Steam Deck `/home`
+    is a different partition from `/`, so the number the warning printed was
+    not the number its sentence described. Introduced by the commit that turned
+    the gate into a warning; caught reviewing it (2026-08-28).
+
+    Not a floor. This project has measured free-space floors for exactly one
+    build — WotLK's native path, `min_data_root_gb` in catalog.py — and they do
+    not transfer to a script that bind-mounts its checkout into the server
+    folder. Refusing an install on a number nobody measured is how the bug
+    above happened. So: measure both disks, say which is which, and let the
+    person decide.
+    """
+    for script in _catalog_installers():
+        lines = script.read_text(encoding="utf-8").splitlines()
+        body = _shell_function_bodies(lines).get("check_system")
+        if body is None or not any('df -BG "$HOME"' in lines[n - 1] for n in body):
+            continue
+        # Non-comment lines only. The first version of this counted the comment
+        # explaining the probe as the probe — the same vacuity that made the
+        # `Install path:` test above pass a script whose prompt had been renamed.
+        # Caught by the mutation battery, not by reading it (2026-08-28).
+        probed = [
+            lines[n - 1]
+            for n in body
+            if "/var/lib/docker" in lines[n - 1] and not lines[n - 1].lstrip().startswith("#")
+        ]
+        assert probed, (
+            f"{script.name}: check_system() warns about Docker's images but only "
+            "measures $HOME, which on a Steam Deck is a different partition"
+        )

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -1473,6 +1473,13 @@ def _catalog_installers() -> list[Path]:
 # ordinary thing to write (review, 2026-08-28).
 SERVER_DIR_READ = re.compile(r"\$\{?SERVER_DIR\}?")
 
+# Same tolerance for the probe these scripts take of $HOME. The guard clause
+# in the Docker-disk test below used a bare literal, so a braced spelling made
+# it `continue` — not "runs and is fooled" but "never runs at all", which is
+# the worse of the two. Fixed for `$SERVER_DIR` in the same commit that left it
+# here (review-of-review, 2026-08-28).
+HOME_PROBE = re.compile(r'df -BG "\$\{?HOME\}?"')
+
 
 def test_every_installer_asks_where_to_install() -> None:
     """The folder the user picked only reaches a script that asks for it.
@@ -1519,8 +1526,31 @@ def test_every_installer_asks_where_to_install() -> None:
         )
         if asked is None:
             silent.append(f"{script.name}: choose_install_dir() never prints {rule.pattern!r}")
-        elif not any(line.strip().startswith("read -r") for line in lines[asked : body.stop - 1]):
+            continue
+        # Not just "a `read -r` happens" — the variable it fills has to be one the
+        # function then uses. `read -r _stray` leaves the answer in a name nobody
+        # reads, so `[[ -z "$user_input" ]]` is always true and SERVER_DIR keeps
+        # its default: the exact bug this branch exists to fix, and it survived
+        # the first rewrite (review-of-review, 2026-08-28).
+        read_line = next(
+            (
+                n
+                for n in range(asked, body.stop)
+                if lines[n - 1].strip().startswith("read -r")
+                and not lines[n - 1].lstrip().startswith("#")
+            ),
+            None,
+        )
+        if read_line is None:
             silent.append(f"{script.name}: prints the prompt at {asked} and reads no answer")
+            continue
+        answer = lines[read_line - 1].split()[2]
+        used = re.compile(r"\$\{?" + re.escape(answer) + r"\}?")
+        if not any(used.search(lines[n - 1]) for n in range(read_line + 1, body.stop)):
+            silent.append(
+                f"{script.name}: reads the answer into ${answer} at line {read_line}, "
+                "which nothing after it uses"
+            )
 
     assert not silent, (
         f"the app types the chosen folder in answer to {rule.pattern!r}; these "
@@ -1559,6 +1589,19 @@ def test_every_installer_calls_choose_install_dir_before_it_uses_the_folder() ->
         if chosen is None:
             problems.append(f"{script.name}: never calls choose_install_dir")
             continue
+        # A read does not have to be inside a function. `SUMMARY_DIR="$SERVER_DIR"`
+        # in the MAIN block above the call copies the DEFAULT, and every later use
+        # of the alias names the folder the user did not pick — the same wrong
+        # folder, laundered through a second variable, and invisible to the
+        # per-function scan below (review-of-review, 2026-08-28).
+        for number, line in enumerate(lines, 1):
+            if number >= chosen or number in in_a_body or line.lstrip().startswith("#"):
+                continue
+            if SERVER_DIR_READ.search(line):
+                problems.append(
+                    f"{script.name}: line {number} reads SERVER_DIR before it is "
+                    f"chosen at line {chosen}: {line.strip()}"
+                )
         for number, name in calls:
             if number >= chosen or name not in bodies:
                 continue
@@ -1590,10 +1633,7 @@ def test_no_installer_refuses_to_run_over_free_space_on_the_wrong_disk() -> None
     refusing: list[str] = []
     for script in _catalog_installers():
         lines = script.read_text(encoding="utf-8").splitlines()
-        probe = next(
-            (n for n, line in enumerate(lines) if re.search(r'df -BG "\$\{?HOME\}?"', line)),
-            None,
-        )
+        probe = next((n for n, line in enumerate(lines) if HOME_PROBE.search(line)), None)
         if probe is None:
             continue
         # From the probe to the `fi` that closes the branch testing it. `exit`
@@ -1631,7 +1671,7 @@ def test_the_main_disk_warning_measures_the_disk_docker_actually_uses() -> None:
     for script in _catalog_installers():
         lines = script.read_text(encoding="utf-8").splitlines()
         body = _shell_function_bodies(lines).get("check_system")
-        if body is None or not any('df -BG "$HOME"' in lines[n - 1] for n in body):
+        if body is None or not any(HOME_PROBE.search(lines[n - 1]) for n in body):
             continue
         # Non-comment lines only. The first version of this counted the comment
         # explaining the probe as the probe — the same vacuity that made the
@@ -1646,3 +1686,38 @@ def test_the_main_disk_warning_measures_the_disk_docker_actually_uses() -> None:
             f"{script.name}: check_system() warns about Docker's images but only "
             "measures $HOME, which on a Steam Deck is a different partition"
         )
+
+
+def test_a_disk_the_installer_could_not_measure_is_not_reported_as_fine() -> None:
+    """An unreadable `df` is not a pass.
+
+    `AVAILABLE_GB=$(df ... )` yields an empty string when `df` fails or prints
+    no second line, and `[ -n "$X" ]` then sends the empty case to the `else`
+    branch — which used to `print_success "... (unknownGB available)"`. That
+    rounds a measurement nobody took up to an OK, the inverse of the mistake
+    `preflight.py` warns about in its own docstring. Reaching for `/var/lib/docker`,
+    which may exist and be unreadable, made it likelier than it had been for
+    `$HOME` (review-of-review, 2026-08-28).
+
+    So every `df` probe in `check_system()` needs a branch of its own for the
+    empty case.
+    """
+    unhandled: list[str] = []
+    for script in _catalog_installers():
+        lines = script.read_text(encoding="utf-8").splitlines()
+        body = _shell_function_bodies(lines).get("check_system")
+        if body is None:
+            continue
+        for number in body:
+            probed = re.match(r"\s*([A-Z_]+)=\$\(df ", lines[number - 1])
+            if probed is None:
+                continue
+            variable = probed.group(1)
+            empty_case = re.compile(r"-z\s+\"\$\{?" + re.escape(variable) + r"\}?\"")
+            if not any(empty_case.search(lines[n - 1]) for n in body):
+                unhandled.append(f"{script.name}:{number} ({variable})")
+
+    assert not unhandled, (
+        "these disk probes report an unreadable disk as fine, because nothing "
+        f"tests the empty case: {unhandled}"
+    )

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -1084,12 +1084,12 @@ def test_the_generated_override_labels_every_bind_mount_it_shares(script_name: s
     for service in ("ac-worldserver", "ac-authserver", "ac-db-import"):
         assert service in services, f"{script_name}: {service} missing from the override"
         mounts = services[service]
-        assert (
-            "${DOCKER_VOL_ETC:-./env/dist/etc}:/azerothcore/env/dist/etc:z" in mounts
-        ), f"{script_name}: {service} has no labelled etc mount, only {mounts}"
-        assert (
-            "${DOCKER_VOL_LOGS:-./env/dist/logs}:/azerothcore/env/dist/logs:z" in mounts
-        ), f"{script_name}: {service} has no labelled logs mount, only {mounts}"
+        assert "${DOCKER_VOL_ETC:-./env/dist/etc}:/azerothcore/env/dist/etc:z" in mounts, (
+            f"{script_name}: {service} has no labelled etc mount, only {mounts}"
+        )
+        assert "${DOCKER_VOL_LOGS:-./env/dist/logs}:/azerothcore/env/dist/logs:z" in mounts, (
+            f"{script_name}: {service} has no labelled logs mount, only {mounts}"
+        )
     # Spelled with the base file's own default so Compose merges by target path
     # rather than adding a second mount of the same directory.
     assert all(
@@ -1122,9 +1122,9 @@ def test_the_relabel_also_runs_on_the_branch_that_reuses_an_existing_build(
     text = script.read_text(encoding="utf-8")
     reuse = text[text.index("Skipping compile") : text.index("Skipping compile") + 1200]
     reuse = reuse[: reuse.index("return 0")]
-    assert (
-        'selinux_label_for_containers "$SERVER_DIR"' in reuse
-    ), f"{script_name}: the reuse branch brings the stack up without relabelling"
+    assert 'selinux_label_for_containers "$SERVER_DIR"' in reuse, (
+        f"{script_name}: the reuse branch brings the stack up without relabelling"
+    )
     assert reuse.index('selinux_label_for_containers "$SERVER_DIR"') < reuse.index(
         "docker compose up"
     ), f"{script_name}: the relabel must run BEFORE the stack comes up"
@@ -1435,3 +1435,109 @@ def test_no_installer_escalates_privileges_without_asking() -> None:
     # Forbidden outright, not merely gated: membership already is root, so the
     # rule buys nothing and is pure attack surface.
     assert not sudoers, f"a passwordless sudo rule is written at: {sudoers}"
+
+
+def test_every_installer_asks_where_to_install() -> None:
+    """The folder the user picked only reaches a script that asks for it.
+
+    `InstallOptions.server_dir` has exactly one channel into a script: the
+    `Install path:` rule in `PROMPT_RULES` types it in when the script asks.
+    `script_env()` does not export it, and `run()` passes no arguments — so a
+    script that never prints that prompt silently installs into its own
+    hardcoded `$HOME/<default>` and the picker is decoration.
+
+    Reported from a Steam Deck (2026-08-28): a tester made
+    `~/wow-server-tortoise`, chose it, and watched Tortoise install into
+    `~/tortoise-wow-server`. TBC and Vanilla had the same hole; only the WotLK
+    scripts had ever grown `choose_install_dir()`. Worse than a wrong folder:
+    `catalog_view._on_run_finished()` then looks for a compose file in the
+    folder the user chose, finds none, and calls a good install failed.
+
+    A grep rather than a run, for the reason the docker-group audit above gives:
+    these scripts install OS packages and cannot be executed in a test.
+    """
+    from yulon import resources
+
+    rule = next(r for r in PROMPT_RULES if "Install path" in r.pattern)
+    prompt = re.compile(rule.pattern, re.IGNORECASE)
+
+    scripts = sorted(resources.installers_dir().rglob("install-*.sh"))
+    assert len(scripts) >= 5, f"expected the catalog's installers, found {scripts}"
+
+    silent = [
+        script.name
+        for script in scripts
+        if not any(prompt.search(line) for line in script.read_text(encoding="utf-8").splitlines())
+    ]
+    assert not silent, (
+        f"these installers never print the prompt {rule.pattern!r}, so the folder "
+        f"the user picked is discarded: {silent}"
+    )
+
+
+def test_every_installer_calls_choose_install_dir_before_it_uses_the_folder() -> None:
+    """Printing the prompt is half of it; the answer has to reach the install.
+
+    The test above is satisfied by a script that defines `choose_install_dir()`
+    and never runs it — the prompt would be in the file, the app would never see
+    it, and `SERVER_DIR` would keep its hardcoded default. So this asserts the
+    call happens in the MAIN block, and that it comes before every other
+    top-level call whose function reads `$SERVER_DIR`. Order is the half with
+    teeth: placed after `show_summary` the summary names the wrong folder, and
+    placed after the existing-install check the script offers to `rm -rf` it.
+
+    Only top-level call order can be checked this way — a `$SERVER_DIR` inside a
+    function definition runs when the function is CALLED, not where it is
+    written, which is what made the first version of this test inert (its
+    ordering branch passed a script whose call had been moved to the end).
+    """
+    from yulon import resources
+
+    scripts = sorted(resources.installers_dir().rglob("install-*.sh"))
+    assert len(scripts) >= 5, f"expected the catalog's installers, found {scripts}"
+
+    problems: list[str] = []
+    for script in scripts:
+        lines = script.read_text(encoding="utf-8").splitlines()
+        bodies = _shell_function_bodies(lines)
+        # The MAIN block: bare top-level calls, in the order bash runs them.
+        in_a_body = {n for span in bodies.values() for n in span}
+        calls = [
+            (n, line.strip())
+            for n, line in enumerate(lines, 1)
+            if re.fullmatch(r"[a-z_][a-z0-9_]*", line.strip()) and n not in in_a_body
+        ]
+        chosen = next((n for n, name in calls if name == "choose_install_dir"), None)
+        if chosen is None:
+            problems.append(f"{script.name}: never calls choose_install_dir")
+            continue
+        for number, name in calls:
+            if number >= chosen or name not in bodies:
+                continue
+            if any("$SERVER_DIR" in lines[n - 1] for n in bodies[name]):
+                problems.append(
+                    f"{script.name}: {name}() uses $SERVER_DIR at line {number}, "
+                    f"before it is chosen at line {chosen}"
+                )
+
+    assert not problems, f"the chosen folder is not in effect where it is used: {problems}"
+
+
+def _shell_function_bodies(lines: list[str]) -> dict[str, range]:
+    """`name -> the 1-based line numbers of its body`, for `name() {` at column 0.
+
+    Good enough for these scripts and no more: they are written in one style,
+    every definition opens with `name() {` unindented and closes with a `}`
+    unindented. A parser would be the wrong trade for a shape that has held
+    across six installers.
+    """
+    bodies: dict[str, range] = {}
+    opened: tuple[str, int] | None = None
+    for number, line in enumerate(lines, 1):
+        match = re.fullmatch(r"([a-z_][a-z0-9_]*)\(\) \{", line)
+        if match and opened is None:
+            opened = (match.group(1), number)
+        elif line == "}" and opened is not None:
+            bodies[opened[0]] = range(opened[1], number + 1)
+            opened = None
+    return bodies

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -1440,15 +1440,21 @@ def test_no_installer_escalates_privileges_without_asking() -> None:
 def _shell_function_bodies(lines: list[str]) -> dict[str, range]:
     """`name -> the 1-based line numbers of its body`, for `name() {` at column 0.
 
-    Good enough for these scripts and no more: they are written in one style,
-    every definition opens with `name() {` unindented and closes with a `}`
-    unindented. A parser would be the wrong trade for a shape that has held
-    across six installers.
+    Good enough for these scripts and no more: every definition is unindented
+    and closes with a `}` unindented. A parser would be the wrong trade for a
+    shape that has held across six installers.
+
+    All three spellings bash accepts, though — `name() {`, `function name() {`
+    and `function name {`. Recognising only the first turned an ordinary style
+    choice into a CI failure that read like a regression: the unrecognised
+    body fell out of `in_a_body` and its lines were then scanned as MAIN-block
+    code, so one renamed definition produced a dozen bogus "reads SERVER_DIR
+    before it is chosen" errors (review, 2026-08-28).
     """
     bodies: dict[str, range] = {}
     opened: tuple[str, int] | None = None
     for number, line in enumerate(lines, 1):
-        match = re.fullmatch(r"([a-z_][a-z0-9_]*)\(\) \{", line)
+        match = re.fullmatch(r"(?:function\s+)?([a-z_][a-z0-9_]*)\s*(?:\(\))?\s*\{", line)
         if match and opened is None:
             opened = (match.group(1), number)
         elif line == "}" and opened is not None:
@@ -1479,6 +1485,15 @@ SERVER_DIR_READ = re.compile(r"\$\{?SERVER_DIR\}?")
 # the worse of the two. Fixed for `$SERVER_DIR` in the same commit that left it
 # here (review-of-review, 2026-08-28).
 HOME_PROBE = re.compile(r'df -BG "\$\{?HOME\}?"')
+
+# Bash keywords are valid identifiers, so a bare `fi` or `done` on its own
+# line looks exactly like a call to a function of that name. Two `fi`s in
+# TBC's MAIN block are picked up today; they are harmless only because no
+# function happens to be called `fi`, which is one unlucky name away from
+# corrupting the ordering scan (review, 2026-08-28).
+SHELL_KEYWORDS = frozenset(
+    "if then elif else fi for while until do done case esac function select time in".split()
+)
 
 
 def test_every_installer_asks_where_to_install() -> None:
@@ -1583,7 +1598,9 @@ def test_every_installer_calls_choose_install_dir_before_it_uses_the_folder() ->
         calls = [
             (n, line.strip())
             for n, line in enumerate(lines, 1)
-            if re.fullmatch(r"[a-z_][a-z0-9_]*", line.strip()) and n not in in_a_body
+            if re.fullmatch(r"[a-z_][a-z0-9_]*", line.strip())
+            and line.strip() not in SHELL_KEYWORDS
+            and n not in in_a_body
         ]
         chosen = next((n for n, name in calls if name == "choose_install_dir"), None)
         if chosen is None:
@@ -1689,35 +1706,85 @@ def test_the_main_disk_warning_measures_the_disk_docker_actually_uses() -> None:
 
 
 def test_a_disk_the_installer_could_not_measure_is_not_reported_as_fine() -> None:
-    """An unreadable `df` is not a pass.
+    """An unreadable `df` is not a pass, and neither is an unreadable number.
 
-    `AVAILABLE_GB=$(df ... )` yields an empty string when `df` fails or prints
-    no second line, and `[ -n "$X" ]` then sends the empty case to the `else`
-    branch — which used to `print_success "... (unknownGB available)"`. That
-    rounds a measurement nobody took up to an OK, the inverse of the mistake
-    `preflight.py` warns about in its own docstring. Reaching for `/var/lib/docker`,
-    which may exist and be unreadable, made it likelier than it had been for
-    `$HOME` (review-of-review, 2026-08-28).
+    `X=$(df ... )` yields an empty string when `df` fails or prints no second
+    line, and `[ -n "$X" ]` then sent the empty case to the `else` branch —
+    which used to `print_success "... (unknownGB available)"`. That rounds a
+    measurement nobody took up to an OK, the inverse of the mistake
+    `preflight.py` warns about in its own docstring.
 
-    So every `df` probe in `check_system()` needs a branch of its own for the
-    empty case.
+    Empty was only half of it. `df` prints `-` for Avail on some filesystems,
+    so after `sed 's/G//'` the variable holds a non-empty non-number: the `-z`
+    branch does not fire, `[ "-" -lt 20 ]` errors instead of comparing, and the
+    `else` branch reports "Disk space OK (-GB available)". In
+    `choose_install_dir()` it is louder — that comparison has no
+    `2>/dev/null` — and it still proceeds (review, 2026-08-28).
+
+    So every `df` probe, in both functions, normalises a non-number to empty
+    and then handles empty.
     """
     unhandled: list[str] = []
     for script in _catalog_installers():
         lines = script.read_text(encoding="utf-8").splitlines()
-        body = _shell_function_bodies(lines).get("check_system")
-        if body is None:
-            continue
-        for number in body:
-            probed = re.match(r"\s*([A-Z_]+)=\$\(df ", lines[number - 1])
-            if probed is None:
+        bodies = _shell_function_bodies(lines)
+        for function in ("check_system", "choose_install_dir"):
+            body = bodies.get(function)
+            if body is None:
                 continue
-            variable = probed.group(1)
-            empty_case = re.compile(r"-z\s+\"\$\{?" + re.escape(variable) + r"\}?\"")
-            if not any(empty_case.search(lines[n - 1]) for n in body):
-                unhandled.append(f"{script.name}:{number} ({variable})")
+            for number in body:
+                probed = re.match(r"\s*([A-Za-z_]+)=\$\(df ", lines[number - 1])
+                if probed is None:
+                    continue
+                variable = probed.group(1)
+                reference = r"\$\{?" + re.escape(variable) + r"\}?"
+                empty_case = re.compile(r"-z\s+\"" + reference + r"\"")
+                # `case "$X" in ''|*[!0-9]*)` — the one idiom these scripts use
+                # to say "not a number", and the only one this looks for.
+                numeric = re.compile(r"case\s+\"" + reference + r"\".*\[!0-9\]")
+                if not any(empty_case.search(lines[n - 1]) for n in body):
+                    unhandled.append(f"{script.name}:{number} ({variable}: no empty case)")
+                if not any(numeric.search(lines[n - 1]) for n in body):
+                    unhandled.append(f"{script.name}:{number} ({variable}: no non-number case)")
 
     assert not unhandled, (
-        "these disk probes report an unreadable disk as fine, because nothing "
-        f"tests the empty case: {unhandled}"
+        "these disk probes report an unmeasurable disk as fine, because nothing "
+        f"rejects what came back: {unhandled}"
     )
+
+
+def test_choose_install_dir_refuses_by_failing() -> None:
+    """Every refusal in `choose_install_dir()` has to exit non-zero.
+
+    `Installer.run()` raises on a non-zero exit and that is the only signal it
+    has; `exit 0` after a `print_error` means the app is told the script
+    finished normally. `catalog_view._on_run_finished()` does catch the specific
+    shape that follows — a clean exit with no compose file in the chosen folder
+    — so this is defence in depth rather than the only guard, but the message
+    the user gets from that path describes an existing install, not the disk or
+    the folder that was actually refused.
+
+    Found by mutating the free-space refusal to `exit 0` and watching the whole
+    file stay green (review, 2026-08-28).
+    """
+    surrendering: list[str] = []
+    for script in _catalog_installers():
+        lines = script.read_text(encoding="utf-8").splitlines()
+        body = _shell_function_bodies(lines).get("choose_install_dir")
+        assert body is not None, f"{script.name}: has no choose_install_dir()"
+        refusing = False
+        for number in body:
+            line = lines[number - 1].strip()
+            if line.startswith("#"):
+                continue
+            if line.startswith("print_error"):
+                refusing = True
+                continue
+            if line.startswith("exit "):
+                # The one deliberate `exit 0`: declining the confirm prompt is a
+                # choice, not a failure, and it follows a print_info.
+                if refusing and line != "exit 1":
+                    surrendering.append(f"{script.name}:{number} {line!r} after print_error")
+                refusing = False
+
+    assert not surrendering, f"these refusals report success: {surrendering}"


### PR DESCRIPTION
Reported by a tester on a Steam Deck, installing Tortoise through Yu'lon 0.6.55:

> it asked me to select a folder (suggestion tortoise-wow-server in the title bar). I created a new folder and named it wow-server-tortoise, I chose the folder I just created. Installation continued but is using its own created folder named tortoise-wow-server

## What was wrong

`InstallOptions.server_dir` has exactly one channel into an installer script: the `Install path:` rule in `PROMPT_RULES` types the chosen path in when the script prints that prompt. `script_env()` does not export it, and `run()` passes no arguments.

Only the WotLK scripts ever grew `choose_install_dir()`. **TBC, Vanilla and Tortoise hardcoded `SERVER_DIR="$HOME/<default>"`**, so for three of the four catalog entries the folder picker was decoration.

The wrong folder was the smaller half. `catalog_view._on_run_finished()` then looks for a compose file in the folder the *user* chose, finds none — the install wrote it to the hardcoded one — and reports a finished, working install as **"Install failed"**, refusing to create a tab for it.

## What this does

1. Ports `choose_install_dir()` from `install-wow-wotlk.sh` into the three, verbatim apart from the default dir name and the space requirement each script already states (20/20/15 GB). Called after `locate_client`, before `show_summary` — the first line that reads `$SERVER_DIR`.
2. `check_system()` no longer exits when `$HOME` is short of space. It probes `$HOME`, which is not necessarily where the server files are headed: `choose_install_dir()` offers an SD card or external drive and checks free space where they are *actually* going. On a 64 GB Deck the two contradicted each other — the prompt offered the card, the gate then quit over the internal disk. All six `install-*.sh`, WotLK included, which had the prompt since 1.2.4 and the contradiction since then too.
3. `check_system()` measures **two** disks and names each. `platform.docker_desktop_data_root()` has always documented that Docker's disk on Linux is `/var/lib/docker`, and on a Steam Deck `/home` is a different partition — so a warning that measured `$HOME` and then said "Docker images live on the main disk" was describing a number it had not taken.
4. An unmeasurable disk is not a pass. `df` yields an empty string when it fails, and prints `-` for Avail on some filesystems — so "not empty" is not "is a number". All 18 probes normalise a non-number to empty and warn.

## Deliberately not here

**No free-space floor.** The only measured floors this project has are `min_data_root_gb` / `min_server_dir_gb`, which apply to WotLK's *native* path — TBC, Vanilla and Tortoise have no `native` block, and those numbers do not transfer to a script that bind-mounts its checkout into the server folder. Refusing an install on a number nobody took is how the original bug happened.

That leaves a real gap, stated plainly: `LogPanel` caps at 5000 blocks (`log_panel.py:28`), so a warning printed in the first hundred lines of a multi-hour build is deleted from the panel long before it ends. For a GUI install, "warn" is close to "say nothing". Closing it needs either a floor measured on a real Deck, or a way for the app to surface a script's warnings.

## Tests

Five greps over the scripts, in `test_installer.py`. A run is not possible — these install OS packages — so each was instead verified by mutation. **Thirteen mutants, each run against the suite, each red.** Three of them survived an earlier version of these same tests and were the reason for a rewrite:

| Mutant | Why it matters |
|---|---|
| `Install path:` renamed in the real `echo` | Would hang forever; the app never recognises the prompt |
| `read -r _stray_unused` | Answer read into a name nothing uses, so the default silently wins |
| Top-level `SUMMARY_DIR="$SERVER_DIR"` before the call | Captures the *default*; every later use names the wrong folder |
| `choose_install_dir` call deleted / moved after `show_summary` | Summary names the wrong folder; the reinstall check offers to `rm -rf` it |
| Consumer reordered using only `${SERVER_DIR}` | Braced and bare are one read |
| `$HOME` gate restored as `... && exit 1` | The original bug, spelled differently |
| Free-space refusal changed to `exit 0` | Six of that function's seven exits have no Python-side equivalent |
| Non-numeric `df` accepted | `"Disk space OK (-GB available)"` |

The first version of the first test was vacuous in a way worth recording: the comment I had written above `choose_install_dir()` quotes `Install path:` to explain the contract, so a whole-file grep for the string was answered by the comment explaining the fix. Two later fixes repeated the same shape, and one arrived with a doubled-backslash regex that matched nothing — caught only because previously-red mutants turned green, never by the suite going red.

Three review rounds; each found real defects, each is fixed here.

## Verification

`ruff`, `black`, `mypy` on linux/win32/darwin, `bash -n` on all eight scripts, 961 passed / 27 skipped. CI green on every commit in the branch.

**Not verified on hardware.** Nobody has run these three installers end to end on a Steam Deck since the change. The failure this fixes was found by a tester, and confirming the fix wants the same.
