### PR TITLE
CI took 42 minutes to say what it can now say in 80 seconds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,12 @@ jobs:
       - name: A daemon has to be there for this job to mean anything
         run: docker info > /dev/null
 
-      # `-v --durations=0` on purpose: 16 tests taking 41 minutes is a defect in
-      # its own right, and nothing in the repo currently records WHICH of them
-      # is slow. Trim this to `-q` once that is answered.
+      # `-v --durations=0` stays. It was added to answer "which of these 16
+      # tests eats 41 minutes", and it did: run 33203168304 named four tests at
+      # ~600s each - 2 x `docker.STOP_GRACE_SECONDS` waited out by fixture
+      # containers that ignored SIGTERM (the fix and the measurement are in
+      # tests/integration/conftest.py). It stays because the job is now short
+      # enough that durations cost nothing, and because a silent regression
+      # here is worth forty minutes.
       - name: pytest (live Docker)
         run: python -m pytest -v --durations=0 -m integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,41 @@
 name: ci
 
+# WHY THIS FILE IS SPLIT IN TWO. Measured on run 33134621630 (2026-08-28):
+# `pytest -q` reported `975 passed, 7 skipped in 2496.46s` - 41m36s - while
+# every other step in the job (checkout, apt, pip, ruff, black, three mypy
+# passes) totalled 60 seconds. The whole suite runs in 39s on a developer's
+# machine. The difference is `tests/integration/`: its own conftest says the
+# marker gate "keeps the default `pytest` run green in CI without Docker", and
+# that assumption is simply wrong - `ubuntu-latest` ships a running Docker
+# daemon, so the live-Docker suite has been executing on every push and every
+# pull request since it was written. The runner's own log localises it: the
+# first progress line (tests 1-72, which is where `tests/integration` sorts)
+# printed 41 minutes in, and the remaining 903 tests printed in the 22 seconds
+# after it.
+#
+# So the fast checks no longer wait behind Docker. `lint-type-test` deselects
+# the marker and answers in about two minutes; `integration` runs the same 16
+# tests it always did, in parallel, on its own runner.
+
 on:
+  # Not a bare `push:`. Every branch here becomes a pull request, and a bare
+  # `push` plus `pull_request` starts TWO full runs for each commit on one -
+  # visible in the run list as a `push` run and a `pull_request` run seconds
+  # apart on the same SHA. Naming the integration branches keeps the push
+  # trigger for the trunk and leaves topic branches to their PR run.
+  #
+  # The trade: a topic branch with no PR open gets no CI. Open the PR (draft is
+  # enough) and it does.
   push:
+    branches: [main, Yulon]
   pull_request:
+
+# Five pushes to `Yulon` inside three minutes each started their own 42-minute
+# run (2026-08-28 00:20-00:23). Only the newest tree's verdict is worth having,
+# and the older runs were still holding runners while it queued.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:
@@ -11,6 +44,7 @@ defaults:
 jobs:
   lint-type-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Two versions, not one. Pinning only 3.11 hid a red suite for a day:
     # `shutil.which` grew a `_winapi` call in 3.12, so tests that fake
     # sys.platform="win32" — which changes it for the whole stdlib, not just the
@@ -29,6 +63,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # `defaults.run.working-directory` applies to `run:` steps only, never
+          # to an action's inputs, so this path is from the repository root.
+          cache: pip
+          cache-dependency-path: pylauncher/requirements-dev.txt
 
       # PySide6's Qt libraries need these even for QT_QPA_PLATFORM=offscreen (the UI tests).
       - run: sudo apt-get update -qq && sudo apt-get install -y -qq libegl1 libgl1 libxkbcommon0 libdbus-1-3
@@ -56,5 +94,39 @@ jobs:
       - name: mypy (types, as macOS)
         run: python -m mypy --platform darwin yulon main.py
 
+      # `not integration` is the whole point of the split - see the header.
       - name: pytest (tests)
-        run: python -m pytest -q
+        run: python -m pytest -q -m "not integration"
+
+  # The live-Docker suite, on its own runner so it blocks nothing else.
+  integration:
+    runs-on: ubuntu-latest
+    # It has taken ~41 minutes; anything past an hour is a hang, not a slow
+    # test, and a hang should not hold a runner for GitHub's six-hour default.
+    timeout-minutes: 60
+    name: integration (live Docker)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pylauncher/requirements-dev.txt
+
+      - run: sudo apt-get update -qq && sudo apt-get install -y -qq libegl1 libgl1 libxkbcommon0 libdbus-1-3
+
+      - run: pip install -r requirements-dev.txt
+
+      # The daemon must be REACHED, not assumed. Every test in this job skips
+      # itself when `docker info` fails, so a runner image that dropped Docker
+      # would turn this job into a green no-op - which is exactly the silence
+      # that let the suite run unnoticed inside `lint-type-test` for weeks.
+      - name: A daemon has to be there for this job to mean anything
+        run: docker info > /dev/null
+
+      # `-v --durations=0` on purpose: 16 tests taking 41 minutes is a defect in
+      # its own right, and nothing in the repo currently records WHICH of them
+      # is slow. Trim this to `-q` once that is answered.
+      - name: pytest (live Docker)
+        run: python -m pytest -v --durations=0 -m integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,13 @@ jobs:
           # `defaults.run.working-directory` applies to `run:` steps only, never
           # to an action's inputs, so this path is from the repository root.
           cache: pip
-          cache-dependency-path: pylauncher/requirements-dev.txt
+          # BOTH files. requirements-dev.txt opens with `-r requirements.txt`,
+          # so a key hashed over the dev file alone would keep serving a cache
+          # built before a runtime pin changed - the one failure mode that makes
+          # a caching bug look like a code bug.
+          cache-dependency-path: |
+            pylauncher/requirements-dev.txt
+            pylauncher/requirements.txt
 
       # PySide6's Qt libraries need these even for QT_QPA_PLATFORM=offscreen (the UI tests).
       - run: sudo apt-get update -qq && sudo apt-get install -y -qq libegl1 libgl1 libxkbcommon0 libdbus-1-3
@@ -112,7 +118,13 @@ jobs:
         with:
           python-version: "3.13"
           cache: pip
-          cache-dependency-path: pylauncher/requirements-dev.txt
+          # BOTH files. requirements-dev.txt opens with `-r requirements.txt`,
+          # so a key hashed over the dev file alone would keep serving a cache
+          # built before a runtime pin changed - the one failure mode that makes
+          # a caching bug look like a code bug.
+          cache-dependency-path: |
+            pylauncher/requirements-dev.txt
+            pylauncher/requirements.txt
 
       - run: sudo apt-get update -qq && sudo apt-get install -y -qq libegl1 libgl1 libxkbcommon0 libdbus-1-3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,29 +10,44 @@ name: ci
 # daemon, so the live-Docker suite has been executing on every push and every
 # pull request since it was written. The runner's own log localises it: the
 # first progress line (tests 1-72, which is where `tests/integration` sorts)
-# printed 41 minutes in, and the remaining 903 tests printed in the 22 seconds
-# after it.
+# printed 41 minutes in, and the remaining 910 of the 982 printed in the 22
+# seconds after it.
 #
 # So the fast checks no longer wait behind Docker. `lint-type-test` deselects
 # the marker and answers in about two minutes; `integration` runs the same 16
 # tests it always did, in parallel, on its own runner.
 
 on:
-  # Not a bare `push:`. Every branch here becomes a pull request, and a bare
-  # `push` plus `pull_request` starts TWO full runs for each commit on one -
-  # visible in the run list as a `push` run and a `pull_request` run seconds
-  # apart on the same SHA. Naming the integration branches keeps the push
-  # trigger for the trunk and leaves topic branches to their PR run.
+  # Not a bare `push:`. Every topic branch here becomes a pull request, and a
+  # bare `push` plus `pull_request` starts TWO full runs for each commit on one
+  # - visible in the run list as a `push` run and a `pull_request` run seconds
+  # apart on the same SHA. Naming refs keeps the push trigger where nothing
+  # else covers it and leaves topic branches to their PR run.
   #
-  # The trade: a topic branch with no PR open gets no CI. Open the PR (draft is
-  # enough) and it does.
+  # `release/**` and `v*` are NOT decoration, and dropping them was a real
+  # regression this list exists to prevent (review, 2026-08-28). Six
+  # `release/v0.6.5x` branches and eight `v0.6.5x` tags exist, none of them has
+  # ever been opened as a pull request, and `v0.6.59` is an ancestor of neither
+  # `main` nor `Yulon` - so a `branches: [main, Yulon]` filter alone leaves the
+  # exact commits `release.yml` builds and ships with no lint, type or test run
+  # from any trigger in this repository.
+  #
+  # The trade that remains: a topic branch with no PR open gets no CI. Open the
+  # PR (draft is enough) and it does.
   push:
-    branches: [main, Yulon]
+    branches: [main, Yulon, "release/**"]
+    tags: ["v*"]
   pull_request:
 
 # Five pushes to `Yulon` inside three minutes each started their own 42-minute
 # run (2026-08-28 00:20-00:23). Only the newest tree's verdict is worth having,
 # and the older runs were still holding runners while it queued.
+#
+# One case this does not dedupe, because the two events land in different
+# groups: a pull request whose HEAD branch is `Yulon` itself (`Yulon` -> `main`)
+# would get both a `push` run and a `pull_request` run per commit. `Yulon` is
+# the branch other work is merged INTO rather than one that is PR'd out of, so
+# the case is unreached today; it is written down so it is not re-discovered.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,15 @@ name: ci
 # seconds after it.
 #
 # So the fast checks no longer wait behind Docker. `lint-type-test` deselects
-# the marker and answers in about two minutes; `integration` runs the same 16
+# the marker and answers in about 80 seconds; `integration` runs the same 16
 # tests it always did, in parallel, on its own runner.
+#
+# The 41 minutes turned out not to be inherent to those tests either - it was
+# four of them waiting out a stop grace, fixed in tests/integration/conftest.py.
+# Measured end to end on the fork: run 33203168304 (before) had the live-Docker
+# job at 2508s; run 33210874877 (after) has it at 112s, same 11 passed and 5
+# skipped. The split still earns its keep - it is what stops a future slow
+# integration test from ever again being charged to every push.
 
 on:
   # Not a bare `push:`. Every topic branch here becomes a pull request, and a
@@ -122,9 +129,12 @@ jobs:
   # The live-Docker suite, on its own runner so it blocks nothing else.
   integration:
     runs-on: ubuntu-latest
-    # It has taken ~41 minutes; anything past an hour is a hang, not a slow
-    # test, and a hang should not hold a runner for GitHub's six-hour default.
-    timeout-minutes: 60
+    # Measured at 112s once the fixture stopped waiting out the stop grace
+    # (run 33210874877). 15 is over 8x that, so it cannot trip on a slow
+    # runner, and it means the failure mode this job actually has - a container
+    # that never answers, waiting out a 300s grace per dependency wave - costs
+    # a quarter of an hour rather than GitHub's six-hour default.
+    timeout-minutes: 15
     name: integration (live Docker)
     steps:
       - uses: actions/checkout@v4

--- a/pylauncher/tests/integration/conftest.py
+++ b/pylauncher/tests/integration/conftest.py
@@ -90,11 +90,36 @@ THROWAWAY_SPEC = docker.ContainerSpec(
 )
 THROWAWAY_REALM_PORT = THROWAWAY_PORTS[1]
 
+# `init: true` ON EVERY SERVICE, AND IT IS WORTH 40 MINUTES OF CI.
+#
+# Measured on GitHub Actions run 33203168304 (2026-08-28), `--durations=0`: four
+# tests took 605.22s, 604.37s, 602.75s and 602.40s. They are exactly the four
+# that stop a running project through the product's own path, and 2400 of the
+# suite's 2475 seconds were those four.
+#
+# 600 is 2 x `docker.STOP_GRACE_SECONDS`, which is 300 and correct: a populated
+# worldserver spends 52-86s draining its character save queue, and Docker's own
+# 10s default was measured SIGKILLing one mid-save. The grace is PER CONTAINER,
+# and compose stops in dependency waves - `auth` and `world` together, then the
+# `db` they depend on - so a project whose containers never answer SIGTERM pays
+# it twice.
+#
+# And these never answered. `sh -c "... sleep 600"` runs as PID 1, where the
+# kernel drops any signal the process has installed no handler for; SIGTERM is
+# discarded, and every stop waited out the full grace before SIGKILL. So the
+# suite was not testing the stop path - it was measuring a timeout, four times.
+#
+# `init: true` puts docker-init at PID 1 instead. It forwards SIGTERM to the
+# shell, which - no longer PID 1 - takes the default action and exits. That is
+# also what a real worldserver does, so the fixture models production MORE
+# closely than it did, not less. The grace stays 300; nothing about the product
+# changes.
 _COMPOSE_YML = f"""\
 services:
   db:
     image: busybox:1.36
     container_name: {THROWAWAY_SPEC.db}
+    init: true
     command: ["sh", "-c", "sleep 2 && touch /tmp/ready && sleep 600"]
     healthcheck:
       test: ["CMD", "test", "-f", "/tmp/ready"]
@@ -106,6 +131,7 @@ services:
   auth:
     image: busybox:1.36
     container_name: {THROWAWAY_SPEC.auth}
+    init: true
     depends_on:
       db:
         condition: service_healthy
@@ -118,6 +144,7 @@ services:
   world:
     image: busybox:1.36
     container_name: {THROWAWAY_SPEC.world}
+    init: true
     depends_on:
       db:
         condition: service_healthy

--- a/pylauncher/tests/integration/conftest.py
+++ b/pylauncher/tests/integration/conftest.py
@@ -4,8 +4,17 @@ Two layers of opt-in, both deliberate:
 
 - **Docker reachable** — every test here is skipped (not failed) when
   `docker info` cannot reach a daemon or the `docker` binary is missing. This
-  is what keeps the default `pytest` run green in CI without Docker
-  (roadmap 1.5 definition of done).
+  is what keeps a bare `pytest` green on a developer machine with no daemon
+  running (roadmap 1.5 definition of done).
+
+  It is NOT what keeps this suite out of CI's fast job, and for a long time
+  nothing did. `ubuntu-latest` ships a *running* Docker daemon, so this gate
+  waves the whole file through: measured on run 33134621630 (2026-08-28), a
+  plain `pytest -q` on the runner took 41m36s, of which 22 seconds was the
+  other 959 tests. `.github/workflows/ci.yml` now selects on the `integration`
+  marker instead — `-m "not integration"` for the fast job, `-m integration`
+  for a job of its own — so a reachable daemon can never again quietly add
+  forty minutes to every push.
 - **A throwaway compose project** (`throwaway_project`) — three tiny `busybox`
   containers shaped like an install (db with a HEALTHCHECK, auth + world that
   print the same ready markers `yulon.docker.wait_ready()` looks for, all

--- a/pylauncher/tests/integration/conftest.py
+++ b/pylauncher/tests/integration/conftest.py
@@ -10,8 +10,10 @@ Two layers of opt-in, both deliberate:
   It is NOT what keeps this suite out of CI's fast job, and for a long time
   nothing did. `ubuntu-latest` ships a *running* Docker daemon, so this gate
   waves the whole file through: measured on run 33134621630 (2026-08-28), a
-  plain `pytest -q` on the runner took 41m36s, of which 22 seconds was the
-  other 959 tests. `.github/workflows/ci.yml` now selects on the `integration`
+  plain `pytest -q` on the runner took 41m36s, and the runner's log puts 22 of
+  those seconds in the last 910 of the 982 tests - i.e. essentially all of it
+  is spent before this directory is done. `.github/workflows/ci.yml` now
+  selects on the `integration`
   marker instead — `-m "not integration"` for the fast job, `-m integration`
   for a job of its own — so a reachable daemon can never again quietly add
   forty minutes to every push.


### PR DESCRIPTION
Every push to this repository waited about 42 minutes for CI. Measured end to end on a fork, it now takes under two, with identical test outcomes.

## What was actually happening

Run `33134621630` reported `975 passed, 7 skipped in 2496.46s`. Every other step in that job — checkout, apt, pip, ruff, black, three mypy passes — totalled **60 seconds**. The same suite finishes in 39s on a developer machine.

The difference was `pylauncher/tests/integration/`. Its conftest said the daemon gate is "what keeps the default `pytest` run green in CI without Docker", and that assumption was wrong: `ubuntu-latest` ships a **running** Docker daemon, so the live-Docker suite had been executing on every push and every pull request since it was written. The runner's own log localised it — the first progress line covers tests 1–72, exactly where `tests/integration` sorts, and it printed 41 minutes in; the remaining 910 of 982 printed in the 22 seconds after.

## And the 41 minutes was not inherent to those tests either

`--durations=0` had never been run on this suite. It named four tests:

```
605.22s  test_docker_lifecycle_end_to_end
604.37s  test_launcher_restart_never_reruns_the_one_shot_import
602.75s  test_stop_staged_reports_whether_there_was_anything_to_stop
602.40s  test_a_stop_never_writes_an_identity_the_folder_could_carry_away
 13.89s  <- next slowest
```

2400 of the suite's 2475 seconds, and exactly the four that stop a running project through the product's own path. 600 is `2 x STOP_GRACE_SECONDS`: the grace is per container, and compose stops in dependency waves — `auth` and `world` together, then the `db` they depend on.

What made it cost anything is the fixture. `sh -c "... sleep 600"` runs as **PID 1**, where the kernel discards any signal the process has installed no handler for. SIGTERM was thrown away and every container sat until SIGKILL, so the suite spent forty minutes measuring a timeout instead of testing a stop.

`init: true` puts docker-init at PID 1; it forwards SIGTERM to the shell, which is no longer PID 1 and exits normally. A real worldserver handles SIGTERM and drains, so the fixture now models production *more* closely than it did. **`STOP_GRACE_SECONDS` is untouched at 300** — it was measured against a populated worldserver draining 7662 queued character saves, and it still protects one.

## Measured, on a fork, before and after

| job | before (`33203168304`) | after (`33210874877`) |
| --- | --- | --- |
| `lint-type-test (py3.11)` | 42 min (single job) | **76 s** |
| `lint-type-test (py3.13)` | 42 min (single job) | **103 s** |
| `integration (live Docker)` | 2508 s | **112 s** |

The integration pytest step went 2474.60s → 58.90s with the same `11 passed, 5 skipped, 966 deselected`. The four tests above are now 9.60s, 6.13s, 4.52s and 3.74s. Nothing was skipped away to buy the speed.

## What else is in here

- **The job split.** `lint-type-test` runs `-m "not integration"`; a new `integration` job runs `-m integration` in parallel and asserts `docker info` first, so a runner image that drops Docker fails loudly instead of turning the job into a green no-op — the same silence that hid this for weeks. The fixture fix alone would have solved the symptom; the split is what stops a future slow integration test from ever again being charged to every push.
- **`push` is scoped**, because a bare `push:` plus `pull_request:` started two full runs for every commit on a topic branch. `release/**` and `v*` are named explicitly and deliberately: six `release/v0.6.5x` branches exist, none has ever been opened as a PR, and `v0.6.59` is an ancestor of neither `main` nor `Yulon` — a `[main, Yulon]` filter alone would leave the exact commits `release.yml` ships with no lint, type or test run from any trigger. The remaining trade is that a topic branch with no PR open gets no CI; a draft PR is enough.
- **`concurrency` with cancel-in-progress**, after five pushes to `Yulon` inside three minutes each started their own 42-minute run and held runners while the newest queued.
- **pip caching**, keyed over both `requirements-dev.txt` and the `requirements.txt` it includes.
- **`timeout-minutes`** on both jobs (15), so a hang costs a quarter of an hour rather than GitHub's six-hour default.

## Verification

Full local gate on the branch: `ruff` clean, `black --check` 76 files unchanged, `mypy` clean on native, `--platform win32` and `--platform darwin`, and `pytest -m "not integration"` → `955 passed, 11 skipped, 16 deselected`. Both CI jobs green on the fork runs cited above.
