### PR TITLE
The Ubuntu pass: nineteen defects from the four-platform hunt

### DIFF
--- a/pylauncher/build/pylauncher.spec
+++ b/pylauncher/build/pylauncher.spec
@@ -45,7 +45,18 @@ a = Analysis(
     hiddenimports=hiddenimports,
     hookspath=[],
     runtime_hooks=[],
-    excludes=["tkinter", "PySide6.QtWebEngineCore", "PySide6.Qt3DCore", "PySide6.QtQuick3D"],
+    # `yulon.__main__` is the `python -m yulon` redirect for a CHECKOUT; it does
+    # `from main import main`, so collect_submodules("yulon") would carry it into
+    # the bundle and pull main.py in a second time as a library module named
+    # `main` beside the real entry point (review, 2026-08-28). The frozen exe IS
+    # main.py and never runs `-m yulon`.
+    excludes=[
+        "tkinter",
+        "PySide6.QtWebEngineCore",
+        "PySide6.Qt3DCore",
+        "PySide6.QtQuick3D",
+        "yulon.__main__",
+    ],
     noarchive=False,
     cipher=block_cipher,
 )

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -199,6 +199,32 @@ dir_is_reusable() {
     return 0
 }
 
+# Are this install's images actually built? Ask the IMAGE STORE, not the
+# container list.
+#
+# `docker compose images` reports the images of a project's EXISTING
+# CONTAINERS. A folder whose build finished but whose `up` never ran - or whose
+# containers were removed - has no containers, so that command answers nothing
+# and a COMPLETE build reads as "nothing was built". Measured on yulon-arch
+# 2026-08-28: `up` failed on a container-name collision, so zero containers
+# existed, and the branch below then offered to delete a good ~35-minute build.
+# In a directory with no containers `docker compose images` failed outright
+# (missing env file) while `config --images` still answered.
+#
+# `config --images` reads the compose FILE, so the image name is derived from
+# this install rather than hardcoded here, and `docker image inspect` then asks
+# the store whether that image exists. Both halves matter: deriving the name
+# keeps this correct if the tag or repository changes, and inspecting the store
+# is the only question whose answer does not depend on containers.
+compiled_images_present() {
+    [ -d "$1" ] || return 1
+    local image
+    image=$(cd "$1" && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
+    [ -n "$image" ] || return 1
+    docker image inspect "$image" >/dev/null 2>&1
+}
+
+
 # Let containers write to the bind-mounted server folder on SELinux systems.
 #
 # AzerothCore's compose mounts env/dist WITHOUT the `:z` suffix that would make
@@ -1308,8 +1334,7 @@ install_server() {
     # If they already exist in $SERVER_DIR, skip the 2-4 hour compile
     # and just start the server — the rest of the install continues
     # normally (account creation, launcher setup, etc.).
-    if [ -d "$SERVER_DIR" ] && \
-       (cd "$SERVER_DIR" && docker compose images 2>/dev/null | grep -qi "worldserver"); then
+    if compiled_images_present "$SERVER_DIR"; then
         print_success "Compiled images already found in $SERVER_DIR"
         print_info "Skipping compile — reusing your existing build."
         print_info "To force a fresh compile, remove the server folder:"

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -1365,8 +1365,20 @@ install_server() {
             sudo rm -rf "$SERVER_DIR"
             print_success "Old install removed"
         else
-            print_info "Keeping existing install — exiting."
-            exit 0
+            # NOT `exit 0`. Nothing was installed, and a zero exit is read
+            # as SUCCESS by the caller: `catalog_view.py` pins a compose
+            # project name into this folder and grows a tab for a server
+            # that was never built - and `docker.py` records that such a pin
+            # is inherited by any COPY of the folder, so Stop in the copy can
+            # stop the original's server. Reproduced on yulon-arch
+            # 2026-08-28: a killed build was retried into the same folder and
+            # the run reported success having done nothing.
+            #
+            # Declining is a legitimate choice; calling it an install is not.
+            print_error "Nothing was installed."
+            print_info "$SERVER_DIR already holds files, and no completed build was found in it."
+            print_info "Choose an empty folder, or remove this one, and run the install again."
+            exit 1
         fi
     fi
 

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -217,12 +217,39 @@ dir_is_reusable() {
 # keeps this correct if the tag or repository changes, and inspecting the store
 # is the only question whose answer does not depend on containers.
 compiled_images_present() {
+    # 0 = built.  1 = definitely not built.  2 = could not find out.
+    #
+    # The third answer is the point. The caller's next step offers to DELETE
+    # this folder, so "I could not ask" must never be spelled the same way as
+    # "there is nothing here". A daemon that is not up yet after boot, one
+    # restarted for maintenance, or a compose file that cannot be read would
+    # otherwise all arrive at that prompt under the message "no completed build
+    # was found in it" - which in those cases is not true, and the folder it
+    # offers to remove may hold hours of compiling. Found by an adversarial
+    # review, 2026-08-28, on a real daemon.
     [ -d "$1" ] || return 1
+    docker image ls >/dev/null 2>&1 || return 2
+
     local image
     image=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
-    [ -n "$image" ] || return 1
-    docker image inspect "$image" >/dev/null 2>&1
+    if [ -z "$image" ]; then
+        # No image name to test. A folder with no compose file at all has
+        # genuinely never been built; a folder that HAS one which compose would
+        # not read is a question we failed to ask.
+        #
+        # One name at a time, NOT `ls a b c d`: that exits non-zero when ANY of
+        # the four is missing, so a folder holding docker-compose.yml and
+        # nothing else read as holding no compose file at all. Caught by the
+        # test for this branch on its first run.
+        for candidate in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
+            [ -f "$1/$candidate" ] && return 2
+        done
+        return 1
+    fi
+    docker image inspect "$image" >/dev/null 2>&1 && return 0
+    return 1
 }
+
 
 
 # Let containers write to the bind-mounted server folder on SELinux systems.
@@ -1334,7 +1361,15 @@ install_server() {
     # If they already exist in $SERVER_DIR, skip the 2-4 hour compile
     # and just start the server — the rest of the install continues
     # normally (account creation, launcher setup, etc.).
-    if compiled_images_present "$SERVER_DIR"; then
+    images_state=0
+    compiled_images_present "$SERVER_DIR" || images_state=$?
+    if [ "$images_state" -eq 2 ]; then
+        print_error "Could not check whether $SERVER_DIR already holds a built server."
+        print_info "Docker did not answer, or the compose file in that folder could not be read."
+        print_info "Nothing has been changed. Start Docker, or fix that folder, and run this again."
+        exit 1
+    fi
+    if [ "$images_state" -eq 0 ]; then
         print_success "Compiled images already found in $SERVER_DIR"
         print_info "Skipping compile — reusing your existing build."
         print_info "To force a fresh compile, remove the server folder:"

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -250,6 +250,47 @@ compiled_images_present() {
     return 1
 }
 
+# Refuse to build into a folder whose container names another install holds.
+#
+# The compose file pins `container_name:` for every service, and Docker keeps
+# those names global to the host - so a second install of the same game, even
+# into a brand-new empty folder, fails at `docker compose up` with
+#   Conflict. The container name "/ac-database" is already in use
+# from the daemon, after the 2-4 hour build. Hit on yulon-ubuntu AND yulon-arch
+# on the same day (2026-08-28), both times from a stopped, not removed, stack
+# left by an earlier install elsewhere on the box. Naming the other install is
+# the whole value here; the daemon's message names a container.
+#
+# "Another install" is decided by the container's own compose label, NOT by a
+# guess at the project name: `com.docker.compose.project.working_dir` is
+# written by compose on every container it creates, and comparing it with
+# THIS folder is the only test that is right for both an install that pinned
+# COMPOSE_PROJECT_NAME and one that did not. A name with no such label was not
+# created by compose at all, and is reported the same way.
+refuse_foreign_containers() {
+    local dir="$1" names name owner
+    names=$(cd "$dir" 2>/dev/null && docker compose config 2>/dev/null         | sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p')
+    [ -n "$names" ] || return 0
+    local here
+    here=$(cd "$dir" 2>/dev/null && pwd -P)
+    for name in $names; do
+        docker container inspect "$name" >/dev/null 2>&1 || continue
+        owner=$(docker container inspect "$name"             --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' 2>/dev/null)
+        if [ "$owner" != "$here" ]; then
+            print_error "A container named '$name' already exists, and it is not this install's."
+            if [ -n "$owner" ]; then
+                print_info "It belongs to the server in: $owner"
+                print_info "Stop and remove that server first (its data volumes are kept), or install this one"
+                print_info "on a machine that is not already running it. Nothing has been changed."
+            else
+                print_info "It was not created by this installer. Remove it, then run the install again."
+            fi
+            exit 1
+        fi
+    done
+}
+
+
 
 
 # Let containers write to the bind-mounted server folder on SELinux systems.
@@ -1509,6 +1550,7 @@ OVERRIDE
 
     selinux_label_for_containers "$SERVER_DIR"
 
+    refuse_foreign_containers "$SERVER_DIR"
     cd "$SERVER_DIR"
     docker compose up -d --build 2>&1 | tee ~/playerbots-build.log
 

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -216,6 +216,21 @@ dir_is_reusable() {
 # the store whether that image exists. Both halves matter: deriving the name
 # keeps this correct if the tag or repository changes, and inspecting the store
 # is the only question whose answer does not depend on containers.
+#
+# SCOPE, deliberately narrower than the name suggests: AzerothCore's compose
+# pins `image:` with no project prefix, so this answers "the image this install
+# needs is on this machine", NOT "this folder built it". On a box with two
+# installs of the same game, a folder holding only a clone answers yes. That is
+# why the caller below says "on this machine" rather than naming the folder,
+# and why a name collision is caught at `up` rather than assumed away here.
+#
+# Do NOT "fix" the scope by matching the image's `com.docker.compose.project`
+# label against this folder's project. `catalog_view._pin_compose_project()`
+# writes COMPOSE_PROJECT_NAME into `.env` AFTER a successful install, so the
+# label (the directory-derived name at build time) and the current project name
+# legitimately differ - and the match would report a real build as missing,
+# which is the delete prompt. Confirmed 2026-08-28 that compose does label built
+# images with the project, so the trap is reachable, not hypothetical.
 compiled_images_present() {
     # 0 = built.  1 = definitely not built.  2 = could not find out.
     #
@@ -228,6 +243,11 @@ compiled_images_present() {
     # offers to remove may hold hours of compiling. Found by an adversarial
     # review, 2026-08-28, on a real daemon.
     [ -d "$1" ] || return 1
+    # A folder that exists but cannot be entered - root-owned 700 from an
+    # earlier sudo run - is a question we failed to ask, not an empty answer.
+    # Without this, `cd` failed quietly below and the verdict was "not built",
+    # which is the delete prompt (review, 2026-08-28).
+    (cd "$1" >/dev/null 2>&1) || return 2
     docker image ls >/dev/null 2>&1 || return 2
 
     local image
@@ -241,6 +261,11 @@ compiled_images_present() {
         # the four is missing, so a folder holding docker-compose.yml and
         # nothing else read as holding no compose file at all. Caught by the
         # test for this branch on its first run.
+        # A compose file that names no worldserver image at all is somebody
+        # else's project, not an unbuilt server and not an unanswered question.
+        if [ -n "$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null)" ]; then
+            return 3
+        fi
         for candidate in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
             [ -f "$1/$candidate" ] && return 2
         done
@@ -268,8 +293,17 @@ compiled_images_present() {
 # COMPOSE_PROJECT_NAME and one that did not. A name with no such label was not
 # created by compose at all, and is reported the same way.
 refuse_foreign_containers() {
-    local dir="$1" names name owner
-    names=$(cd "$dir" 2>/dev/null && docker compose config 2>/dev/null         | sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p')
+    local dir="$1" config names name owner
+    # `config`'s own exit status, separately from the names it yields: an
+    # unreadable compose file used to look exactly like "pins no names", and the
+    # guard passed silently - the same "could not ask" spelled as "nothing here"
+    # that compiled_images_present was taught to report (review, 2026-08-28).
+    if ! config=$(cd "$dir" 2>/dev/null && docker compose config 2>/dev/null); then
+        print_error "Could not read the compose file in $dir, so its container names"
+        print_error "could not be checked against the containers already on this machine."
+        exit 1
+    fi
+    names=$(printf '%s\n' "$config" | sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p')
     [ -n "$names" ] || return 0
     local here
     here=$(cd "$dir" 2>/dev/null && pwd -P)
@@ -281,7 +315,12 @@ refuse_foreign_containers() {
             if [ -n "$owner" ]; then
                 print_info "It belongs to the server in: $owner"
                 print_info "Stop and remove that server first (its data volumes are kept), or install this one"
-                print_info "on a machine that is not already running it. Nothing has been changed."
+                print_info "on a machine that is not already running it."
+                # NOT "nothing has been changed": this guard needs a compose file
+                # to read container names from, so it can only run AFTER the clone -
+                # the source tree and the generated override are already in $dir by
+                # now (review, 2026-08-28).
+                print_info "The source in $dir was left as it is; nothing was built or started."
             else
                 print_info "It was not created by this installer. Remove it, then run the install again."
             fi
@@ -1411,8 +1450,8 @@ install_server() {
         exit 1
     fi
     if [ "$images_state" -eq 0 ]; then
-        print_success "Compiled images already found in $SERVER_DIR"
-        print_info "Skipping compile — reusing your existing build."
+        print_success "The images this server needs are already on this machine"
+        print_info "Skipping the compile and starting them."
         print_info "To force a fresh compile, remove the server folder:"
         print_info "  sudo rm -rf $SERVER_DIR"
         # Also here, not only on the fresh-build path. This branch is how a user
@@ -1425,6 +1464,22 @@ install_server() {
         selinux_label_for_containers "$SERVER_DIR"
         cd "$SERVER_DIR" || exit 1
         docker compose up -d 2>&1 | tail -5
+        # The build path has checked this since it was written; this one never
+        # did. On fedora (`set -o pipefail`, no `-e`) a failed `up` fell through
+        # to `return 0`, and `wait_for_server` greps `docker ps` HOST-GLOBALLY -
+        # so the container that made `up` fail on a name conflict is a running
+        # `ac-worldserver` belonging to the OTHER install, and the loop finds it
+        # "ready...", prints "Server is READY!" and exits 0 (review, 2026-08-28).
+        if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+            print_error "The build is already here, but starting it failed."
+            # A diagnosis AFTER the failure, never a gate before it: this branch
+            # is how a MOVED install folder recovers, and compose bakes
+            # `working_dir` into a container at creation - so an unconditional
+            # ownership check here would refuse the move, naming a folder that no
+            # longer exists, with nothing to do about it.
+            refuse_foreign_containers "$SERVER_DIR"
+            exit 1
+        fi
         return 0
     fi
 

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -219,7 +219,7 @@ dir_is_reusable() {
 compiled_images_present() {
     [ -d "$1" ] || return 1
     local image
-    image=$(cd "$1" && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
+    image=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
     [ -n "$image" ] || return 1
     docker image inspect "$image" >/dev/null 2>&1
 }

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-fedora.sh
@@ -250,8 +250,9 @@ compiled_images_present() {
     (cd "$1" >/dev/null 2>&1) || return 2
     docker image ls >/dev/null 2>&1 || return 2
 
-    local image
-    image=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
+    local image images prefix candidate
+    images=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null)
+    image=$(echo "$images" | grep -i "worldserver" | head -1)
     if [ -z "$image" ]; then
         # No image name to test. A folder with no compose file at all has
         # genuinely never been built; a folder that HAS one which compose would
@@ -263,7 +264,7 @@ compiled_images_present() {
         # test for this branch on its first run.
         # A compose file that names no worldserver image at all is somebody
         # else's project, not an unbuilt server and not an unanswered question.
-        if [ -n "$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null)" ]; then
+        if [ -n "$images" ]; then
             return 3
         fi
         for candidate in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
@@ -271,8 +272,33 @@ compiled_images_present() {
         done
         return 1
     fi
-    docker image inspect "$image" >/dev/null 2>&1 && return 0
-    return 1
+    # EVERY image this build produces, not just the worldserver one. A prune that
+    # took `ac-db-import` but left `ac-worldserver` used to answer "built", and
+    # the caller's reuse path then runs `up` with no `--build` - so the stack
+    # comes up against a missing or foreign image having deliberately skipped a
+    # 2-4 hour compile. Found by an independent adversarial review (Codex),
+    # 2026-08-28.
+    #
+    # Siblings are recognised by the prefix the worldserver image itself carries
+    # (`acore/ac-wotlk-`), which keeps third-party images in the same compose
+    # file out of it: `mysql:8.0` is PULLED, not built, so requiring it to be on
+    # the machine would report a good build as missing every time it was pruned -
+    # and that is the delete prompt.
+    prefix=${image%worldserver*}
+    if [ "$prefix" = "$image" ]; then
+        # No `worldserver` component to strip, so no prefix can be derived and
+        # the single-image question is the only one available.
+        docker image inspect "$image" >/dev/null 2>&1 && return 0
+        return 1
+    fi
+    for candidate in $images; do
+        case "$candidate" in
+            "$prefix"*)
+                docker image inspect "$candidate" >/dev/null 2>&1 || return 1
+                ;;
+        esac
+    done
+    return 0
 }
 
 # Refuse to build into a folder whose container names another install holds.
@@ -1447,6 +1473,15 @@ install_server() {
         print_error "Could not check whether $SERVER_DIR already holds a built server."
         print_info "Docker did not answer, or the compose file in that folder could not be read."
         print_info "Nothing has been changed. Start Docker, or fix that folder, and run this again."
+        exit 1
+    fi
+    if [ "$images_state" -eq 3 ]; then
+        # Without a branch of its own this fell through to "Remove it and start
+        # fresh?", which offers `rm -rf` on a folder we have just identified as
+        # somebody else's project. Never offer that (review, 2026-08-29).
+        print_error "$SERVER_DIR holds a docker compose project that is not this server."
+        print_info "Its compose file names no worldserver image, so nothing in it was built here."
+        print_info "Nothing has been changed. Choose a different folder and run this again."
         exit 1
     fi
     if [ "$images_state" -eq 0 ]; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -170,7 +170,7 @@ dir_is_reusable() {
 compiled_images_present() {
     [ -d "$1" ] || return 1
     local image
-    image=$(cd "$1" && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
+    image=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
     [ -n "$image" ] || return 1
     docker image inspect "$image" >/dev/null 2>&1
 }

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -150,6 +150,32 @@ dir_is_reusable() {
     return 0
 }
 
+# Are this install's images actually built? Ask the IMAGE STORE, not the
+# container list.
+#
+# `docker compose images` reports the images of a project's EXISTING
+# CONTAINERS. A folder whose build finished but whose `up` never ran - or whose
+# containers were removed - has no containers, so that command answers nothing
+# and a COMPLETE build reads as "nothing was built". Measured on yulon-arch
+# 2026-08-28: `up` failed on a container-name collision, so zero containers
+# existed, and the branch below then offered to delete a good ~35-minute build.
+# In a directory with no containers `docker compose images` failed outright
+# (missing env file) while `config --images` still answered.
+#
+# `config --images` reads the compose FILE, so the image name is derived from
+# this install rather than hardcoded here, and `docker image inspect` then asks
+# the store whether that image exists. Both halves matter: deriving the name
+# keeps this correct if the tag or repository changes, and inspecting the store
+# is the only question whose answer does not depend on containers.
+compiled_images_present() {
+    [ -d "$1" ] || return 1
+    local image
+    image=$(cd "$1" && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
+    [ -n "$image" ] || return 1
+    docker image inspect "$image" >/dev/null 2>&1
+}
+
+
 # Let containers write to the bind-mounted server folder on SELinux systems.
 #
 # AzerothCore's compose mounts env/dist WITHOUT the `:z` suffix that would make
@@ -1123,8 +1149,7 @@ install_server() {
     # If they already exist in $SERVER_DIR, skip the 2-4 hour compile
     # and just start the server — the rest of the install continues
     # normally (account creation, launcher setup, etc.).
-    if [ -d "$SERVER_DIR" ] && \
-       (cd "$SERVER_DIR" && docker compose images 2>/dev/null | grep -qi "worldserver"); then
+    if compiled_images_present "$SERVER_DIR"; then
         print_success "Compiled images already found in $SERVER_DIR"
         print_info "Skipping compile — reusing your existing build."
         print_info "To force a fresh compile, remove the server folder:"

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -167,6 +167,21 @@ dir_is_reusable() {
 # the store whether that image exists. Both halves matter: deriving the name
 # keeps this correct if the tag or repository changes, and inspecting the store
 # is the only question whose answer does not depend on containers.
+#
+# SCOPE, deliberately narrower than the name suggests: AzerothCore's compose
+# pins `image:` with no project prefix, so this answers "the image this install
+# needs is on this machine", NOT "this folder built it". On a box with two
+# installs of the same game, a folder holding only a clone answers yes. That is
+# why the caller below says "on this machine" rather than naming the folder,
+# and why a name collision is caught at `up` rather than assumed away here.
+#
+# Do NOT "fix" the scope by matching the image's `com.docker.compose.project`
+# label against this folder's project. `catalog_view._pin_compose_project()`
+# writes COMPOSE_PROJECT_NAME into `.env` AFTER a successful install, so the
+# label (the directory-derived name at build time) and the current project name
+# legitimately differ - and the match would report a real build as missing,
+# which is the delete prompt. Confirmed 2026-08-28 that compose does label built
+# images with the project, so the trap is reachable, not hypothetical.
 compiled_images_present() {
     # 0 = built.  1 = definitely not built.  2 = could not find out.
     #
@@ -179,6 +194,11 @@ compiled_images_present() {
     # offers to remove may hold hours of compiling. Found by an adversarial
     # review, 2026-08-28, on a real daemon.
     [ -d "$1" ] || return 1
+    # A folder that exists but cannot be entered - root-owned 700 from an
+    # earlier sudo run - is a question we failed to ask, not an empty answer.
+    # Without this, `cd` failed quietly below and the verdict was "not built",
+    # which is the delete prompt (review, 2026-08-28).
+    (cd "$1" >/dev/null 2>&1) || return 2
     docker image ls >/dev/null 2>&1 || return 2
 
     local image
@@ -192,6 +212,11 @@ compiled_images_present() {
         # the four is missing, so a folder holding docker-compose.yml and
         # nothing else read as holding no compose file at all. Caught by the
         # test for this branch on its first run.
+        # A compose file that names no worldserver image at all is somebody
+        # else's project, not an unbuilt server and not an unanswered question.
+        if [ -n "$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null)" ]; then
+            return 3
+        fi
         for candidate in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
             [ -f "$1/$candidate" ] && return 2
         done
@@ -219,8 +244,17 @@ compiled_images_present() {
 # COMPOSE_PROJECT_NAME and one that did not. A name with no such label was not
 # created by compose at all, and is reported the same way.
 refuse_foreign_containers() {
-    local dir="$1" names name owner
-    names=$(cd "$dir" 2>/dev/null && docker compose config 2>/dev/null         | sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p')
+    local dir="$1" config names name owner
+    # `config`'s own exit status, separately from the names it yields: an
+    # unreadable compose file used to look exactly like "pins no names", and the
+    # guard passed silently - the same "could not ask" spelled as "nothing here"
+    # that compiled_images_present was taught to report (review, 2026-08-28).
+    if ! config=$(cd "$dir" 2>/dev/null && docker compose config 2>/dev/null); then
+        print_error "Could not read the compose file in $dir, so its container names"
+        print_error "could not be checked against the containers already on this machine."
+        exit 1
+    fi
+    names=$(printf '%s\n' "$config" | sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p')
     [ -n "$names" ] || return 0
     local here
     here=$(cd "$dir" 2>/dev/null && pwd -P)
@@ -232,7 +266,12 @@ refuse_foreign_containers() {
             if [ -n "$owner" ]; then
                 print_info "It belongs to the server in: $owner"
                 print_info "Stop and remove that server first (its data volumes are kept), or install this one"
-                print_info "on a machine that is not already running it. Nothing has been changed."
+                print_info "on a machine that is not already running it."
+                # NOT "nothing has been changed": this guard needs a compose file
+                # to read container names from, so it can only run AFTER the clone -
+                # the source tree and the generated override are already in $dir by
+                # now (review, 2026-08-28).
+                print_info "The source in $dir was left as it is; nothing was built or started."
             else
                 print_info "It was not created by this installer. Remove it, then run the install again."
             fi
@@ -1226,8 +1265,8 @@ install_server() {
         exit 1
     fi
     if [ "$images_state" -eq 0 ]; then
-        print_success "Compiled images already found in $SERVER_DIR"
-        print_info "Skipping compile — reusing your existing build."
+        print_success "The images this server needs are already on this machine"
+        print_info "Skipping the compile and starting them."
         print_info "To force a fresh compile, remove the server folder:"
         print_info "  sudo rm -rf \"$SERVER_DIR\""
         # Also here, not only on the fresh-build path. This branch is how a user
@@ -1240,6 +1279,22 @@ install_server() {
         selinux_label_for_containers "$SERVER_DIR"
         cd "$SERVER_DIR" || exit 1
         docker compose up -d 2>&1 | tail -5
+        # The build path has checked this since it was written; this one never
+        # did. On fedora (`set -o pipefail`, no `-e`) a failed `up` fell through
+        # to `return 0`, and `wait_for_server` greps `docker ps` HOST-GLOBALLY -
+        # so the container that made `up` fail on a name conflict is a running
+        # `ac-worldserver` belonging to the OTHER install, and the loop finds it
+        # "ready...", prints "Server is READY!" and exits 0 (review, 2026-08-28).
+        if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+            print_error "The build is already here, but starting it failed."
+            # A diagnosis AFTER the failure, never a gate before it: this branch
+            # is how a MOVED install folder recovers, and compose bakes
+            # `working_dir` into a container at creation - so an unconditional
+            # ownership check here would refuse the move, naming a folder that no
+            # longer exists, with nothing to do about it.
+            refuse_foreign_containers "$SERVER_DIR"
+            exit 1
+        fi
         return 0
     fi
 

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -201,6 +201,47 @@ compiled_images_present() {
     return 1
 }
 
+# Refuse to build into a folder whose container names another install holds.
+#
+# The compose file pins `container_name:` for every service, and Docker keeps
+# those names global to the host - so a second install of the same game, even
+# into a brand-new empty folder, fails at `docker compose up` with
+#   Conflict. The container name "/ac-database" is already in use
+# from the daemon, after the 2-4 hour build. Hit on yulon-ubuntu AND yulon-arch
+# on the same day (2026-08-28), both times from a stopped, not removed, stack
+# left by an earlier install elsewhere on the box. Naming the other install is
+# the whole value here; the daemon's message names a container.
+#
+# "Another install" is decided by the container's own compose label, NOT by a
+# guess at the project name: `com.docker.compose.project.working_dir` is
+# written by compose on every container it creates, and comparing it with
+# THIS folder is the only test that is right for both an install that pinned
+# COMPOSE_PROJECT_NAME and one that did not. A name with no such label was not
+# created by compose at all, and is reported the same way.
+refuse_foreign_containers() {
+    local dir="$1" names name owner
+    names=$(cd "$dir" 2>/dev/null && docker compose config 2>/dev/null         | sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p')
+    [ -n "$names" ] || return 0
+    local here
+    here=$(cd "$dir" 2>/dev/null && pwd -P)
+    for name in $names; do
+        docker container inspect "$name" >/dev/null 2>&1 || continue
+        owner=$(docker container inspect "$name"             --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' 2>/dev/null)
+        if [ "$owner" != "$here" ]; then
+            print_error "A container named '$name' already exists, and it is not this install's."
+            if [ -n "$owner" ]; then
+                print_info "It belongs to the server in: $owner"
+                print_info "Stop and remove that server first (its data volumes are kept), or install this one"
+                print_info "on a machine that is not already running it. Nothing has been changed."
+            else
+                print_info "It was not created by this installer. Remove it, then run the install again."
+            fi
+            exit 1
+        fi
+    done
+}
+
+
 
 
 # Let containers write to the bind-mounted server folder on SELinux systems.
@@ -1323,6 +1364,7 @@ OVERRIDE
 
     selinux_label_for_containers "$SERVER_DIR"
 
+    refuse_foreign_containers "$SERVER_DIR"
     cd "$SERVER_DIR"
     docker compose up -d --build 2>&1 | tee ~/playerbots-build.log
 

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -201,8 +201,9 @@ compiled_images_present() {
     (cd "$1" >/dev/null 2>&1) || return 2
     docker image ls >/dev/null 2>&1 || return 2
 
-    local image
-    image=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
+    local image images prefix candidate
+    images=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null)
+    image=$(echo "$images" | grep -i "worldserver" | head -1)
     if [ -z "$image" ]; then
         # No image name to test. A folder with no compose file at all has
         # genuinely never been built; a folder that HAS one which compose would
@@ -214,7 +215,7 @@ compiled_images_present() {
         # test for this branch on its first run.
         # A compose file that names no worldserver image at all is somebody
         # else's project, not an unbuilt server and not an unanswered question.
-        if [ -n "$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null)" ]; then
+        if [ -n "$images" ]; then
             return 3
         fi
         for candidate in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
@@ -222,8 +223,33 @@ compiled_images_present() {
         done
         return 1
     fi
-    docker image inspect "$image" >/dev/null 2>&1 && return 0
-    return 1
+    # EVERY image this build produces, not just the worldserver one. A prune that
+    # took `ac-db-import` but left `ac-worldserver` used to answer "built", and
+    # the caller's reuse path then runs `up` with no `--build` - so the stack
+    # comes up against a missing or foreign image having deliberately skipped a
+    # 2-4 hour compile. Found by an independent adversarial review (Codex),
+    # 2026-08-28.
+    #
+    # Siblings are recognised by the prefix the worldserver image itself carries
+    # (`acore/ac-wotlk-`), which keeps third-party images in the same compose
+    # file out of it: `mysql:8.0` is PULLED, not built, so requiring it to be on
+    # the machine would report a good build as missing every time it was pruned -
+    # and that is the delete prompt.
+    prefix=${image%worldserver*}
+    if [ "$prefix" = "$image" ]; then
+        # No `worldserver` component to strip, so no prefix can be derived and
+        # the single-image question is the only one available.
+        docker image inspect "$image" >/dev/null 2>&1 && return 0
+        return 1
+    fi
+    for candidate in $images; do
+        case "$candidate" in
+            "$prefix"*)
+                docker image inspect "$candidate" >/dev/null 2>&1 || return 1
+                ;;
+        esac
+    done
+    return 0
 }
 
 # Refuse to build into a folder whose container names another install holds.
@@ -1262,6 +1288,15 @@ install_server() {
         print_error "Could not check whether $SERVER_DIR already holds a built server."
         print_info "Docker did not answer, or the compose file in that folder could not be read."
         print_info "Nothing has been changed. Start Docker, or fix that folder, and run this again."
+        exit 1
+    fi
+    if [ "$images_state" -eq 3 ]; then
+        # Without a branch of its own this fell through to "Remove it and start
+        # fresh?", which offers `rm -rf` on a folder we have just identified as
+        # somebody else's project. Never offer that (review, 2026-08-29).
+        print_error "$SERVER_DIR holds a docker compose project that is not this server."
+        print_info "Its compose file names no worldserver image, so nothing in it was built here."
+        print_info "Nothing has been changed. Choose a different folder and run this again."
         exit 1
     fi
     if [ "$images_state" -eq 0 ]; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -1180,8 +1180,20 @@ install_server() {
             sudo rm -rf "$SERVER_DIR"
             print_success "Old install removed"
         else
-            print_info "Keeping existing install — exiting."
-            exit 0
+            # NOT `exit 0`. Nothing was installed, and a zero exit is read
+            # as SUCCESS by the caller: `catalog_view.py` pins a compose
+            # project name into this folder and grows a tab for a server
+            # that was never built - and `docker.py` records that such a pin
+            # is inherited by any COPY of the folder, so Stop in the copy can
+            # stop the original's server. Reproduced on yulon-arch
+            # 2026-08-28: a killed build was retried into the same folder and
+            # the run reported success having done nothing.
+            #
+            # Declining is a legitimate choice; calling it an install is not.
+            print_error "Nothing was installed."
+            print_info "$SERVER_DIR already holds files, and no completed build was found in it."
+            print_info "Choose an empty folder, or remove this one, and run the install again."
+            exit 1
         fi
     fi
 

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk-ubuntu.sh
@@ -168,12 +168,39 @@ dir_is_reusable() {
 # keeps this correct if the tag or repository changes, and inspecting the store
 # is the only question whose answer does not depend on containers.
 compiled_images_present() {
+    # 0 = built.  1 = definitely not built.  2 = could not find out.
+    #
+    # The third answer is the point. The caller's next step offers to DELETE
+    # this folder, so "I could not ask" must never be spelled the same way as
+    # "there is nothing here". A daemon that is not up yet after boot, one
+    # restarted for maintenance, or a compose file that cannot be read would
+    # otherwise all arrive at that prompt under the message "no completed build
+    # was found in it" - which in those cases is not true, and the folder it
+    # offers to remove may hold hours of compiling. Found by an adversarial
+    # review, 2026-08-28, on a real daemon.
     [ -d "$1" ] || return 1
+    docker image ls >/dev/null 2>&1 || return 2
+
     local image
     image=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
-    [ -n "$image" ] || return 1
-    docker image inspect "$image" >/dev/null 2>&1
+    if [ -z "$image" ]; then
+        # No image name to test. A folder with no compose file at all has
+        # genuinely never been built; a folder that HAS one which compose would
+        # not read is a question we failed to ask.
+        #
+        # One name at a time, NOT `ls a b c d`: that exits non-zero when ANY of
+        # the four is missing, so a folder holding docker-compose.yml and
+        # nothing else read as holding no compose file at all. Caught by the
+        # test for this branch on its first run.
+        for candidate in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
+            [ -f "$1/$candidate" ] && return 2
+        done
+        return 1
+    fi
+    docker image inspect "$image" >/dev/null 2>&1 && return 0
+    return 1
 }
+
 
 
 # Let containers write to the bind-mounted server folder on SELinux systems.
@@ -1149,7 +1176,15 @@ install_server() {
     # If they already exist in $SERVER_DIR, skip the 2-4 hour compile
     # and just start the server — the rest of the install continues
     # normally (account creation, launcher setup, etc.).
-    if compiled_images_present "$SERVER_DIR"; then
+    images_state=0
+    compiled_images_present "$SERVER_DIR" || images_state=$?
+    if [ "$images_state" -eq 2 ]; then
+        print_error "Could not check whether $SERVER_DIR already holds a built server."
+        print_info "Docker did not answer, or the compose file in that folder could not be read."
+        print_info "Nothing has been changed. Start Docker, or fix that folder, and run this again."
+        exit 1
+    fi
+    if [ "$images_state" -eq 0 ]; then
         print_success "Compiled images already found in $SERVER_DIR"
         print_info "Skipping compile — reusing your existing build."
         print_info "To force a fresh compile, remove the server folder:"

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -164,6 +164,32 @@ dir_is_reusable() {
     return 0
 }
 
+# Are this install's images actually built? Ask the IMAGE STORE, not the
+# container list.
+#
+# `docker compose images` reports the images of a project's EXISTING
+# CONTAINERS. A folder whose build finished but whose `up` never ran - or whose
+# containers were removed - has no containers, so that command answers nothing
+# and a COMPLETE build reads as "nothing was built". Measured on yulon-arch
+# 2026-08-28: `up` failed on a container-name collision, so zero containers
+# existed, and the branch below then offered to delete a good ~35-minute build.
+# In a directory with no containers `docker compose images` failed outright
+# (missing env file) while `config --images` still answered.
+#
+# `config --images` reads the compose FILE, so the image name is derived from
+# this install rather than hardcoded here, and `docker image inspect` then asks
+# the store whether that image exists. Both halves matter: deriving the name
+# keeps this correct if the tag or repository changes, and inspecting the store
+# is the only question whose answer does not depend on containers.
+compiled_images_present() {
+    [ -d "$1" ] || return 1
+    local image
+    image=$(cd "$1" && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
+    [ -n "$image" ] || return 1
+    docker image inspect "$image" >/dev/null 2>&1
+}
+
+
 # Let containers write to the bind-mounted server folder on SELinux systems.
 #
 # AzerothCore's compose mounts env/dist WITHOUT the `:z` suffix that would make
@@ -1266,8 +1292,7 @@ install_server() {
     # If they already exist in $SERVER_DIR, skip the 2-4 hour compile
     # and just start the server — the rest of the install continues
     # normally (account creation, launcher setup, etc.).
-    if [ -d "$SERVER_DIR" ] && \
-       (cd "$SERVER_DIR" && docker compose images 2>/dev/null | grep -qi "worldserver"); then
+    if compiled_images_present "$SERVER_DIR"; then
         print_success "Compiled images already found in $SERVER_DIR"
         print_info "Skipping compile — reusing your existing build."
         print_info "To force a fresh compile, remove the server folder:"

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -181,6 +181,21 @@ dir_is_reusable() {
 # the store whether that image exists. Both halves matter: deriving the name
 # keeps this correct if the tag or repository changes, and inspecting the store
 # is the only question whose answer does not depend on containers.
+#
+# SCOPE, deliberately narrower than the name suggests: AzerothCore's compose
+# pins `image:` with no project prefix, so this answers "the image this install
+# needs is on this machine", NOT "this folder built it". On a box with two
+# installs of the same game, a folder holding only a clone answers yes. That is
+# why the caller below says "on this machine" rather than naming the folder,
+# and why a name collision is caught at `up` rather than assumed away here.
+#
+# Do NOT "fix" the scope by matching the image's `com.docker.compose.project`
+# label against this folder's project. `catalog_view._pin_compose_project()`
+# writes COMPOSE_PROJECT_NAME into `.env` AFTER a successful install, so the
+# label (the directory-derived name at build time) and the current project name
+# legitimately differ - and the match would report a real build as missing,
+# which is the delete prompt. Confirmed 2026-08-28 that compose does label built
+# images with the project, so the trap is reachable, not hypothetical.
 compiled_images_present() {
     # 0 = built.  1 = definitely not built.  2 = could not find out.
     #
@@ -193,6 +208,11 @@ compiled_images_present() {
     # offers to remove may hold hours of compiling. Found by an adversarial
     # review, 2026-08-28, on a real daemon.
     [ -d "$1" ] || return 1
+    # A folder that exists but cannot be entered - root-owned 700 from an
+    # earlier sudo run - is a question we failed to ask, not an empty answer.
+    # Without this, `cd` failed quietly below and the verdict was "not built",
+    # which is the delete prompt (review, 2026-08-28).
+    (cd "$1" >/dev/null 2>&1) || return 2
     docker image ls >/dev/null 2>&1 || return 2
 
     local image
@@ -206,6 +226,11 @@ compiled_images_present() {
         # the four is missing, so a folder holding docker-compose.yml and
         # nothing else read as holding no compose file at all. Caught by the
         # test for this branch on its first run.
+        # A compose file that names no worldserver image at all is somebody
+        # else's project, not an unbuilt server and not an unanswered question.
+        if [ -n "$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null)" ]; then
+            return 3
+        fi
         for candidate in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
             [ -f "$1/$candidate" ] && return 2
         done
@@ -233,8 +258,17 @@ compiled_images_present() {
 # COMPOSE_PROJECT_NAME and one that did not. A name with no such label was not
 # created by compose at all, and is reported the same way.
 refuse_foreign_containers() {
-    local dir="$1" names name owner
-    names=$(cd "$dir" 2>/dev/null && docker compose config 2>/dev/null         | sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p')
+    local dir="$1" config names name owner
+    # `config`'s own exit status, separately from the names it yields: an
+    # unreadable compose file used to look exactly like "pins no names", and the
+    # guard passed silently - the same "could not ask" spelled as "nothing here"
+    # that compiled_images_present was taught to report (review, 2026-08-28).
+    if ! config=$(cd "$dir" 2>/dev/null && docker compose config 2>/dev/null); then
+        print_error "Could not read the compose file in $dir, so its container names"
+        print_error "could not be checked against the containers already on this machine."
+        exit 1
+    fi
+    names=$(printf '%s\n' "$config" | sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p')
     [ -n "$names" ] || return 0
     local here
     here=$(cd "$dir" 2>/dev/null && pwd -P)
@@ -246,7 +280,12 @@ refuse_foreign_containers() {
             if [ -n "$owner" ]; then
                 print_info "It belongs to the server in: $owner"
                 print_info "Stop and remove that server first (its data volumes are kept), or install this one"
-                print_info "on a machine that is not already running it. Nothing has been changed."
+                print_info "on a machine that is not already running it."
+                # NOT "nothing has been changed": this guard needs a compose file
+                # to read container names from, so it can only run AFTER the clone -
+                # the source tree and the generated override are already in $dir by
+                # now (review, 2026-08-28).
+                print_info "The source in $dir was left as it is; nothing was built or started."
             else
                 print_info "It was not created by this installer. Remove it, then run the install again."
             fi
@@ -1369,8 +1408,8 @@ install_server() {
         exit 1
     fi
     if [ "$images_state" -eq 0 ]; then
-        print_success "Compiled images already found in $SERVER_DIR"
-        print_info "Skipping compile — reusing your existing build."
+        print_success "The images this server needs are already on this machine"
+        print_info "Skipping the compile and starting them."
         print_info "To force a fresh compile, remove the server folder:"
         print_info "  sudo rm -rf $SERVER_DIR"
         # Also here, not only on the fresh-build path. This branch is how a user
@@ -1383,6 +1422,22 @@ install_server() {
         selinux_label_for_containers "$SERVER_DIR"
         cd "$SERVER_DIR" || exit 1
         docker compose up -d 2>&1 | tail -5
+        # The build path has checked this since it was written; this one never
+        # did. On fedora (`set -o pipefail`, no `-e`) a failed `up` fell through
+        # to `return 0`, and `wait_for_server` greps `docker ps` HOST-GLOBALLY -
+        # so the container that made `up` fail on a name conflict is a running
+        # `ac-worldserver` belonging to the OTHER install, and the loop finds it
+        # "ready...", prints "Server is READY!" and exits 0 (review, 2026-08-28).
+        if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+            print_error "The build is already here, but starting it failed."
+            # A diagnosis AFTER the failure, never a gate before it: this branch
+            # is how a MOVED install folder recovers, and compose bakes
+            # `working_dir` into a container at creation - so an unconditional
+            # ownership check here would refuse the move, naming a folder that no
+            # longer exists, with nothing to do about it.
+            refuse_foreign_containers "$SERVER_DIR"
+            exit 1
+        fi
         return 0
     fi
 

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -182,12 +182,39 @@ dir_is_reusable() {
 # keeps this correct if the tag or repository changes, and inspecting the store
 # is the only question whose answer does not depend on containers.
 compiled_images_present() {
+    # 0 = built.  1 = definitely not built.  2 = could not find out.
+    #
+    # The third answer is the point. The caller's next step offers to DELETE
+    # this folder, so "I could not ask" must never be spelled the same way as
+    # "there is nothing here". A daemon that is not up yet after boot, one
+    # restarted for maintenance, or a compose file that cannot be read would
+    # otherwise all arrive at that prompt under the message "no completed build
+    # was found in it" - which in those cases is not true, and the folder it
+    # offers to remove may hold hours of compiling. Found by an adversarial
+    # review, 2026-08-28, on a real daemon.
     [ -d "$1" ] || return 1
+    docker image ls >/dev/null 2>&1 || return 2
+
     local image
     image=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
-    [ -n "$image" ] || return 1
-    docker image inspect "$image" >/dev/null 2>&1
+    if [ -z "$image" ]; then
+        # No image name to test. A folder with no compose file at all has
+        # genuinely never been built; a folder that HAS one which compose would
+        # not read is a question we failed to ask.
+        #
+        # One name at a time, NOT `ls a b c d`: that exits non-zero when ANY of
+        # the four is missing, so a folder holding docker-compose.yml and
+        # nothing else read as holding no compose file at all. Caught by the
+        # test for this branch on its first run.
+        for candidate in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
+            [ -f "$1/$candidate" ] && return 2
+        done
+        return 1
+    fi
+    docker image inspect "$image" >/dev/null 2>&1 && return 0
+    return 1
 }
+
 
 
 # Let containers write to the bind-mounted server folder on SELinux systems.
@@ -1292,7 +1319,15 @@ install_server() {
     # If they already exist in $SERVER_DIR, skip the 2-4 hour compile
     # and just start the server — the rest of the install continues
     # normally (account creation, launcher setup, etc.).
-    if compiled_images_present "$SERVER_DIR"; then
+    images_state=0
+    compiled_images_present "$SERVER_DIR" || images_state=$?
+    if [ "$images_state" -eq 2 ]; then
+        print_error "Could not check whether $SERVER_DIR already holds a built server."
+        print_info "Docker did not answer, or the compose file in that folder could not be read."
+        print_info "Nothing has been changed. Start Docker, or fix that folder, and run this again."
+        exit 1
+    fi
+    if [ "$images_state" -eq 0 ]; then
         print_success "Compiled images already found in $SERVER_DIR"
         print_info "Skipping compile — reusing your existing build."
         print_info "To force a fresh compile, remove the server folder:"

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -1323,8 +1323,20 @@ install_server() {
             sudo rm -rf "$SERVER_DIR"
             print_success "Old install removed"
         else
-            print_info "Keeping existing install — exiting."
-            exit 0
+            # NOT `exit 0`. Nothing was installed, and a zero exit is read
+            # as SUCCESS by the caller: `catalog_view.py` pins a compose
+            # project name into this folder and grows a tab for a server
+            # that was never built - and `docker.py` records that such a pin
+            # is inherited by any COPY of the folder, so Stop in the copy can
+            # stop the original's server. Reproduced on yulon-arch
+            # 2026-08-28: a killed build was retried into the same folder and
+            # the run reported success having done nothing.
+            #
+            # Declining is a legitimate choice; calling it an install is not.
+            print_error "Nothing was installed."
+            print_info "$SERVER_DIR already holds files, and no completed build was found in it."
+            print_info "Choose an empty folder, or remove this one, and run the install again."
+            exit 1
         fi
     fi
 

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -215,6 +215,47 @@ compiled_images_present() {
     return 1
 }
 
+# Refuse to build into a folder whose container names another install holds.
+#
+# The compose file pins `container_name:` for every service, and Docker keeps
+# those names global to the host - so a second install of the same game, even
+# into a brand-new empty folder, fails at `docker compose up` with
+#   Conflict. The container name "/ac-database" is already in use
+# from the daemon, after the 2-4 hour build. Hit on yulon-ubuntu AND yulon-arch
+# on the same day (2026-08-28), both times from a stopped, not removed, stack
+# left by an earlier install elsewhere on the box. Naming the other install is
+# the whole value here; the daemon's message names a container.
+#
+# "Another install" is decided by the container's own compose label, NOT by a
+# guess at the project name: `com.docker.compose.project.working_dir` is
+# written by compose on every container it creates, and comparing it with
+# THIS folder is the only test that is right for both an install that pinned
+# COMPOSE_PROJECT_NAME and one that did not. A name with no such label was not
+# created by compose at all, and is reported the same way.
+refuse_foreign_containers() {
+    local dir="$1" names name owner
+    names=$(cd "$dir" 2>/dev/null && docker compose config 2>/dev/null         | sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p')
+    [ -n "$names" ] || return 0
+    local here
+    here=$(cd "$dir" 2>/dev/null && pwd -P)
+    for name in $names; do
+        docker container inspect "$name" >/dev/null 2>&1 || continue
+        owner=$(docker container inspect "$name"             --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' 2>/dev/null)
+        if [ "$owner" != "$here" ]; then
+            print_error "A container named '$name' already exists, and it is not this install's."
+            if [ -n "$owner" ]; then
+                print_info "It belongs to the server in: $owner"
+                print_info "Stop and remove that server first (its data volumes are kept), or install this one"
+                print_info "on a machine that is not already running it. Nothing has been changed."
+            else
+                print_info "It was not created by this installer. Remove it, then run the install again."
+            fi
+            exit 1
+        fi
+    done
+}
+
+
 
 
 # Let containers write to the bind-mounted server folder on SELinux systems.
@@ -1475,6 +1516,7 @@ OVERRIDE
 
     selinux_label_for_containers "$SERVER_DIR"
 
+    refuse_foreign_containers "$SERVER_DIR"
     cd "$SERVER_DIR"
     docker compose up -d --build 2>&1 | tee ~/playerbots-build.log
 

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -215,8 +215,9 @@ compiled_images_present() {
     (cd "$1" >/dev/null 2>&1) || return 2
     docker image ls >/dev/null 2>&1 || return 2
 
-    local image
-    image=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
+    local image images prefix candidate
+    images=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null)
+    image=$(echo "$images" | grep -i "worldserver" | head -1)
     if [ -z "$image" ]; then
         # No image name to test. A folder with no compose file at all has
         # genuinely never been built; a folder that HAS one which compose would
@@ -228,7 +229,7 @@ compiled_images_present() {
         # test for this branch on its first run.
         # A compose file that names no worldserver image at all is somebody
         # else's project, not an unbuilt server and not an unanswered question.
-        if [ -n "$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null)" ]; then
+        if [ -n "$images" ]; then
             return 3
         fi
         for candidate in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
@@ -236,8 +237,33 @@ compiled_images_present() {
         done
         return 1
     fi
-    docker image inspect "$image" >/dev/null 2>&1 && return 0
-    return 1
+    # EVERY image this build produces, not just the worldserver one. A prune that
+    # took `ac-db-import` but left `ac-worldserver` used to answer "built", and
+    # the caller's reuse path then runs `up` with no `--build` - so the stack
+    # comes up against a missing or foreign image having deliberately skipped a
+    # 2-4 hour compile. Found by an independent adversarial review (Codex),
+    # 2026-08-28.
+    #
+    # Siblings are recognised by the prefix the worldserver image itself carries
+    # (`acore/ac-wotlk-`), which keeps third-party images in the same compose
+    # file out of it: `mysql:8.0` is PULLED, not built, so requiring it to be on
+    # the machine would report a good build as missing every time it was pruned -
+    # and that is the delete prompt.
+    prefix=${image%worldserver*}
+    if [ "$prefix" = "$image" ]; then
+        # No `worldserver` component to strip, so no prefix can be derived and
+        # the single-image question is the only one available.
+        docker image inspect "$image" >/dev/null 2>&1 && return 0
+        return 1
+    fi
+    for candidate in $images; do
+        case "$candidate" in
+            "$prefix"*)
+                docker image inspect "$candidate" >/dev/null 2>&1 || return 1
+                ;;
+        esac
+    done
+    return 0
 }
 
 # Refuse to build into a folder whose container names another install holds.
@@ -1405,6 +1431,15 @@ install_server() {
         print_error "Could not check whether $SERVER_DIR already holds a built server."
         print_info "Docker did not answer, or the compose file in that folder could not be read."
         print_info "Nothing has been changed. Start Docker, or fix that folder, and run this again."
+        exit 1
+    fi
+    if [ "$images_state" -eq 3 ]; then
+        # Without a branch of its own this fell through to "Remove it and start
+        # fresh?", which offers `rm -rf` on a folder we have just identified as
+        # somebody else's project. Never offer that (review, 2026-08-29).
+        print_error "$SERVER_DIR holds a docker compose project that is not this server."
+        print_info "Its compose file names no worldserver image, so nothing in it was built here."
+        print_info "Nothing has been changed. Choose a different folder and run this again."
         exit 1
     fi
     if [ "$images_state" -eq 0 ]; then

--- a/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
+++ b/pylauncher/catalog/installers/wow-wotlk/install-wow-wotlk.sh
@@ -184,7 +184,7 @@ dir_is_reusable() {
 compiled_images_present() {
     [ -d "$1" ] || return 1
     local image
-    image=$(cd "$1" && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
+    image=$(cd "$1" 2>/dev/null && docker compose config --images 2>/dev/null | grep -i "worldserver" | head -1)
     [ -n "$image" ] || return 1
     docker image inspect "$image" >/dev/null 2>&1
 }

--- a/pylauncher/main.py
+++ b/pylauncher/main.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 from yulon import platform
 from yulon.log import configure, get_logger
-from yulon.ui.widgets.job import in_flight
 
 logger = get_logger(__name__)
 
@@ -310,6 +309,12 @@ def build_window() -> object:
     # end of test_main.py where a window is dropped. `in_flight()` owns the pair
     # until the thread has finished; the properties stay for
     # `_stop_background_threads`, which joins by them.
+    # Imported here, not at module scope: `main.py` keeps every Qt import inside
+    # the functions that build a window, so `--provision` runs on a box with no
+    # Qt at all. A module-level import of this contradicted the file's own
+    # lazy-import comments (review, 2026-08-28).
+    from yulon.ui.widgets.job import in_flight
+
     in_flight().hold(update_thread, update_worker)
     window.setProperty("update_thread", update_thread)
     window.setProperty("update_worker", update_worker)
@@ -520,6 +525,8 @@ def _stop_background_threads(window: object) -> None:
     # Whatever the panels and runners above did not own any more: `job.InFlight`
     # keeps every started pair alive until its thread has finished, so this is
     # the join for a worker whose panel is already gone.
+    from yulon.ui.widgets.job import in_flight
+
     in_flight().wait_all(8000)
 
 

--- a/pylauncher/main.py
+++ b/pylauncher/main.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from yulon import platform
 from yulon.log import configure, get_logger
+from yulon.ui.widgets.job import in_flight
 
 logger = get_logger(__name__)
 
@@ -300,7 +301,17 @@ def build_window() -> object:
     update_thread.started.connect(update_worker.run)
     update_worker.done.connect(banner_host.show_update)
     update_worker.done.connect(update_thread.quit)
-    window.setProperty("update_thread", update_thread)  # keep references alive with the window
+    # `setProperty` does NOT keep a Python object alive - a Qt property holds a
+    # QObject*, not a reference - so `update_worker` used to die the moment this
+    # function returned, and the thread started three lines down then called
+    # `run` on freed memory whenever the OS got round to scheduling it. Native
+    # backtrace on yulon-ubuntu (2026-08-28): `QThread::started` ->
+    # `SignalManager::qt_metacall` -> SIGBUS in `QMetaMethod::name()`, at the
+    # end of test_main.py where a window is dropped. `in_flight()` owns the pair
+    # until the thread has finished; the properties stay for
+    # `_stop_background_threads`, which joins by them.
+    in_flight().hold(update_thread, update_worker)
+    window.setProperty("update_thread", update_thread)
     window.setProperty("update_worker", update_worker)
     update_thread.start()
     window.resize(1100, 750)
@@ -509,8 +520,6 @@ def _stop_background_threads(window: object) -> None:
     # Whatever the panels and runners above did not own any more: `job.InFlight`
     # keeps every started pair alive until its thread has finished, so this is
     # the join for a worker whose panel is already gone.
-    from yulon.ui.widgets.job import in_flight
-
     in_flight().wait_all(8000)
 
 

--- a/pylauncher/main.py
+++ b/pylauncher/main.py
@@ -506,6 +506,12 @@ def _stop_background_threads(window: object) -> None:
     if isinstance(thread, QThread) and thread.isRunning():
         thread.quit()
         thread.wait(8000)
+    # Whatever the panels and runners above did not own any more: `job.InFlight`
+    # keeps every started pair alive until its thread has finished, so this is
+    # the join for a worker whose panel is already gone.
+    from yulon.ui.widgets.job import in_flight
+
+    in_flight().wait_all(8000)
 
 
 if __name__ == "__main__":

--- a/pylauncher/pyproject.toml
+++ b/pylauncher/pyproject.toml
@@ -10,12 +10,18 @@ target-version = "py311"
 select = ["E", "F", "I", "UP", "B"]
 
 [tool.mypy]
+# `mypy .` and CI's `mypy yulon main.py` (`ci.yml`) now check the same set.
+# `tests/` is excluded rather than listed under `files`, because an explicit
+# path on the command line REPLACES `files` and `.` is what everyone types -
+# so `files` left the bare command walking tests/, where `strict` turns mock
+# fakes into 375 attr-defined errors CI never gates on. Four boxes reported
+# that identical number in one day before anyone compared the two commands.
 python_version = "3.11"
 strict = true
 warn_unused_ignores = true
 disallow_untyped_defs = true
 disallow_any_generics = true
-exclude = ["build/"]
+exclude = ["build/", "tests/"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/pylauncher/tests/integration/conftest.py
+++ b/pylauncher/tests/integration/conftest.py
@@ -144,10 +144,45 @@ services:
 # The same project with a database that can never report healthy: the
 # fail-closed case. A worldserver started against a dead database is the
 # outcome the health gate exists to prevent.
-_NEVER_HEALTHY_YML = _COMPOSE_YML.replace(
-    'command: ["sh", "-c", "sleep 2 && touch /tmp/ready && sleep 600"]',
-    'command: ["sh", "-c", "sleep 600"]',  # /tmp/ready is never created
+# /tmp/ready is never created. Same trap-and-wait shape as the healthy one, so
+# the teardown is still instant. Built by replacing the healthy command and
+# CHECKED to have changed something: this used to be a bare `.replace()`, and
+# when the healthy command was rewritten to trap SIGTERM the replace silently
+# matched nothing, the "never healthy" database came up healthy, and CI failed
+# with "DID NOT RAISE DockerCommandError" (run 33201823461, 2026-08-28).
+_HEALTHY_DB_COMMAND = (
+    "command: ["
+    + chr(34)
+    + "sh"
+    + chr(34)
+    + ", "
+    + chr(34)
+    + "-c"
+    + chr(34)
+    + ", "
+    + chr(34)
+    + "trap 'exit 0' TERM; sleep 2 && touch /tmp/ready; sleep 600 & wait"
+    + chr(34)
+    + "]"
 )
+_NEVER_HEALTHY_DB_COMMAND = (
+    "command: ["
+    + chr(34)
+    + "sh"
+    + chr(34)
+    + ", "
+    + chr(34)
+    + "-c"
+    + chr(34)
+    + ", "
+    + chr(34)
+    + "trap 'exit 0' TERM; sleep 600 & wait"
+    + chr(34)
+    + "]"
+)
+assert _HEALTHY_DB_COMMAND in _COMPOSE_YML, "the healthy db command moved; update both constants"
+_NEVER_HEALTHY_YML = _COMPOSE_YML.replace(_HEALTHY_DB_COMMAND, _NEVER_HEALTHY_DB_COMMAND)
+assert _NEVER_HEALTHY_YML != _COMPOSE_YML
 
 
 def docker_available() -> bool:

--- a/pylauncher/tests/integration/conftest.py
+++ b/pylauncher/tests/integration/conftest.py
@@ -84,7 +84,7 @@ services:
   db:
     image: busybox:1.36
     container_name: {THROWAWAY_SPEC.db}
-    command: ["sh", "-c", "sleep 2 && touch /tmp/ready && sleep 600"]
+    command: ["sh", "-c", "trap 'exit 0' TERM; sleep 2 && touch /tmp/ready; sleep 600 & wait"]
     healthcheck:
       test: ["CMD", "test", "-f", "/tmp/ready"]
       interval: 1s
@@ -101,7 +101,10 @@ services:
     command:
       - sh
       - -c
-      - echo 'Added realm "Yulon" at {THROWAWAY_REALM_HOST}:{THROWAWAY_REALM_PORT}'; sleep 600
+      - >-
+        trap 'exit 0' TERM;
+        echo 'Added realm "Yulon" at {THROWAWAY_REALM_HOST}:{THROWAWAY_REALM_PORT}';
+        sleep 600 & wait
     ports:
       - "{THROWAWAY_REALM_HOST}:{THROWAWAY_REALM_PORT}:{THROWAWAY_REALM_PORT}"
   world:
@@ -110,8 +113,25 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    command: ["sh", "-c", "echo 'World initialized, ready...'; sleep 600"]
+    command:
+      - sh
+      - -c
+      - trap 'exit 0' TERM; echo 'World initialized, ready...'; sleep 600 & wait
 """
+# Every stand-in traps SIGTERM and waits on a BACKGROUNDED sleep. Both halves are
+# required, and without them the suite pays five minutes twice.
+#
+# `sleep` as PID 1 does not die on SIGTERM: the kernel gives PID 1 no default
+# action for it, so `docker compose stop -t 300` waits out the whole grace period
+# (`docker.STOP_GRACE_SECONDS`, correct at 300 for a real worldserver draining its
+# save queue) and then SIGKILLs. Measured on yulon-fedora 2026-08-28:
+# `time docker stop -t 300` on `busybox sh -c "sleep 600"` took 5m0.748s, and two
+# tests do it, which is most of a 32-42 minute local run.
+#
+# The trap alone is not enough. A foreground `sleep` blocks the shell from
+# running the handler until it returns, so the sleep is backgrounded and `wait`
+# holds the shell in a signal-interruptible state.
+
 # The `depends_on: condition: service_healthy` edges above are not decoration.
 # `start_staged()` deleted its Python health-wait on the grounds that compose
 # owns the dependency graph and fails closed when the database never becomes

--- a/pylauncher/tests/test_docker.py
+++ b/pylauncher/tests/test_docker.py
@@ -77,6 +77,55 @@ def test_status_returns_running_container_names(monkeypatch: pytest.MonkeyPatch)
     assert docker.status() == ["ac-database", "ac-worldserver"]
 
 
+def test_status_gives_docker_ps_a_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`docker ps` must not be allowed to hang the five-second status poll forever.
+
+    `refresh_status()` sets `_status_pending` and clears it only from a
+    callback, so a call that never returns is not a slow poll - it is a
+    permanently wedged Server tab, reading "status: unknown" until the app is
+    restarted, with every later poll returning early at the guard. Measured on
+    yulon-win11 (2026-08-28): `docker ps` hung 8+ minutes under memory
+    pressure, and 125 seconds on an earlier run.
+
+    Asserted on the timeout that reaches the run seam rather than on the
+    constant, because the bug was never the value - it was that no value was
+    passed at all.
+    """
+    seen: list[float | None] = []
+
+    def fake_run(
+        cmd: list[str], cwd: Path | None = None, timeout: float | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        seen.append(timeout)
+        return _completed(0, "ac-worldserver\n", "")
+
+    monkeypatch.setattr(docker.runner, "run", fake_run)
+
+    assert docker.status() == ["ac-worldserver"]
+    assert seen and seen[0] is not None, "docker ps was run with no deadline at all"
+    assert 0 < seen[0] <= 120, f"deadline of {seen[0]}s is not a bound worth having"
+
+
+def test_a_status_timeout_surfaces_as_an_error_the_poll_can_recover_from(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timed-out `docker ps` must raise, not return an empty list.
+
+    `runner.run()` reports a timeout as a non-zero `CompletedProcess`, the same
+    shape as a missing CLI. If `status()` swallowed that it would answer "no
+    containers are running", which reads as a stopped server rather than an
+    unreachable daemon - and `_status_failed()`, the callback that clears
+    `_status_pending`, would never fire.
+    """
+    monkeypatch.setattr(
+        docker.runner,
+        "run",
+        lambda cmd, cwd=None, timeout=None: _completed(1, "", "timed out after 30.0s"),
+    )
+    with pytest.raises(docker.DockerCommandError):
+        docker.status()
+
+
 def test_health_returns_status_or_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
     """`health()` returns the inspect status, or `unknown` on failure/empty."""
     monkeypatch.setattr(

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -567,13 +567,13 @@ _IMAGES_PROBE = """
 set -u
 docker() { echo "$*" >>"$CALLS"; %(stub)s; }
 %(body)s
-if compiled_images_present "$1"; then echo YES; else echo NO; fi
+compiled_images_present "$1"; echo "STATUS=$?"
 """
 
 
 def _compiled_images_present(
     script: Path, target: Path, calls: Path, *, stub: str
-) -> tuple[str, list[str]]:
+) -> tuple[int, list[str]]:
     """Run the installer's own `compiled_images_present`, and report what it ASKED.
 
     Lifted out of the shipped script, like `_dir_is_reusable` above, so this
@@ -600,9 +600,12 @@ def _compiled_images_present(
         f"{script.name}: the probe is missing a function the shipped code calls, "
         f"so its result means nothing:\n{out.stderr.strip()}"
     )
-    return out.stdout.strip(), [
-        line for line in calls.read_text(encoding="utf-8").splitlines() if line
-    ]
+    status = next(
+        int(line.removeprefix("STATUS="))
+        for line in out.stdout.splitlines()
+        if line.startswith("STATUS=")
+    )
+    return status, [line for line in calls.read_text(encoding="utf-8").splitlines() if line]
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
@@ -638,7 +641,7 @@ def test_a_finished_build_is_recognised_when_no_containers_exist(
         stub=_STUB_BUILT,
     )
 
-    assert answer == "YES", f"{script_name}: a finished build was not recognised"
+    assert answer == 0, f"{script_name}: a finished build was not recognised"
     assert any(
         call.startswith("image inspect ") for call in asked
     ), f"{script_name}: never asked the image store; it asked {asked}"
@@ -680,8 +683,105 @@ def test_a_folder_with_no_build_is_still_reported_as_unbuilt(
         ),
     )
 
-    assert answer == "NO", f"{script_name}: an unbuilt folder was reported as built"
+    assert answer == 1, f"{script_name}: an unbuilt folder was reported as built"
     assert any(call.startswith("image inspect ") for call in asked)
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_a_daemon_that_will_not_answer_is_not_reported_as_an_unbuilt_folder(
+    tmp_path: Path, script_name: str
+) -> None:
+    """ "Could not ask" must not be spelled the same way as "nothing is here".
+
+    The caller's next step offers to DELETE the folder. A daemon that is not up
+    yet after boot, or one restarted for maintenance, would otherwise arrive at
+    that prompt under the message "no completed build was found in it" - untrue
+    in that case, about a folder that may hold hours of compiling. Found by an
+    adversarial review (2026-08-28) against a real daemon, by pointing
+    DOCKER_HOST at a socket that does not exist.
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    target = tmp_path / "server"
+    target.mkdir()
+    (target / "docker-compose.yml").write_text("services: {}", encoding="utf-8")
+
+    answer, _asked = _compiled_images_present(
+        script, target, tmp_path / "calls", stub="return 1"  # every docker call fails
+    )
+
+    assert answer == 2, (
+        f"{script_name}: an unreachable daemon answered {answer}, which the caller reads as "
+        f"a verdict rather than a failure to reach one"
+    )
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_a_compose_file_that_cannot_be_read_is_not_reported_as_an_unbuilt_folder(
+    tmp_path: Path, script_name: str
+) -> None:
+    """A compose file that compose itself will not parse is a question we failed to ask.
+
+    The daemon answers, so the failure is narrower than the test above: the
+    folder has a compose file, and `config --images` still yields no image
+    name. That is "could not find out", not "nothing was built".
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    target = tmp_path / "server"
+    target.mkdir()
+    (target / "docker-compose.yml").write_text("this: is: not: valid: yaml:", encoding="utf-8")
+
+    answer, _asked = _compiled_images_present(
+        script,
+        target,
+        tmp_path / "calls",
+        # `image ls` succeeds (daemon is up); `compose config` fails.
+        stub='case "$*" in "compose config --images") return 1;; esac',
+    )
+
+    assert answer == 2, f"{script_name}: an unreadable compose file answered {answer}"
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_a_folder_with_no_compose_file_is_a_verdict_not_a_failure(
+    tmp_path: Path, script_name: str
+) -> None:
+    """The companion to the two above: "cannot tell" must not swallow the real "no".
+
+    A folder with no compose file in it has genuinely never held a built
+    server, and saying so is what lets a first install proceed. If every
+    uncertain-looking case answered 2, the install would refuse to start.
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    target = tmp_path / "server"
+    target.mkdir()
+    (target / "leftover.txt").write_text("x", encoding="utf-8")
+
+    answer, _asked = _compiled_images_present(
+        script,
+        target,
+        tmp_path / "calls",
+        stub='case "$*" in "compose config --images") return 1;; esac',
+    )
+
+    assert answer == 1, f"{script_name}: a folder with no compose file answered {answer}"
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
@@ -709,7 +809,7 @@ def test_the_image_name_is_read_from_the_compose_file(tmp_path: Path, script_nam
         stub=_STUB_RENAMED,
     )
 
-    assert answer == "YES"
+    assert answer == 0
     assert (
         "image inspect example.test/renamed-worldserver:v9" in asked
     ), f"{script_name}: did not inspect the image the compose file named: {asked}"

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -1625,69 +1625,6 @@ def _shell_function_bodies(lines: list[str]) -> dict[str, range]:
     return bodies
 
 
-@pytest.mark.parametrize(
-    "script_name",
-    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
-)
-def test_declining_to_start_fresh_is_not_reported_as_a_successful_install(
-    script_name: str,
-) -> None:
-    """Answering "n" to "Remove it and start fresh?" must not exit 0.
-
-    A zero exit is read as SUCCESS by the caller. `catalog_view.py` then pins a
-    compose project name into a folder holding no server and grows a tab for
-    one that was never built - and `docker.py` records that such a pin is
-    inherited by any COPY of the folder, so Stop in the copy can stop the
-    original's server. Reproduced on yulon-arch (2026-08-28): a build killed
-    mid-compile was retried into the same folder, and the run logged "install
-    finished" having done nothing at all.
-
-    Structural rather than behavioural, deliberately and with the cost stated:
-    the branch sits inside `install_server()` after `install_docker`/
-    `install_git`, so reaching it for real means running an installer. What is
-    asserted instead is the shape that carries the bug - which exit follows the
-    decline - with comments stripped first, because a test that a comment can
-    satisfy is how 80fb68a9 earned a green run for a fix it had not made.
-    """
-    script = (
-        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
-    )
-    lines = script.read_text(encoding="utf-8").splitlines()
-    body = _shell_function_bodies(lines).get("install_server")
-    assert body is not None, f"{script_name}: no install_server() to read"
-
-    code = [
-        (number, lines[number - 1].strip())
-        for number in body
-        if lines[number - 1].strip() and not lines[number - 1].strip().startswith("#")
-    ]
-    asked = [
-        i for i, (_, text) in enumerate(code) if 'ask_yes_no "Remove it and start fresh?"' in text
-    ]
-    assert len(asked) == 1, f"{script_name}: expected one start-fresh prompt, found {len(asked)}"
-
-    after = code[asked[0] :]
-    else_at = next(i for i, (_, text) in enumerate(after) if text == "else")
-    exit_number, exit_text = next(
-        (number, text) for number, text in after[else_at:] if text.startswith("exit ")
-    )
-
-    assert exit_text != "exit 0", (
-        f"{script_name}:{exit_number}: declining exits 0, so a caller records an install "
-        f"that never happened"
-    )
-    assert exit_text == "exit 1", f"{script_name}:{exit_number}: unexpected exit {exit_text!r}"
-
-    # Reported as an error, not as information: the app shows the script's last
-    # words verbatim when it exits non-zero (`installer.py`'s CalledProcessError
-    # branch), so this is the sentence the user is left holding.
-    said = [text for _, text in after[else_at:]]
-    assert any(text.startswith("print_error ") for text in said), (
-        f"{script_name}: the decline branch never calls print_error, so a failure "
-        f"is announced in the tone of a status update"
-    )
-
-
 def _catalog_installers() -> list[Path]:
     from yulon import resources
 
@@ -2013,3 +1950,100 @@ def test_choose_install_dir_refuses_by_failing() -> None:
                 refusing = False
 
     assert not surrendering, f"these refusals report success: {surrendering}"
+
+
+_DECLINE_PROBE = """
+set -u
+print_header() { :; }
+print_step() { :; }
+print_info() { echo "INFO $*"; }
+print_warning() { echo "WARN $*"; }
+print_error() { echo "ERROR $*"; }
+print_success() { echo "OK $*"; }
+ask_yes_no() { echo "ASKED $*"; return 1; }   # the user says NO
+docker() { echo "DOCKER $*"; }
+sudo() { echo "SUDO $*"; }
+SERVER_DIR="$1"
+%(reusable)s
+%(block)s
+echo "REACHED THE END OF THE BLOCK"
+"""
+
+
+def _decline_block(script: Path) -> str:
+    """The existing-folder branch, taken verbatim out of the shipped script.
+
+    From `if [ -d "$SERVER_DIR" ] && ! dir_is_reusable` to the `fi` that closes
+    it at the same indentation.
+    """
+    lines = script.read_text(encoding="utf-8").splitlines()
+    start = next(
+        i
+        for i, text in enumerate(lines)
+        if text.strip().startswith('if [ -d "$SERVER_DIR" ] && ! dir_is_reusable')
+    )
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    end = next(
+        i
+        for i in range(start + 1, len(lines))
+        if lines[i].strip() == "fi" and (len(lines[i]) - len(lines[i].lstrip())) == indent
+    )
+    return "\n".join(lines[start : end + 1])
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_declining_to_start_fresh_exits_non_zero(tmp_path: Path, script_name: str) -> None:
+    """RUN the decline branch and read its exit status. Do not read its shape.
+
+    A zero exit is success to whoever is reading it. `catalog_view.py` pinned a
+    compose project name into a folder holding no server and grew a tab for one
+    that was never built; `docker.py` records that such a pin is inherited by
+    any COPY of the folder, so Stop in the copy can stop the original's server.
+    Reproduced on yulon-arch (2026-08-28) end to end through `Installer.run()`.
+
+    This replaces a structural version that scanned for "the first `exit` after
+    the first `else`". An adversarial review defeated it in one move: an
+    unreachable `if false; then exit 1; fi` placed before a live `exit 0` made
+    it pass against the very bug it existed to catch. Line order is not control
+    flow. So the branch is lifted out of the shipped script and executed, with
+    `ask_yes_no` answering no — the same answer `PROMPT_RULES` gives, since
+    nothing sets `InstallOptions.reinstall`.
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    occupied = tmp_path / "server"
+    occupied.mkdir()
+    (occupied / "docker-compose.yml").write_text("x", encoding="utf-8")
+
+    body = script.read_text(encoding="utf-8")
+    reusable = body[
+        body.index("dir_is_reusable() {") : body.index("\n}", body.index("dir_is_reusable() {")) + 2
+    ]
+    probe = _DECLINE_PROBE % {"reusable": reusable, "block": _decline_block(script)}
+    out = subprocess.run(
+        ["bash", "-c", probe, "probe", str(occupied)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert "command not found" not in out.stderr, (
+        f"{script_name}: the probe is missing a function the shipped code calls, "
+        f"so its result means nothing:\n{out.stderr.strip()}"
+    )
+    assert (
+        "ASKED" in out.stdout
+    ), f"{script_name}: the branch never reached the prompt:\n{out.stdout}"
+    assert out.returncode == 1, (
+        f"{script_name}: declining exited {out.returncode}, so a caller records an install "
+        f"that never happened. Output was:\n{out.stdout}"
+    )
+    assert (
+        "REACHED THE END OF THE BLOCK" not in out.stdout
+    ), f"{script_name}: the branch fell through instead of exiting"
+    assert "SUDO rm" not in out.stdout, f"{script_name}: declining deleted the folder anyway"

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -2305,3 +2305,63 @@ def test_declining_to_start_fresh_exits_non_zero(tmp_path: Path, script_name: st
         "REACHED THE END OF THE BLOCK" not in out.stdout
     ), f"{script_name}: the branch fell through instead of exiting"
     assert "SUDO rm" not in out.stdout, f"{script_name}: declining deleted the folder anyway"
+
+
+# A compose file that names two BUILT images and one PULLED one - which is the
+# shape of AzerothCore's - with the image store answering differently per image.
+_STUB_PARTIAL_BUILD = (
+    'case "$*" in '
+    '"compose config --images") '
+    "echo acore/ac-wotlk-worldserver:master; "
+    "echo acore/ac-wotlk-db-import:master; "
+    "echo mysql:8.0;; "
+    '"image inspect acore/ac-wotlk-db-import:master") return 1;; '
+    "esac"
+)
+_STUB_THIRD_PARTY_PRUNED = (
+    'case "$*" in '
+    '"compose config --images") '
+    "echo acore/ac-wotlk-worldserver:master; "
+    "echo acore/ac-wotlk-db-import:master; "
+    "echo mysql:8.0;; "
+    '"image inspect mysql:8.0") return 1;; '
+    "esac"
+)
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_a_half_built_image_set_is_not_a_finished_build(tmp_path: Path, script_name: str) -> None:
+    """One surviving worldserver image is not the same thing as a finished build.
+
+    The probe used to test the FIRST image whose name contains "worldserver" and
+    nothing else, so a prune that took `ac-db-import` still answered "built" -
+    and the caller then skips a 2-4 hour compile and runs `up` with no `--build`.
+    Found by an independent adversarial review (Codex), 2026-08-28.
+
+    The second half is the half that constrains the fix: `mysql:8.0` is PULLED,
+    not built, so requiring EVERY image in the compose file to be on the machine
+    would report a good build as missing whenever that one was pruned - and that
+    is the branch which offers to delete the folder.
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    target = tmp_path / "server"
+    target.mkdir()
+
+    half_built, _asked = _compiled_images_present(
+        script, target, tmp_path / "calls-partial", stub=_STUB_PARTIAL_BUILD
+    )
+    assert half_built == 1, f"{script_name}: a missing db-import image still read as built"
+
+    pulled_away, _asked = _compiled_images_present(
+        script, target, tmp_path / "calls-pulled", stub=_STUB_THIRD_PARTY_PRUNED
+    )
+    assert pulled_away == 0, (
+        f"{script_name}: a pruned third-party image reported a real build as missing, "
+        "which is the folder-delete prompt"
+    )

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -815,6 +815,138 @@ def test_the_image_name_is_read_from_the_compose_file(tmp_path: Path, script_nam
     ), f"{script_name}: did not inspect the image the compose file named: {asked}"
 
 
+_FOREIGN_PROBE = """
+set -u
+print_error() { echo "ERROR $*"; }
+print_info() { echo "INFO $*"; }
+docker() { echo "$*" >>"$CALLS"; %(stub)s; }
+%(body)s
+refuse_foreign_containers "$1"; echo "STATUS=$?"
+"""
+
+
+def _refuse_foreign_containers(
+    script: Path, target: Path, calls: Path, *, stub: str
+) -> tuple[int, str, list[str]]:
+    """Run the installer's own `refuse_foreign_containers` against a stubbed docker."""
+    body = script.read_text(encoding="utf-8")
+    start = body.index("refuse_foreign_containers() {")
+    end = body.index("\n}", start) + 2
+    calls.write_text("", encoding="utf-8")
+    probe = _FOREIGN_PROBE % {"stub": stub, "body": body[start:end]}
+    out = subprocess.run(
+        ["bash", "-c", probe, "probe", str(target)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"PATH": os.environ.get("PATH", ""), "CALLS": str(calls)},
+    )
+    assert "command not found" not in out.stderr, (
+        f"{script.name}: the probe is missing a function the shipped code calls:"
+        f"\n{out.stderr.strip()}"
+    )
+    status = next(
+        (
+            int(line.removeprefix("STATUS="))
+            for line in out.stdout.splitlines()
+            if line.startswith("STATUS=")
+        ),
+        out.returncode,  # `exit 1` inside the function ends the probe before STATUS prints
+    )
+    asked = [line for line in calls.read_text(encoding="utf-8").splitlines() if line]
+    return status, out.stdout, asked
+
+
+# What `docker compose config` prints for a stack that pins two names, and the
+# label answers `docker container inspect` gives for each ownership case.
+_CONFIG = (
+    'echo "services:"; echo "  db:"; echo "    container_name: ac-database"; '
+    'echo "  world:"; echo "    container_name: ac-worldserver"'
+)
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_a_name_held_by_another_install_is_refused_and_the_other_install_is_named(
+    tmp_path: Path, script_name: str
+) -> None:
+    """The daemon's error names a container; the user needs the other server's folder.
+
+    Two installs of the same game cannot coexist while `container_name:` pins
+    the names host-wide, and the second one only finds out after a 2-4 hour
+    build, from "Conflict. The container name "/ac-database" is already in
+    use". Hit on yulon-ubuntu and yulon-arch the same day (2026-08-28), both
+    from a stopped stack left by an earlier install. Refuse BEFORE the build,
+    and say whose it is.
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    target = tmp_path / "new-install"
+    target.mkdir()
+    stub = (
+        f'case "$*" in "compose config") {_CONFIG};; '
+        '"container inspect ac-database") return 0;; '
+        '"container inspect ac-database --format"*) echo /home/pk/other-install;; '
+        '"container inspect ac-worldserver") return 1;; '
+        "esac"
+    )
+
+    status, said, asked = _refuse_foreign_containers(script, target, tmp_path / "calls", stub=stub)
+
+    assert status == 1, f"{script_name}: a foreign container was not refused:\n{said}"
+    assert "ERROR" in said and "ac-database" in said
+    assert "/home/pk/other-install" in said, f"{script_name}: did not name the owner:\n{said}"
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_this_installs_own_containers_do_not_refuse_it(tmp_path: Path, script_name: str) -> None:
+    """Ownership is the compose working-dir label, so the same folder is never "foreign"."""
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    target = tmp_path / "mine"
+    target.mkdir()
+    here = str(target.resolve())
+    stub = (
+        f'case "$*" in "compose config") {_CONFIG};; '
+        '"container inspect "*" --format"*) echo ' + here + ";; "
+        '"container inspect "*) return 0;; '
+        "esac"
+    )
+
+    status, said, _ = _refuse_foreign_containers(script, target, tmp_path / "calls", stub=stub)
+
+    assert status == 0, f"{script_name}: refused its own containers:\n{said}"
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_names_nobody_holds_pass_straight_through(tmp_path: Path, script_name: str) -> None:
+    """The ordinary first install: names declared, none exist yet."""
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    target = tmp_path / "fresh"
+    target.mkdir()
+    stub = f'case "$*" in "compose config") {_CONFIG};; "container inspect "*) return 1;; esac'
+
+    status, said, asked = _refuse_foreign_containers(script, target, tmp_path / "calls", stub=stub)
+
+    assert status == 0, f"{script_name}: a clean host was refused:\n{said}"
+    assert any(a.startswith("container inspect ac-database") for a in asked)
+
+
 _SELINUX_PROBE = """
 set -u
 print_info() { :; }

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -1625,6 +1625,69 @@ def _shell_function_bodies(lines: list[str]) -> dict[str, range]:
     return bodies
 
 
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_declining_to_start_fresh_is_not_reported_as_a_successful_install(
+    script_name: str,
+) -> None:
+    """Answering "n" to "Remove it and start fresh?" must not exit 0.
+
+    A zero exit is read as SUCCESS by the caller. `catalog_view.py` then pins a
+    compose project name into a folder holding no server and grows a tab for
+    one that was never built - and `docker.py` records that such a pin is
+    inherited by any COPY of the folder, so Stop in the copy can stop the
+    original's server. Reproduced on yulon-arch (2026-08-28): a build killed
+    mid-compile was retried into the same folder, and the run logged "install
+    finished" having done nothing at all.
+
+    Structural rather than behavioural, deliberately and with the cost stated:
+    the branch sits inside `install_server()` after `install_docker`/
+    `install_git`, so reaching it for real means running an installer. What is
+    asserted instead is the shape that carries the bug - which exit follows the
+    decline - with comments stripped first, because a test that a comment can
+    satisfy is how 80fb68a9 earned a green run for a fix it had not made.
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    lines = script.read_text(encoding="utf-8").splitlines()
+    body = _shell_function_bodies(lines).get("install_server")
+    assert body is not None, f"{script_name}: no install_server() to read"
+
+    code = [
+        (number, lines[number - 1].strip())
+        for number in body
+        if lines[number - 1].strip() and not lines[number - 1].strip().startswith("#")
+    ]
+    asked = [
+        i for i, (_, text) in enumerate(code) if 'ask_yes_no "Remove it and start fresh?"' in text
+    ]
+    assert len(asked) == 1, f"{script_name}: expected one start-fresh prompt, found {len(asked)}"
+
+    after = code[asked[0] :]
+    else_at = next(i for i, (_, text) in enumerate(after) if text == "else")
+    exit_number, exit_text = next(
+        (number, text) for number, text in after[else_at:] if text.startswith("exit ")
+    )
+
+    assert exit_text != "exit 0", (
+        f"{script_name}:{exit_number}: declining exits 0, so a caller records an install "
+        f"that never happened"
+    )
+    assert exit_text == "exit 1", f"{script_name}:{exit_number}: unexpected exit {exit_text!r}"
+
+    # Reported as an error, not as information: the app shows the script's last
+    # words verbatim when it exits non-zero (`installer.py`'s CalledProcessError
+    # branch), so this is the sentence the user is left holding.
+    said = [text for _, text in after[else_at:]]
+    assert any(text.startswith("print_error ") for text in said), (
+        f"{script_name}: the decline branch never calls print_error, so a failure "
+        f"is announced in the tone of a status update"
+    )
+
+
 def _catalog_installers() -> list[Path]:
     from yulon import resources
 

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -553,6 +553,168 @@ def test_the_installers_reusable_check_fails_closed(tmp_path: Path, script_name:
     assert _dir_is_reusable(script, tmp_path / "does-not-exist") == "PROTECTED"
 
 
+# `docker` stubs for the probe below: what the compose FILE names, with the
+# image-store answer left to each test.
+_STUB_BUILT = (
+    'case "$*" in ' '"compose config --images") echo acore/ac-wotlk-worldserver:master;; ' "esac"
+)
+_STUB_RENAMED = (
+    'case "$*" in ' '"compose config --images") echo example.test/renamed-worldserver:v9;; ' "esac"
+)
+
+
+_IMAGES_PROBE = """
+set -u
+docker() { echo "$*" >>"$CALLS"; %(stub)s; }
+%(body)s
+if compiled_images_present "$1"; then echo YES; else echo NO; fi
+"""
+
+
+def _compiled_images_present(
+    script: Path, target: Path, calls: Path, *, stub: str
+) -> tuple[str, list[str]]:
+    """Run the installer's own `compiled_images_present`, and report what it ASKED.
+
+    Lifted out of the shipped script, like `_dir_is_reusable` above, so this
+    cannot pass against a copy that has drifted. The argv matters as much as the
+    answer here: the bug being pinned is not a wrong verdict but the wrong
+    QUESTION - `docker compose images` asks about a project's containers when
+    what is meant is "does this image exist".
+    """
+    body = script.read_text(encoding="utf-8")
+    start = body.index("compiled_images_present() {")
+    end = body.index("\n}", start) + 2
+    calls.write_text("", encoding="utf-8")
+    probe = _IMAGES_PROBE % {"stub": stub, "body": body[start:end]}
+    out = subprocess.run(
+        ["bash", "-c", probe, "probe", str(target)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"PATH": os.environ.get("PATH", ""), "CALLS": str(calls)},
+    )
+    # An unlifted callee is `command not found`, and bash's 127 is
+    # indistinguishable from an honest "no" to every caller here.
+    assert "command not found" not in out.stderr, (
+        f"{script.name}: the probe is missing a function the shipped code calls, "
+        f"so its result means nothing:\n{out.stderr.strip()}"
+    )
+    return out.stdout.strip(), [
+        line for line in calls.read_text(encoding="utf-8").splitlines() if line
+    ]
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_a_finished_build_is_recognised_when_no_containers_exist(
+    tmp_path: Path, script_name: str
+) -> None:
+    """A build with no containers must not read as "nothing was built".
+
+    `docker compose images` reports the images of a project's EXISTING
+    CONTAINERS, not the image store. A folder whose compile finished but whose
+    `up` never ran has no containers, so it answered nothing - and the branch
+    downstream then offers to delete the folder and recompile. Measured on
+    yulon-arch (2026-08-28): `up` failed on a container-name collision and the
+    installer offered to throw away a good 35-minute build.
+
+    The three scripts are separate files that have diverged before, so all three
+    are checked.
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    target = tmp_path / "server"
+    target.mkdir()
+
+    answer, asked = _compiled_images_present(
+        script,
+        target,
+        tmp_path / "calls",
+        stub=_STUB_BUILT,
+    )
+
+    assert answer == "YES", f"{script_name}: a finished build was not recognised"
+    assert any(
+        call.startswith("image inspect ") for call in asked
+    ), f"{script_name}: never asked the image store; it asked {asked}"
+    assert not any(
+        "compose images" in call for call in asked
+    ), f"{script_name}: still asks `compose images`, which answers about containers: {asked}"
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_a_folder_with_no_build_is_still_reported_as_unbuilt(
+    tmp_path: Path, script_name: str
+) -> None:
+    """The companion: asking the store must not become "yes" to everything.
+
+    Without this, the fix above would skip the compile on a folder that has
+    never been built - which is the same class of damage in the other
+    direction. `docker image inspect` exits non-zero for an image that is not
+    there, and that has to stay a "no".
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    target = tmp_path / "server"
+    target.mkdir()
+
+    answer, asked = _compiled_images_present(
+        script,
+        target,
+        tmp_path / "calls",
+        stub=(
+            'case "$*" in '
+            '"compose config --images") echo acore/ac-wotlk-worldserver:master;; '
+            '"image inspect acore/ac-wotlk-worldserver:master") return 1;; '
+            "esac"
+        ),
+    )
+
+    assert answer == "NO", f"{script_name}: an unbuilt folder was reported as built"
+    assert any(call.startswith("image inspect ") for call in asked)
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="needs a POSIX shell")
+@pytest.mark.parametrize(
+    "script_name",
+    ["install-wow-wotlk.sh", "install-wow-wotlk-fedora.sh", "install-wow-wotlk-ubuntu.sh"],
+)
+def test_the_image_name_is_read_from_the_compose_file(tmp_path: Path, script_name: str) -> None:
+    """The name is derived from the install, not written down here.
+
+    Hardcoding `acore/ac-wotlk-worldserver:master` in the script would go stale
+    the first time upstream moved the tag, and the failure would present as
+    "your build vanished, recompile for 2-4 hours".
+    """
+    script = (
+        Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
+    )
+    target = tmp_path / "server"
+    target.mkdir()
+
+    answer, asked = _compiled_images_present(
+        script,
+        target,
+        tmp_path / "calls",
+        stub=_STUB_RENAMED,
+    )
+
+    assert answer == "YES"
+    assert (
+        "image inspect example.test/renamed-worldserver:v9" in asked
+    ), f"{script_name}: did not inspect the image the compose file named: {asked}"
+
+
 _SELINUX_PROBE = """
 set -u
 print_info() { :; }

--- a/pylauncher/tests/test_installer.py
+++ b/pylauncher/tests/test_installer.py
@@ -1514,14 +1514,40 @@ def test_the_relabel_also_runs_on_the_branch_that_reuses_an_existing_build(
         Path(__file__).resolve().parents[1] / "catalog" / "installers" / "wow-wotlk" / script_name
     )
     text = script.read_text(encoding="utf-8")
-    reuse = text[text.index("Skipping compile") : text.index("Skipping compile") + 1200]
-    reuse = reuse[: reuse.index("return 0")]
+    # Anchored on the branch CONDITION, not on the message it prints. This test
+    # used to find the branch by the words "Skipping compile", and a reword
+    # broke it - a test that a copy edit can fail is testing the copy.
+    start = text.index('if [ "$images_state" -eq 0 ]; then')
+    # End on the `return 0` STATEMENT, not the first occurrence of the string -
+    # the branch's own comments quote it, and a substring search stops there.
+    reuse = text[start : text.index(chr(10) + "        return 0" + chr(10), start)]
     assert (
         'selinux_label_for_containers "$SERVER_DIR"' in reuse
     ), f"{script_name}: the reuse branch brings the stack up without relabelling"
     assert reuse.index('selinux_label_for_containers "$SERVER_DIR"') < reuse.index(
         "docker compose up"
     ), f"{script_name}: the relabel must run BEFORE the stack comes up"
+
+    # The same branch must not report success when `up` failed: it is the only
+    # `docker compose up` in the file that had no PIPESTATUS check, and on the
+    # fedora script (`set -o pipefail`, no `-e`) it fell through to `return 0`
+    # while `wait_for_server` greps `docker ps` host-globally and certifies the
+    # OTHER install's container (review, 2026-08-28).
+    assert (
+        "PIPESTATUS" in reuse
+    ), f"{script_name}: the reuse branch returns 0 whatever `docker compose up` did"
+    assert reuse.index("docker compose up") < reuse.index(
+        "PIPESTATUS"
+    ), f"{script_name}: the status check must come after the `up` it checks"
+    assert (
+        'refuse_foreign_containers "$SERVER_DIR"' in reuse
+    ), f"{script_name}: a failed reuse `up` does not say whose containers took the names"
+    # ...and only as a diagnosis, after the failure. An unconditional guard here
+    # would refuse a MOVED install folder, naming a path that no longer exists.
+    assert reuse.index("PIPESTATUS") < reuse.index('refuse_foreign_containers "$SERVER_DIR"'), (
+        f"{script_name}: the ownership check runs before `up` fails, so it gates the "
+        f"recovery path instead of explaining it"
+    )
 
 
 def test_installer_refuses_a_reserved_folder_before_asking_for_a_password(

--- a/pylauncher/tests/test_log_panel.py
+++ b/pylauncher/tests/test_log_panel.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 from tests.conftest import process_events
 from yulon.ui.widgets.log_panel import LogPanel
@@ -178,3 +178,164 @@ def test_the_thread_can_be_joined_without_an_event_loop(qapp: object) -> None:
     panel.run(lambda: iter(["one", "two"]))
     assert panel.wait(5000) is True, "the join timed out with nothing pumping the main thread"
     assert panel.running is False
+
+
+def test_the_worker_is_destroyed_on_the_gui_thread_not_its_own(qapp: object) -> None:
+    """Which thread runs `~QObject()` for the worker is the whole bug, so assert on it.
+
+    `thread.finished.connect(worker.deleteLater)` - the textbook pattern - ran
+    the worker's destructor on the WORKER thread during Qt's thread teardown.
+    `_StreamWorker` is a Python subclass, so that destructor needs the GIL; if
+    the GUI thread held it inside Qt's connection mutex at that instant, each
+    side held what the other needed. gdb on yulon-ubuntu (2026-08-28) caught
+    exactly that deadlock, and the same race that does not deadlock corrupted
+    memory: SIGSEGV or SIGBUS in 9 of 20 GUI-only runs under load.
+
+    A race is not a test, so this pins the invariant behind it instead:
+    `destroyed` fires from inside the destructor, on whatever thread is running
+    it, and a direct connection delivers it there. Old code: the worker's
+    thread. Fixed code: this one.
+    """
+    import threading
+
+    from PySide6.QtCore import Qt
+
+    from yulon.ui.widgets.log_panel import LogPanel
+
+    panel = LogPanel()
+    assert panel.run(lambda: iter(["one line"]), title="t")
+    assert panel.wait(5000)
+    worker = panel._worker
+    assert worker is not None, "the panel must still own its worker after the job"
+
+    destroyed_on: list[int] = []
+    worker.destroyed.connect(
+        lambda *_: destroyed_on.append(threading.get_ident()),
+        Qt.ConnectionType.DirectConnection,
+    )
+    del worker
+
+    # A second run disposes of the panel's reference; `job.InFlight` drops its
+    # own once `finished` reaches `sweep()` on the GUI thread - a queued slot,
+    # so the loop has to be pumped for the destructor to run at all.
+    assert panel.run(lambda: iter(["two"]), title="t")
+    assert panel.wait(5000)
+    _pump_until(qapp, lambda: bool(destroyed_on))
+
+    assert destroyed_on, "the first worker was never destroyed"
+    assert (
+        destroyed_on[0] == threading.get_ident()
+    ), "the worker was destroyed on a thread other than the GUI thread"
+
+
+def test_a_finished_job_leaves_a_live_worker_not_a_dangling_wrapper(qapp: object) -> None:
+    """The panel kept `self._worker` AND handed it to `deleteLater` - one had to give.
+
+    Under the old code the deferred delete destroyed the C++ object while the
+    Python attribute still pointed at it; shiboken then reports the wrapper as
+    invalid. Now Python is the sole owner until `_dispose_last_job()`.
+    """
+    import shiboken6
+
+    from yulon.ui.widgets.log_panel import LogPanel
+
+    panel = LogPanel()
+    assert panel.run(lambda: iter(["x"]), title="t")
+    assert panel.wait(5000)
+    qapp.processEvents()  # type: ignore[attr-defined]  # give any deferred delete its chance to run
+
+    assert panel._worker is not None
+    assert shiboken6.isValid(panel._worker), "the worker's C++ side was deleted out from under it"
+
+
+def _pump_until(qapp: object, done: Callable[[], bool], tries: int = 50) -> None:
+    """Pump the GUI event loop until `done()` - queued slots need a running loop."""
+    for _ in range(tries):
+        qapp.processEvents()  # type: ignore[attr-defined]
+        if done():
+            return
+
+
+def test_a_panel_dropped_before_its_thread_runs_does_not_leave_the_worker_dead(
+    qapp: object,
+) -> None:
+    """The crash, from a native backtrace: `QThread::started` -> `worker.run` on freed memory.
+
+    Between `thread.start()` and the OS scheduling the thread there is a window,
+    and in it the panel holding the only reference to the worker can be
+    garbage-collected. Python owns an unparented QObject, so the worker dies
+    with the panel; the thread then wakes, PySide looks `run` up on it, and
+    `QMetaMethod::name()` reads freed memory. SIGBUS on yulon-ubuntu under gdb
+    (2026-08-28), 100% of runs; 1 in 20 idle, 9 in 20 under load - the window
+    is scheduling latency. Closing a tab right after "Follow worldserver log" is
+    the same sequence in the app.
+
+    Held open here with a gate the source blocks on, so the panel can be dropped
+    while the job is provably still in flight. Under the old code this test does
+    not fail - the process dies.
+    """
+    import gc
+    import threading
+    import weakref
+
+    from yulon.ui.widgets.log_panel import LogPanel
+
+    gate = threading.Event()
+
+    def source() -> Iterator[str]:
+        gate.wait(5.0)
+        yield "released"
+
+    panel = LogPanel()
+    assert panel.run(source, title="t")
+    thread = panel._thread
+    assert thread is not None
+    worker_ref = weakref.ref(panel._worker)  # type: ignore[arg-type]
+    del panel
+    gc.collect()
+
+    assert worker_ref() is not None, "the worker died with the panel while its thread was live"
+
+    gate.set()
+    assert thread.wait(5000), "the thread never finished"
+    _pump_until(qapp, lambda: worker_ref() is None)
+    assert worker_ref() is None, "the worker was not released once its thread finished"
+
+
+def test_a_runner_dropped_before_its_thread_runs_does_not_leave_the_worker_dead(
+    qapp: object,
+) -> None:
+    """`ThreadedJobRunner` had the identical window: `_live` died with the view."""
+    import gc
+    import threading
+    import weakref
+
+    from PySide6.QtCore import QObject
+
+    from yulon.ui.widgets.job import ThreadedJobRunner
+
+    gate = threading.Event()
+
+    def work() -> int:
+        gate.wait(5.0)
+        return 1
+
+    owner = QObject()
+    runner = ThreadedJobRunner(owner)
+    runner(work, lambda _r: None, lambda _e: None)
+    thread, worker = runner._live[0]
+    worker_ref = weakref.ref(worker)
+    del worker, runner, owner
+    gc.collect()
+
+    assert worker_ref() is not None, "the worker died with the runner while its thread was live"
+
+    gate.set()
+    # `_JobWorker` ends its thread through `done -> thread.quit`, a queued slot
+    # on the GUI thread, so the loop must be pumped for the thread to exit at
+    # all - which is what the app does, and what `ThreadedJobRunner.wait()`
+    # sidesteps by quitting explicitly. A bare `thread.wait()` here just times out.
+    _pump_until(qapp, lambda: not thread.isRunning(), tries=500)
+    assert not thread.isRunning(), "the job thread never exited"
+    _pump_until(qapp, lambda: worker_ref() is None)
+    assert worker_ref() is None

--- a/pylauncher/tests/test_maintenance.py
+++ b/pylauncher/tests/test_maintenance.py
@@ -273,6 +273,42 @@ def test_verify_dump_rejects_a_dump_of_a_different_database(tmp_path: Path) -> N
         verify_dump(path, "acore_world")
 
 
+def test_verify_dump_accepts_a_mariadb_dump_that_opens_with_the_sandbox_directive(
+    tmp_path: Path,
+) -> None:
+    r"""MariaDB 10.6+ writes a line BEFORE the banner, and it is still a real dump.
+
+    `mariadb-dump` emits `/*M!999999\- enable the sandbox mode */` as the very
+    first line, so the banner is no longer at byte 0. The header pattern was
+    anchored there, which made `verify_dump()` call every MariaDB backup "not a
+    database backup" — and because `plan_restore()`/`restore()`/`_safety_backup()`
+    share this gate, restore failed for the same reason. Found on a live Tortoise
+    server (mariadb-dump 10.6.28) on a dump that was complete, named its database
+    and ended with its trailer.
+    """
+    path = tmp_path / "20260828_150338_tw_char.sql"
+    path.write_bytes(rb"/*M!999999\- enable the sandbox mode */" + b"\n" + good_dump("acore_world"))
+
+    assert verify_dump(path, "acore_world") == path.stat().st_size
+
+
+def test_verify_dump_still_refuses_a_file_with_no_banner_anywhere(tmp_path: Path) -> None:
+    """Matching the banner at any line start must not degrade into matching nothing.
+
+    The companion to the test above: loosening the anchor is only safe while a
+    file that never says "MySQL dump"/"MariaDB dump" is still refused.
+    """
+    path = tmp_path / "20260828_150338_acore_world.sql"
+    path.write_bytes(
+        b"CREATE DATABASE `acore_world`;" + b"\n"
+        b"USE `acore_world`;" + b"\n"
+        b"-- Dump completed on 2026-08-28 15:03:38" + b"\n"
+    )
+
+    with pytest.raises(MaintenanceError, match="does not start like a mysqldump"):
+        verify_dump(path, "acore_world")
+
+
 # ----------------------------------------------------------------- restore
 
 

--- a/pylauncher/tests/test_maintenance.py
+++ b/pylauncher/tests/test_maintenance.py
@@ -292,6 +292,63 @@ def test_verify_dump_accepts_a_mariadb_dump_that_opens_with_the_sandbox_directiv
     assert verify_dump(path, "acore_world") == path.stat().st_size
 
 
+def test_verify_dump_refuses_a_file_that_merely_contains_dump_shaped_text(
+    tmp_path: Path,
+) -> None:
+    r"""A banner buried in row data is the content's, not the file's.
+
+    Accepting the MariaDB sandbox directive meant matching the banner at any
+    line start rather than at byte 0 — and left there, that also accepts a file
+    that is not a dump at all. A table of support tickets, GM notes or chat logs
+    whose free-text column holds pasted dump output near the top satisfies the
+    banner, the `USE` line and the trailer, all three, and `verify_dump()` is
+    what gates restore.
+
+    Found by an adversarial review (2026-08-28) with the working bypass below,
+    against an implementation whose own tests were green: the companion test
+    only covered a file with no banner ANYWHERE, so a banner in the wrong place
+    went unexamined.
+    """
+    path = tmp_path / "20260101_000000_acore_world.sql"
+    path.write_bytes(
+        b"-- Some other tool export, not mysqldump at all\n"
+        b"INSERT INTO support_tickets VALUES (1, 42, 'Customer pasted:\n"
+        b"-- MySQL dump 10.13  Distrib 10.6.28-MariaDB, for Linux (x86_64)\n\n"
+        b"USE `acore_world`;\n');\n"
+        b"-- filler " + b"x" * 200 + b"\n"
+        b"-- Dump completed on 2026-01-01 12:00:00\n"
+    )
+
+    # Both spellings: the database-identity check is not what stops this either.
+    with pytest.raises(MaintenanceError, match="does not start like a mysqldump"):
+        verify_dump(path)
+    with pytest.raises(MaintenanceError, match="does not start like a mysqldump"):
+        verify_dump(path, "acore_world")
+
+
+def test_verify_dump_accepts_a_banner_behind_comments_but_not_behind_sql(
+    tmp_path: Path,
+) -> None:
+    r"""What may precede the banner is exactly what a dump itself writes there.
+
+    Executable comments (`/*M!...*/`, `/*!...*/`) and `--` lines are a dump's
+    own preamble and must not disqualify it. One line of SQL in front of the
+    banner means the file started as something else.
+    """
+    commented = tmp_path / "20260101_000000_acore_auth.sql"
+    commented.write_bytes(
+        b"/*!999999 an executable comment */\n"
+        b"-- a plain comment line\n"
+        b"\n" + good_dump("acore_auth")
+    )
+    assert verify_dump(commented, "acore_auth") == commented.stat().st_size
+
+    sql_first = tmp_path / "20260101_000000_acore_world.sql"
+    sql_first.write_bytes(b"SET foreign_key_checks=0;\n" + good_dump("acore_world"))
+    with pytest.raises(MaintenanceError, match="does not start like a mysqldump"):
+        verify_dump(sql_first, "acore_world")
+
+
 def test_verify_dump_still_refuses_a_file_with_no_banner_anywhere(tmp_path: Path) -> None:
     """Matching the banner at any line start must not degrade into matching nothing.
 

--- a/pylauncher/tests/test_maintenance.py
+++ b/pylauncher/tests/test_maintenance.py
@@ -366,6 +366,34 @@ def test_verify_dump_still_refuses_a_file_with_no_banner_anywhere(tmp_path: Path
         verify_dump(path, "acore_world")
 
 
+def test_verify_dump_refuses_sql_hiding_after_a_closed_block_comment(tmp_path: Path) -> None:
+    """A `*/` mid-line hands the scan back, and what follows still has to justify itself.
+
+    The line-based preamble scan skipped any line that both opened AND closed a
+    comment, so it never looked past the terminator. That let
+    `/* ... */ DROP DATABASE unrelated;` sit above a real banner and pass
+    `verify_dump()` - and since `plan_restore()` takes its safety dump only for
+    the databases the census names on their own lines, that DROP had no backup
+    behind it. Found by an independent adversarial review (Codex), 2026-08-28.
+    """
+    path = tmp_path / "20260101_000000_acore_auth.sql"
+    path.write_bytes(
+        b"/* harmless-looking comment */ DROP DATABASE unrelated;\n" + good_dump("acore_auth")
+    )
+
+    with pytest.raises(MaintenanceError, match="does not start like a mysqldump"):
+        verify_dump(path, "acore_auth")
+
+
+def test_verify_dump_refuses_a_banner_inside_an_unterminated_comment(tmp_path: Path) -> None:
+    """An open `/*` swallows the banner, so the banner is not the file's own opening."""
+    path = tmp_path / "20260101_000000_acore_auth.sql"
+    path.write_bytes(b"/* opened and never closed\n" + good_dump("acore_auth"))
+
+    with pytest.raises(MaintenanceError, match="does not start like a mysqldump"):
+        verify_dump(path, "acore_auth")
+
+
 # ----------------------------------------------------------------- restore
 
 

--- a/pylauncher/yulon/__main__.py
+++ b/pylauncher/yulon/__main__.py
@@ -1,0 +1,19 @@
+"""`python -m yulon` — the same entry point as `main.py`.
+
+Every box in the 2026-08-28 run tried `python -m yulon` first and got
+"No module named yulon.__main__", because the entry point is the sibling
+`main.py` (which is what PyInstaller freezes). This is a redirect, not a
+second entry point, so there is nothing here for the two to disagree about.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# `main.py` sits beside the package, not inside it.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from main import main  # noqa: E402
+
+raise SystemExit(main())

--- a/pylauncher/yulon/catalog/installer.py
+++ b/pylauncher/yulon/catalog/installer.py
@@ -90,6 +90,13 @@ _ERROR_TAIL_LINES = 12
 DEFAULT_TERM = "xterm-256color"
 
 
+# The stable half of `Installer.sudo_marker`. The token after it is random and
+# per-install, so this prefix is the only part a module-level prompter can match
+# on - and matching is what keeps sudo's prompt hidden while the two y/n consent
+# rules stay visible (review, 2026-08-28).
+SUDO_PROMPT_PREFIX = "[sudo via Yu'lon "
+
+
 class InstallerError(RuntimeError):
     """The install could not start or did not finish (message is user-readable)."""
 
@@ -461,7 +468,7 @@ class Installer:
         # token matters too: this string is the LABEL of the one dialog in the
         # app that asks for the user's password, so it has to read as sudo
         # asking, not as a bare hex token (review, 2026-08-22).
-        self.sudo_marker = f"[sudo via Yu'lon {secrets.token_hex(8)}] password:"
+        self.sudo_marker = f"{SUDO_PROMPT_PREFIX}{secrets.token_hex(8)}] password:"
 
     @property
     def script(self) -> Path:
@@ -739,7 +746,7 @@ def installer_for(
 
 
 def _terminal_prompter(prompt: str) -> str:
-    """Answer the one prompt `run()` forwards - sudo's - from the terminal.
+    """Answer the prompts `run()` forwards, from the terminal.
 
     The CLI passed no `ask` at all, and `runner.interact()` writes nothing for
     a missing answer, so on any box where sudo wants a password the CLI parked
@@ -749,15 +756,24 @@ def _terminal_prompter(prompt: str) -> str:
     Never returns None. Off a terminal there is nothing to type, and an empty
     answer is the failure path that ENDS: sudo refuses it, retries, gives up,
     and the script's own guard exits non-zero with "Could not cache sudo
-    credentials". A failure the user can read beats a hang they cannot.
+    credentials"; a y/n rule reads it as "no". A failure the user can read beats
+    a hang they cannot.
     """
     import getpass
     import sys
 
-    if sys.stdin.isatty():
+    # Only sudo's own prompt is hidden. `ask` is consulted for EVERY ASK_THE_USER
+    # rule, and the other two are consent questions - "Add '$USER' to the docker
+    # group (grants root-equivalent access)?" and "Install Docker via rpm-ostree
+    # and reboot now?" - which a person must be able to see themselves answering.
+    # `script_env()` builds sudo's prompt with a random marker, so the two are
+    # told apart exactly rather than guessed (review, 2026-08-28).
+    if not sys.stdin.isatty():
+        sys.stderr.write(f"no terminal to answer {prompt.strip()!r}; declining\n")
+        return ""
+    if SUDO_PROMPT_PREFIX in prompt:
         return getpass.getpass(prompt + " ")
-    sys.stderr.write("sudo asked for a password and there is no terminal to type one on\n")
-    return ""
+    return input(prompt + " ")
 
 
 def _main(argv: list[str] | None = None) -> int:

--- a/pylauncher/yulon/catalog/installer.py
+++ b/pylauncher/yulon/catalog/installer.py
@@ -738,6 +738,28 @@ def installer_for(
     return Installer(entry, installers_root=installers_root, platform_id=platform_id)
 
 
+def _terminal_prompter(prompt: str) -> str:
+    """Answer the one prompt `run()` forwards - sudo's - from the terminal.
+
+    The CLI passed no `ask` at all, and `runner.interact()` writes nothing for
+    a missing answer, so on any box where sudo wants a password the CLI parked
+    at the prompt forever: no timeout, no error, a process that never exits.
+    Reproduced on yulon-arch (2026-08-28), which is not passwordless.
+
+    Never returns None. Off a terminal there is nothing to type, and an empty
+    answer is the failure path that ENDS: sudo refuses it, retries, gives up,
+    and the script's own guard exits non-zero with "Could not cache sudo
+    credentials". A failure the user can read beats a hang they cannot.
+    """
+    import getpass
+    import sys
+
+    if sys.stdin.isatty():
+        return getpass.getpass(prompt + " ")
+    sys.stderr.write("sudo asked for a password and there is no terminal to type one on\n")
+    return ""
+
+
 def _main(argv: list[str] | None = None) -> int:
     """CLI entry point: `python -m yulon.catalog.installer <game-id> [options]`.
 
@@ -762,12 +784,16 @@ def _main(argv: list[str] | None = None) -> int:
     except KeyError:
         sys.stderr.write(f"unknown game {args.game!r}\n")
         return 2
-    installer = Installer(entry, installers_root=args.installers_root)
+    # `installer_for()`, not `Installer(...)`: the CLI used to construct the
+    # script engine directly, so it could never exercise `NativeInstaller` on
+    # any platform, and "I ran the install through the CLI" proved less than it
+    # sounded like it did. It now dispatches exactly as the Install button does.
+    installer = installer_for(entry, installers_root=args.installers_root)
     options = InstallOptions(
         server_dir=args.server_dir, client_dir=args.client_dir, reinstall=args.reinstall
     )
     try:
-        for line in installer.run(options):
+        for line in installer.run(options, ask=_terminal_prompter):
             sys.stdout.write(line + "\n")
             sys.stdout.flush()
     except InstallerError as exc:

--- a/pylauncher/yulon/catalog/native.py
+++ b/pylauncher/yulon/catalog/native.py
@@ -386,6 +386,11 @@ class NativeInstaller:
             # would be refused by the record of the failure it is retrying.
             self._record_error(server_dir, state, str(exc))
             raise
+        # The bash path logs `install of <id> finished` (installer.py); this path
+        # logged nothing at the end, so the only sign a run had ended was the
+        # compose-project pin - which is how a tester on yulon-win11 (2026-08-28)
+        # read a seven-minute readiness wait as "the install was not remembered".
+        logger.info(f"install of {self.entry.id} finished")
         yield f"{self.entry.name} is installed and running in {server_dir}"
 
     # -- preflight -------------------------------------------------------

--- a/pylauncher/yulon/controller_wow_wotlk/maintenance.py
+++ b/pylauncher/yulon/controller_wow_wotlk/maintenance.py
@@ -144,7 +144,16 @@ CLIENT_CACHE_NOTE = (
 # can exit 0 on a dump that stopped early, and the guide already knows the file
 # has to be checked ("If the file is missing or 0 bytes, something went wrong").
 # A size check alone passes a dump that died after the first table.
-_DUMP_HEADER = re.compile(rb"^--\s+(MySQL|MariaDB)\s+dump\s")
+#
+# The banner is matched at ANY line start, not at byte 0, because it is no longer
+# the first thing in the file. MariaDB 10.6+ writes a sandbox-mode directive ahead
+# of it - `/*M!999999\- enable the sandbox mode */` - so an anchored match rejected
+# every backup taken against a MariaDB server as "not a database backup", and
+# `verify_dump()` gates restore as well as backup. Observed on a live Tortoise
+# server (mariadb-dump 10.6.28, 2026-08-28) on a dump that was complete and ended
+# with its trailer. `_USE_LINE` and `_CREATE_DB_LINE` below already spell a
+# line-start this way.
+_DUMP_HEADER = re.compile(rb"(?:\A|\n)--\s+(MySQL|MariaDB)\s+dump\s")
 _DUMP_TRAILER = b"-- Dump completed"
 
 # Which schemas a dump file will write into. `USE` is what `--databases` always
@@ -575,7 +584,7 @@ def verify_dump(path: Path, database: str | None = None) -> int:
         raise MaintenanceError(f"could not read {path}: {exc}") from exc
     if size == 0:
         raise MaintenanceError(f"{path.name} is empty, so nothing was dumped")
-    if not _DUMP_HEADER.match(head):
+    if not _DUMP_HEADER.search(head):
         raise MaintenanceError(
             f"{path.name} does not start like a mysqldump, so it is not a database backup"
         )

--- a/pylauncher/yulon/controller_wow_wotlk/maintenance.py
+++ b/pylauncher/yulon/controller_wow_wotlk/maintenance.py
@@ -619,26 +619,47 @@ def _banner_is_the_files_own(head: bytes) -> bool:
     match = _DUMP_HEADER.search(head)
     if match is None:
         return False
-    # `/* ... */` is tracked as a BLOCK, not a line: a `/*` with no `*/` on its
-    # own line opens a comment that runs to the closing `*/`, and a banner inside
-    # an open comment is content, not the file's opening (review, 2026-08-28).
-    # mysqldump's own preamble only ever uses the single-line `/*!...*/` form, so
-    # a real dump never opens a block here.
-    in_block = False
-    for line in head[: match.start()].splitlines():
-        text = line.strip()
-        if in_block:
-            if b"*/" in text:
-                in_block = False
-            continue
-        if not text or text.startswith(b"--"):
-            continue
-        if text.startswith(b"/*"):
-            if b"*/" not in text:
-                in_block = True
-            continue
-        return False
-    return not in_block
+    return _only_dump_preamble(head[: match.start()])
+
+
+def _only_dump_preamble(prefix: bytes) -> bool:
+    """Is everything above the banner a comment a dump itself would write?
+
+    Scanned as BYTES, not line by line. The line-based version this replaces
+    accepted `/* anything */ DROP DATABASE other;` - it saw a line that both
+    opened and closed a comment, skipped the whole line, and never looked at the
+    SQL after the terminator. So a file could carry executable statements above a
+    banner that `verify_dump()` then vouched for, against a database the census
+    below never names and `plan_restore()` therefore takes no safety dump of.
+    Found by an independent adversarial review (Codex), 2026-08-28, with a
+    working bypass.
+
+    Walking the bytes means every `*/` hands the scan back where it stopped, and
+    whatever follows it has to be whitespace or another comment in its own right.
+    """
+    index, end = 0, len(prefix)
+    while index < end:
+        if prefix[index : index + 1].isspace():
+            index += 1
+        elif prefix.startswith(b"--", index):
+            newline = prefix.find(b"\n", index)
+            if newline == -1:
+                # `_DUMP_HEADER` matches at `\A` or after a newline, and the
+                # newline is part of the match - so a `--` comment with no line
+                # break left in the prefix ends exactly where the banner's own
+                # line begins. There is nothing after it to check.
+                return True
+            index = newline + 1
+        elif prefix.startswith(b"/*", index):
+            close = prefix.find(b"*/", index + 2)
+            if close == -1:
+                # An unterminated block comment swallows the banner: it is text
+                # inside a comment, not the file's own opening.
+                return False
+            index = close + 2
+        else:
+            return False
+    return True
 
 
 def _read_edge(path: Path, offset: int) -> bytes:

--- a/pylauncher/yulon/controller_wow_wotlk/maintenance.py
+++ b/pylauncher/yulon/controller_wow_wotlk/maintenance.py
@@ -619,10 +619,26 @@ def _banner_is_the_files_own(head: bytes) -> bool:
     match = _DUMP_HEADER.search(head)
     if match is None:
         return False
-    return all(
-        not line.strip() or line.lstrip().startswith((b"--", b"/*"))
-        for line in head[: match.start()].splitlines()
-    )
+    # `/* ... */` is tracked as a BLOCK, not a line: a `/*` with no `*/` on its
+    # own line opens a comment that runs to the closing `*/`, and a banner inside
+    # an open comment is content, not the file's opening (review, 2026-08-28).
+    # mysqldump's own preamble only ever uses the single-line `/*!...*/` form, so
+    # a real dump never opens a block here.
+    in_block = False
+    for line in head[: match.start()].splitlines():
+        text = line.strip()
+        if in_block:
+            if b"*/" in text:
+                in_block = False
+            continue
+        if not text or text.startswith(b"--"):
+            continue
+        if text.startswith(b"/*"):
+            if b"*/" not in text:
+                in_block = True
+            continue
+        return False
+    return not in_block
 
 
 def _read_edge(path: Path, offset: int) -> bytes:

--- a/pylauncher/yulon/controller_wow_wotlk/maintenance.py
+++ b/pylauncher/yulon/controller_wow_wotlk/maintenance.py
@@ -584,7 +584,7 @@ def verify_dump(path: Path, database: str | None = None) -> int:
         raise MaintenanceError(f"could not read {path}: {exc}") from exc
     if size == 0:
         raise MaintenanceError(f"{path.name} is empty, so nothing was dumped")
-    if not _DUMP_HEADER.search(head):
+    if not _banner_is_the_files_own(head):
         raise MaintenanceError(
             f"{path.name} does not start like a mysqldump, so it is not a database backup"
         )
@@ -598,6 +598,31 @@ def verify_dump(path: Path, database: str | None = None) -> int:
             f"{path.name} does not name {database}; it is a dump of something else"
         )
     return size
+
+
+def _banner_is_the_files_own(head: bytes) -> bool:
+    """Is the dump banner this file's OWN opening, or just text inside it?
+
+    Matching the banner at any line start is what lets a MariaDB dump through
+    (10.6+ writes a sandbox directive ahead of it). Left at that, it also lets
+    through a file that merely CONTAINS dump-shaped text - a table of support
+    tickets or chat logs whose free-text column holds pasted dump output near
+    the top would satisfy the banner, the `USE` line and the trailer, and
+    `verify_dump()` gates restore. Found by an adversarial review, 2026-08-28,
+    with a working bypass.
+
+    So the banner may be preceded only by what a dump itself writes there:
+    executable comments (`/*M!...*/`, `/*!...*/`) and `--` comment lines, blank
+    or otherwise. One line of SQL or free text in front of it means the banner
+    belongs to the content, not to the file.
+    """
+    match = _DUMP_HEADER.search(head)
+    if match is None:
+        return False
+    return all(
+        not line.strip() or line.lstrip().startswith((b"--", b"/*"))
+        for line in head[: match.start()].splitlines()
+    )
 
 
 def _read_edge(path: Path, offset: int) -> bytes:

--- a/pylauncher/yulon/docker.py
+++ b/pylauncher/yulon/docker.py
@@ -215,7 +215,11 @@ def _cli_missing(proc: subprocess.CompletedProcess[str]) -> bool:
 
 
 def _run(
-    argv: list[str], cwd: Path | None = None, *, wsl_distro: str | None = None
+    argv: list[str],
+    cwd: Path | None = None,
+    *,
+    timeout: float | None = None,
+    wsl_distro: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run `docker <argv...>`; raise `DockerCommandError` on non-zero exit.
 
@@ -225,7 +229,7 @@ def _run(
     in front of the sentence is noise to the user reading it in a dialog, and
     `_docker()` has already put the command in the log at DEBUG.
     """
-    proc = _docker(argv, cwd=cwd, wsl_distro=wsl_distro)
+    proc = _docker(argv, cwd=cwd, timeout=timeout, wsl_distro=wsl_distro)
     if _cli_missing(proc):
         raise DockerCliMissingError(platform.DOCKER_CLI_MISSING_HELP)
     if proc.returncode != 0:
@@ -786,6 +790,21 @@ def remove_staged(spec: ContainerSpec, server_dir: Path, *, wsl_distro: str | No
 
     logger.info(f"remove_staged(): removed {len(before)} container(s); volumes untouched")
     return True
+
+
+# How long `status()` waits for `docker ps`. It is a local call, so a healthy
+# daemon answers in milliseconds and a cold Docker Desktop in a few seconds -
+# but an unhealthy one has no upper bound, and without a deadline the GUI's
+# five-second poll wedges PERMANENTLY rather than slowly: `refresh_status()` sets
+# `_status_pending` and clears it only from a callback, so a call that never
+# returns makes every later poll return early at the guard, and the Server tab
+# reads "status: unknown" until the app is restarted. Measured on yulon-win11
+# 2026-08-28: `docker ps` hung 8+ minutes under memory pressure, and 125 seconds
+# on an earlier run there. 30s is six polls - far above a slow honest answer and
+# far below either of those. A timeout arrives as a non-zero CompletedProcess
+# (see `_docker`), so it becomes DockerCommandError, so `_status_failed()` clears
+# the flag and names the reason, and the next poll simply tries again.
+STATUS_TIMEOUT_SECONDS = 30.0
 
 
 STOP_GRACE_SECONDS = 300
@@ -1622,7 +1641,9 @@ def status(*, wsl_distro: str | None = None) -> list[str]:
             `_status_safe()`/the polling helpers below instead.
     """
     logger.debug("status() called")
-    proc = _run(["ps", "--format", "{{.Names}}"], wsl_distro=wsl_distro)
+    proc = _run(
+        ["ps", "--format", "{{.Names}}"], timeout=STATUS_TIMEOUT_SECONDS, wsl_distro=wsl_distro
+    )
     return [name for name in proc.stdout.splitlines() if name.strip()]
 
 

--- a/pylauncher/yulon/ui/widgets/job.py
+++ b/pylauncher/yulon/ui/widgets/job.py
@@ -111,12 +111,25 @@ class InFlight(QObject):
         self._pairs = [pair for pair in self._pairs if pair[0].isRunning()]
 
     def wait_all(self, timeout_ms: int = 10_000) -> bool:
-        """Join everything still running (app shutdown). True if all finished in time."""
+        """Join everything still running (app shutdown). True if all finished in time.
+
+        `quit()` ends an event loop; it cannot interrupt a `run()` still inside
+        its work - a blocked `subprocess.run`, a `docker logs -f` with no new
+        line. A pair that does not finish is left held, and Qt's abort at
+        interpreter exit (a QThread destroyed while running) follows. That is
+        the pre-existing contract and this class does not change it; what it
+        can do is put a name in the log first, so the abort is not a mystery.
+        """
         done = True
-        for thread, _worker in list(self._pairs):
+        for thread, worker in list(self._pairs):
             if thread.isRunning():
                 thread.quit()
-                done = bool(thread.wait(timeout_ms)) and done
+                if not thread.wait(timeout_ms):
+                    done = False
+                    logger.warning(
+                        f"a background job did not finish within {timeout_ms} ms at exit: "
+                        f"{type(worker).__name__}; Qt will abort when it is destroyed"
+                    )
         self.sweep()
         return done
 

--- a/pylauncher/yulon/ui/widgets/job.py
+++ b/pylauncher/yulon/ui/widgets/job.py
@@ -64,6 +64,74 @@ class _JobWorker(QObject):
             self.done.emit(result)
 
 
+class InFlight(QObject):
+    """Owns every started (thread, worker) pair until the thread has FINISHED.
+
+    The crash this exists for, from a native backtrace on yulon-ubuntu
+    (2026-08-28): a worker QThread is scheduled by the OS, emits `started`,
+    PySide dispatches it to `worker.run` - and dies in `QMetaMethod::name()`
+    because the worker's C++ object is already gone. Between `thread.start()`
+    and the OS actually running the thread there is a window, and in it the
+    panel or view that held the only Python reference to the worker can be
+    garbage-collected. Python owns an unparented QObject, so the worker is
+    deleted with it; the thread then wakes and calls a method on freed memory.
+    SIGSEGV or SIGBUS, single Python frame on the main thread (it was waiting
+    for the GIL the dying thread held), no frame on the worker thread at all.
+
+    Load-dependent, because the window is scheduling latency: 1 in 20 runs on
+    an idle box, 9 in 20 with a worldserver running beside it, and 100% under
+    gdb, which is what finally produced the backtrace. The same sequence in
+    the app is closing a tab right after pressing "Follow worldserver log".
+
+    So a started pair is held HERE, by an object that lives on the GUI thread
+    and outlives any panel, until `finished` says the thread is done - and only
+    then dropped, on this thread, where deleting a QObject whose thread has
+    exited is safe. `sweep()` is a Slot, so `thread.finished` reaches it as a
+    queued call on the GUI thread rather than on the thread that is finishing;
+    dropping the pair from the worker thread itself would be the OTHER crash
+    (see `LogPanel._dispose_last_job`).
+
+    The threads are also created without a parent. A QThread parented to a
+    panel is destroyed with the panel, and a QThread destroyed while running
+    ends the process rather than warning - so the panel must not be able to
+    take the thread down with it either.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._pairs: list[tuple[QThread, QObject]] = []
+
+    def hold(self, thread: QThread, worker: QObject) -> None:
+        self._pairs.append((thread, worker))
+        thread.finished.connect(self.sweep)
+
+    @Slot()
+    def sweep(self) -> None:
+        """Drop every pair whose thread has finished. Runs on the GUI thread."""
+        self._pairs = [pair for pair in self._pairs if pair[0].isRunning()]
+
+    def wait_all(self, timeout_ms: int = 10_000) -> bool:
+        """Join everything still running (app shutdown). True if all finished in time."""
+        done = True
+        for thread, _worker in list(self._pairs):
+            if thread.isRunning():
+                thread.quit()
+                done = bool(thread.wait(timeout_ms)) and done
+        self.sweep()
+        return done
+
+
+_in_flight: InFlight | None = None
+
+
+def in_flight() -> InFlight:
+    """The process-wide holder, made on first use so it lives on the GUI thread."""
+    global _in_flight
+    if _in_flight is None:
+        _in_flight = InFlight()
+    return _in_flight
+
+
 class ThreadedJobRunner:
     """Runs each call on its own `QThread`; call it like a function.
 
@@ -78,10 +146,12 @@ class ThreadedJobRunner:
 
     def __call__(self, work: Work, on_done: OnDone, on_error: OnError) -> None:
         self._prune()
-        thread = QThread(self._parent)
+        # No parent, and held by `in_flight()` until finished - see `InFlight`.
+        thread = QThread()
         worker = _JobWorker(work)
         worker.moveToThread(thread)
         self._live.append((thread, worker))
+        in_flight().hold(thread, worker)
         thread.started.connect(worker.run)
         worker.done.connect(on_done)
         worker.failed.connect(on_error)

--- a/pylauncher/yulon/ui/widgets/log_panel.py
+++ b/pylauncher/yulon/ui/widgets/log_panel.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import QHBoxLayout, QLabel, QPlainTextEdit, QPushButton, 
 
 from yulon import runner
 from yulon.log import get_logger
+from yulon.ui.widgets.job import in_flight
 
 logger = get_logger(__name__)
 
@@ -178,9 +179,13 @@ class LogPanel(QWidget):
         self._stop_requested = False
         self._status.setText(title)
         self._stop_button.setEnabled(True)
-        thread = QThread(self)
+        # No parent, and held by `in_flight()` until finished: a panel dropped
+        # between `start()` and the OS scheduling the thread must not take the
+        # worker down with it - see `job.InFlight`.
+        thread = QThread()
         worker = _StreamWorker(source)
         worker.moveToThread(thread)
+        in_flight().hold(thread, worker)
         thread.started.connect(worker.run)
         worker.line.connect(self.append)
         worker.finished.connect(self._on_finished)

--- a/pylauncher/yulon/ui/widgets/log_panel.py
+++ b/pylauncher/yulon/ui/widgets/log_panel.py
@@ -173,6 +173,7 @@ class LogPanel(QWidget):
         if self.running:
             logger.debug("log panel busy; run() ignored")
             return False
+        self._dispose_last_job()
         self._cancel = cancel
         self._stop_requested = False
         self._status.setText(title)
@@ -184,11 +185,53 @@ class LogPanel(QWidget):
         worker.line.connect(self.append)
         worker.finished.connect(self._on_finished)
         worker.finished.connect(thread.quit)
-        thread.finished.connect(worker.deleteLater)
+        # Deliberately NOT `thread.finished.connect(worker.deleteLater)`, the
+        # textbook pattern - see `_dispose_last_job()` for why it is the segfault.
         self._thread, self._worker = thread, worker
         thread.start()
         self.run_started.emit()
         return True
+
+    def _dispose_last_job(self) -> None:
+        """Delete the previous job's worker HERE, on the GUI thread, once its thread is gone.
+
+        This used to be `thread.finished.connect(worker.deleteLater)` - the
+        textbook Qt pattern, and it is the segfault. `deleteLater` posts the
+        delete to the object's OWN thread, and Qt runs it inside that thread's
+        final cleanup (`QThreadPrivate::finish`) - on the worker thread.
+        `_StreamWorker` is a Python subclass, so tearing it down needs the GIL.
+        If the GUI thread holds the GIL at that instant and is inside Qt's
+        connection mutex - delivering a signal into a Python slot, which is
+        most of what a GUI thread does - each side holds what the other needs.
+
+        gdb on yulon-ubuntu, 2026-08-28: the main thread in
+        `cleanOrphanedConnectionsImpl` -> `QBasicMutex::lockInternal`, reached
+        from a slider `rangeChanged` into a Python slot; a thread named
+        "QThread" in `~QObject()` -> `Shiboken::GilState::acquire`. That is the
+        deadlock. The same race that does not deadlock corrupts memory instead:
+        9 of 20 GUI-only runs died with SIGSEGV or SIGBUS, always at the
+        boundary where one test module's last worker finished while the next
+        module's fixture was building a window. Removing `processEvents()` from
+        that fixture's teardown changed nothing, which is how the suspect moved
+        from the fixture to here.
+
+        And the panel already held `self._worker`, so the deferred delete was
+        destroying the C++ side of an object Python still pointed at.
+
+        Deleting from the GUI thread is safe once the worker's thread has
+        finished: an object whose thread is gone has no affinity, and Qt permits
+        its destruction from any thread. `running` is false to reach here, and
+        `wait()` turns "not running" into "fully exited" rather than "about to".
+        The QThread object itself lives on the GUI thread - it was created here -
+        so ITS deferred delete is a GUI-thread event and is fine.
+        """
+        thread, worker = self._thread, self._worker
+        self._thread = self._worker = None
+        if thread is None:
+            return
+        thread.wait(5000)
+        thread.deleteLater()
+        del worker  # the last Python reference; the C++ object goes with it, on this thread
 
     @Slot()
     def stop(self) -> None:

--- a/pyplan/bug-checklist-2026-08-28.md
+++ b/pyplan/bug-checklist-2026-08-28.md
@@ -1,0 +1,229 @@
+# Bug checklist — the four-platform hunt, 2026-08-28
+
+Every defect found by running Yu'lon on **Ubuntu 24.04, Fedora 44, Arch, Windows 11** and the
+physical **m910q** box, against `upstream/Yulon` (base `d576a00c`). Tick as they land.
+
+**Status key:** `[x]` fixed and verified on a real box · `[ ]` open · **drafted** = patch written,
+not yet applied · **decision** = not a fix, an owner call.
+
+Evidence for every item is in `dml-vmrun/runlogs/` (per-box reports and one file per major finding).
+Nothing here is from reading code alone — each was reproduced.
+
+---
+
+## 1. Fixed and verified — on branch `fix/ubuntu-to-green` (16 commits, CI green)
+
+These are shared fixes: found on one platform, they affect all of them.
+
+- [x] **The installer asked which containers exist and called it "was it built?"**
+  `install-wow-wotlk.sh:1249` (+ `-ubuntu.sh`, `-fedora.sh`)
+  `docker compose images` reports a project's **existing containers**, not the image store. A folder
+  whose compile finished but whose `up` never ran read as "nothing was built" — and the next branch
+  offered to delete a good 35-minute build. Now asks `config --images` (the compose file) then
+  `docker image inspect` (the store).
+  *Verified on real Docker: same folder, old check `NOT BUILT`, new check `BUILT`.*
+  **Must stay ahead of the next item** — with `reinstall` set, a wrong verdict here deletes the build.
+
+- [x] **Declining "Remove it and start fresh?" exited 0, and the app filed that as an install**
+  `installer.py:180`, `install-wow-wotlk.sh:1273`, `catalog_view.py:497`
+  Zero means success to the caller: the view pinned a compose project name into a folder holding no
+  server and grew a tab for one that was never built. `docker.py` records that such a pin is
+  inherited by any **copy** of the folder, so Stop in the copy could stop the original's server.
+  *Verified end-to-end through `Installer.run()`: before — "install finished", no error; after —
+  `InstallerError: exited with status 1`, folder untouched.*
+
+- [x] **A slow Docker daemon wedged the Server tab permanently**
+  `docker.py:1615`, `controller_view.py:445`
+  `docker ps` ran with **no timeout**. `refresh_status()` sets `_status_pending` and clears it only
+  from a callback, so a call that never returned meant every later poll bailed at the guard —
+  `status: unknown` forever, no error, nothing to click. Reproduced independently on Windows: **8+
+  minutes frozen, three manual Refresh clicks did nothing**, recovered only by killing Docker.
+  *Verified with `docker` stubbed to `sleep 3600`: before — still hanging when killed; after —
+  `DockerCommandError` at the deadline.*
+
+- [x] **The GUI test suite died in 9 of 20 runs — three separate thread-lifetime bugs**
+  `ui/widgets/job.py`, `ui/widgets/log_panel.py`, `main.py`
+  A worker was garbage-collected with its panel/view **before the OS scheduled its thread**;
+  `QThread::started → worker.run` then ran on freed memory. Native backtrace: SIGBUS in
+  `QMetaMethod::name()`. Three sites, found one at a time because each fix only moved the crash —
+  the third was `main.py`'s `setProperty("update_worker", …)  # keep references alive`, and **a Qt
+  property holds a `QObject*`, not a Python reference**.
+  *Gate: **25/25 clean under gdb** (pre-fix died on run 1, half-fixed on run 2) and **20/20 plain**
+  (baseline 1/20, half-fixed 5/20).*
+
+- [x] **Every MariaDB backup — and every restore — was rejected**
+  `controller_wow_wotlk/maintenance.py:147`
+  MariaDB 10.6 writes `/*M!999999\- enable the sandbox mode */` before the banner, so
+  `-- MariaDB dump` is no longer at byte 0 and the anchored check refused a complete dump.
+  `plan_restore()`, `restore()` and `_safety_backup()` all gate on the same `verify_dump()`.
+  *Found on a live Tortoise server; fixed, then hardened after review (below).*
+
+- [x] **Accepting MariaDB's preamble also accepted a file that was not a dump** *(found by review)*
+  A support-tickets table whose free-text column held pasted dump output satisfied the banner, the
+  `USE` line and the trailer — and was accepted as a dump **of that database**. Now the banner may
+  be preceded only by what a dump itself writes: `/*!…*/`, `--`, blank lines.
+
+- [x] **The installer CLI hung forever at sudo, and could never reach the native engine**
+  `installer.py:741`
+  `_main()` passed no `ask` callback, and sudo reads from a pty — so on any box needing a password
+  the CLI parked with no timeout and no error. It also built `Installer(...)` directly, so
+  `NativeInstaller` was unreachable from the CLI on every platform.
+
+- [x] **Integration teardown burned 300 s twice per run**
+  `tests/integration/conftest.py:87`
+  Fixture containers ran `sleep` as PID 1, which gets no default SIGTERM action, so
+  `docker compose stop -t 300` waited out the whole grace period. Made the suite 32–45 minutes.
+  *Measured: old shape still running when a 120 s probe gave up; new shape stops in **0.27 s**.*
+
+- [x] **`mypy .` disagreed with CI** — `pyproject.toml` now excludes `tests/`; all four invocations
+  report the same 38 files, 0 issues. Four boxes reported the identical 375 errors before anyone
+  compared the two commands.
+
+- [x] **`python -m yulon` did not exist** — every box tried it first and got
+  `No module named yulon.__main__`. Added as a redirect to `main.main()`.
+
+- [x] **A native install logged nothing when it finished** — the bash path logs
+  `install of <id> finished`; the native path logged nothing, so the only completion signal was a
+  compose-project pin. That is why a careful tester read a 7-minute readiness wait as
+  "the install was not remembered" and filed it as a HIGH defect that turned out not to exist.
+
+- [x] **Two installs of the same game collide — the user-facing half**
+  `native/base.yml.tmpl:52,119,145,207,231`
+  `container_name:` is pinned, so the names are global to the host and a second install fails at
+  `docker compose up` with a raw daemon `Conflict` — **after** the 2–4 hour build. Hit independently
+  on Ubuntu and Arch. Now refused **before** the build, naming the folder that owns the name.
+  *Coexistence itself is still open — see Decisions.*
+
+---
+
+## 2. Found by review, patch drafted, not yet applied
+
+A six-lens review plus an adversarial pass over the fixes above. These are real; the patches are
+written and waiting on the review's final verdict.
+
+- [ ] **drafted** — **The collision guard is not on the path where the collision was measured.**
+  `install-wow-wotlk.sh:1242` The skip-compile branch runs `docker compose up -d | tail -5` and
+  `return 0`, so the daemon's Conflict is printed, its exit status is swallowed by `tail`, and the
+  script reports success. That is exactly the Arch scenario: build complete, `up` collided.
+- [ ] **drafted** — **`InFlight.sweep()` frees a worker while its thread is still inside
+  `QThreadPrivate::finish()`.** `job.py:111` Qt clears `isRunning()` *before* the thread has exited
+  (`wait(0)` still false), so the release must `wait()` first, like `_dispose_last_job` does.
+- [ ] **drafted** — **An install folder the user cannot enter is reported "definitely not built"**,
+  and the script then offers to `sudo rm -rf` it. A root-owned 700 folder from an earlier run hits
+  this. Should land in "could not check", not the delete prompt.
+- [ ] **drafted** — **`refuse_foreign_containers` passes silently when `docker compose config`
+  fails** — an unreadable compose file looks identical to "pins no names".
+- [ ] **drafted** — **A symlinked install dir is refused as another install's.** Compose records the
+  *logical* working dir; the guard compares a *physical* path.
+- [ ] **drafted** — **Tests stay green when the call site is removed.** The lifted-function tests
+  prove the helpers work, not that anything calls them. Needs a test that both `compose up` sites
+  are guarded.
+- [ ] **drafted** — **The frozen artifact would carry `yulon/__main__.py`**, pulling `main.py` in a
+  second time as a library module. Excluded in the spec.
+- [ ] **drafted** — **Four fixes have no test that names them** — the CLI prompter, the native
+  completion log, the update-worker hold, and `python -m yulon`.
+
+---
+
+## 3. Fedora — SELinux
+
+- [ ] **The Python bind-mount probe omits the SELinux relabel.** `docker.py:2428` mounts
+  `{mount}:/probe:ro` with no `:z`/`:Z`. Proven by A/B on an enforcing box — and `ausearch` showed
+  **no denial**, because Fedora `dontaudit`s exactly this case, so "no AVC in the log" is not
+  evidence SELinux is innocent. Also `tests/integration/conftest.py:210`.
+  *Harmless today (see next item); HIGH the moment Linux moves to the native engine.*
+- [ ] **The entire `preflight` module is unreachable on Linux.** `installer_for()` → `is_native()` →
+  `script_platforms: ["linux"]` means every Linux box gets the bash script and never touches
+  `catalog/preflight.py`. Two separate findings share this one root cause: the SELinux probe above,
+  and the CPU-vs-RAM check below. **Both wake up together when Phase 7.2 retires the bash lineage.**
+- [ ] **`_cpu_check`'s remedy names Docker Desktop**, which does not exist on native Linux.
+  `preflight.py:355`. Its arithmetic is right and would have caught Fedora bricking itself: at 8 GB
+  it computes `affordable = 4` against `jobs = 7`. It never ran.
+
+## 4. Arch — prerequisites
+
+- [ ] **The launcher will not start from source on a stock Arch desktop.** Qt names one missing
+  library; `ldd` shows **six**: `xcb-util-cursor xcb-util-wm xcb-util-keysyms xcb-util-image
+  xcb-util-renderutil libxkbcommon-x11`. The README lists no Linux prerequisite. `libxkbcommon-x11`
+  is one of the five sonames `check-bundle-closure.sh` already caught missing from the shipped
+  tarball — same library, hit again on a path that gate does not cover.
+- [ ] **Document the Debian-family equivalent** (`libxcb-cursor0` and friends), found on m910q.
+- [ ] **Document that LAN setup is only partly automatic on Arch** — `detect_firewall()` returns
+  `"none"` (no `ufw`, no `firewall-cmd`) and the app degrades gracefully to manual instructions.
+  Correct behaviour, but "networking works" means something weaker there.
+
+## 5. Windows
+
+- [ ] **`compose_file()` crashes on an unreachable WSL path.** `installer.py:67` calls `is_file()`
+  unguarded; `\\wsl.localhost\<distro>\…` for a stopped distro raises `WinError 64`, which `pathlib`
+  does **not** swallow. **Intermittent** — the first call raises, later calls on the same path
+  return cleanly (WSL's 9P provider degrades to `ENOENT`, which pathlib *does* swallow) — so the fix
+  must be a broad `except OSError`, not a special case for errno 64.
+- [ ] **"Find in WSL…" appears on every tile and always fails.** `wsl_distros()` returns
+  `('docker-desktop',)` on a box with no real distro. `catalog_view.py:263` gates the button on that
+  list, and its comment claims `wsl_distros()` "answers () for all of them" — false on **every**
+  Windows box with Docker Desktop. **`tests/test_platform.py:526` pins the buggy value**, so fixing
+  it breaks a green test and will look like a regression.
+- [ ] **Tab titles collide.** `main.py:220` titles a tab `server_dir.name`, and the installer always
+  suggests the same leaf name — two installs in different parents are indistinguishable in the tab
+  strip. Not data loss: Stop is ownership-protected by compose labels and refuses across installs.
+
+---
+
+## 6. Decisions — not bugs to fix
+
+- [ ] **Self-update has never worked for anyone.** `update.py:26` calls `/releases/latest`, which by
+  definition excludes prereleases — and **every** upstream release is flagged `Pre-release`
+  (`v0.6.57Public`, `v0.6.55Public`, `v0.6.53`). Two independent fixes, not exclusive:
+  **code** (call `/releases?per_page=5` and take the first non-draft — works with the release
+  practice as it is), and **process** (`gh release edit … --prerelease=false`, needs upstream write
+  access). *Which depends on whether 0.6.x is meant to be pre-release.*
+- [ ] **Two installs of one game cannot coexist.** The template already parameterises the compose
+  *project* (`name: {{PROJECT_NAME}}`) and then pins global `container_name:`s that override it. The
+  service names already provide Compose DNS, so those five lines are redundant for addressing — but
+  `catalog.json`'s `containers` map names them literally and **40 call sites across 7 controller
+  files** find containers that way. Options: **(a)** product rule "one server per game per machine",
+  zero further code; **(b)** resolve by project+service everywhere — its own PR, with a
+  two-installs-coexist gate, because the failure mode is stopping the wrong server.
+- [ ] **Tortoise on Windows.** `catalog.json:226` declares `platforms: ["linux"]` for a script named
+  `install-tortoise-wow-wsl.sh`. There is **no code path that runs an install script inside a WSL
+  distro** — `installer.py` has no WSL handling and `bash_available()` deliberately refuses the WSL
+  shim. Options: **(a)** rename the script, zero code; **(b)** build "install into WSL distro X" —
+  that is roadmap 7.7.
+- [ ] **The Accounts tab is create-only.** No list, no set-password, no standalone GM level. The
+  Console is not a workaround for listing — `account list` is not a mangosd command either. A
+  feature gap; no documented decision says it should be that way.
+- [ ] **No floor on Docker's data root.** The branch warns on both disks. The VM that died in this
+  run died of **host-side dynamic-VHDX exhaustion, invisible from the guest** (guest read 41 GB
+  free, host had 8), so no guest check could have seen it — and turning the warning into a refusal
+  would block installs that would have succeeded.
+
+---
+
+## 7. Coverage — what was and was not exercised
+
+Installed for real: **WotLK** via apt (Ubuntu), pacman (Arch) and the **native engine** (Windows —
+first time ever, 72-minute build into a path with spaces, `ac-db-import` exited 0, which settles the
+9p question open since 2026-08-25). 500 bots verified four independent ways on each.
+
+- [ ] **Fedora's dnf variant has never completed a fresh compile** — it reached 83% at 8 GB and
+  swap-thrashed the box unreachable. Owed by Fedora's own pass at 23 GB.
+- [ ] **TBC, Vanilla and Tortoise installers have never been run.** All three need a client dir.
+  Clients are now on m910q (`~/clients/WoW-Client-1.12.1`, `~/clients/WoW-Client-2.4.3`,
+  `~/TurtleWoW`); m910q has 52 GB free. **Note Vanilla's script refuses under 20 GB on both the
+  target disk and Docker's root**, so prune between installs.
+
+---
+
+## One thing worth keeping
+
+Three of these have an obvious fix that is **wrong**, and two of them arm a worse bug:
+
+1. Setting `reinstall=True` (the natural fix for the silent-success bug) turns the unreliable image
+   check from harmless into **deleting a good 2–4 hour build**. Fix the image check first.
+2. Deleting `container_name:` makes every container `<project>-ac-worldserver-1`, and the controller
+   finds nothing.
+3. Changing the compose-file guard before installs are resumable breaks a case that currently works.
+
+The pattern: *check whether the thing you are about to make true is guarded by something that is
+only safe while it is false.*


### PR DESCRIPTION
Nineteen commits from the four-platform bug hunt, all of them Ubuntu-verified on a real box (yulon-ubuntu, 8 vCPU / 23 GB) rather than reasoned about. Every defect below was reproduced before it was fixed.

## The ones that could destroy work

**A good build was offered up for deletion.** `compiled_images_present()` asked `docker compose images`, which reports the images of a project's *existing containers*. A folder whose compile finished but whose `up` never ran has no containers, so a complete build answered "nothing was built" - and the next branch offers to `rm -rf` the folder. Measured on yulon-arch: `up` failed on a container-name collision, zero containers existed, and the installer offered to throw away a good 35-minute build. It now asks the image store via `docker compose config --images` + `docker image inspect`, and answers **0 built / 1 not built / 2 could not find out / 3 not this installer's project** - because "I could not ask" must never be spelled the same way as "there is nothing here" when the next question is a delete prompt.

**A partially pruned build read as a finished one.** Only the first image whose name contains `worldserver` was tested, so a prune that took `ac-db-import` still answered "built" and the reuse path ran `up` with no `--build`. Now every image sharing the worldserver image's prefix must be present. Third-party images are deliberately excluded: `mysql:8.0` is pulled, not built, and requiring it would report a good build as missing - which is the delete prompt again.

**A dump with executable SQL above its banner passed verification.** The preamble check read line by line, so a line that both opened and closed a comment was skipped whole and nothing after the `*/` was examined. `/* comment */ DROP DATABASE unrelated;` above a real banner passed `verify_dump()`, and `plan_restore()` takes its safety dump only for databases the census names on their own lines - so that DROP had no backup behind it. The scan now walks bytes.

**An interrupted install was recorded as a success.** Declining "remove it and start fresh?" exited 0, which the caller reads as *installed*: `catalog_view.py` pinned a compose project name into the folder and grew a tab for a server that was never built. Reproduced on yulon-arch after a killed build was retried into the same folder.

## The GUI crash

A worker was garbage-collected before the OS scheduled its thread, so `QThread::started` reached `worker.run` on freed memory - SIGBUS inside `QMetaMethod::name()`, confirmed under gdb at three separate sites. Fixed with a process-wide `InFlight` holding each `(QThread, worker)` pair until the thread finishes, released on the GUI thread via a queued slot.

Gate: **25 gdb runs, no crash** on the fixed tree; the baseline died on run 1.

## The rest

- **`docker.status()` could wedge the GUI forever.** A hung `docker ps` left `_status_pending` set and the status poll never recovered. 30 s timeout.
- **Free space was checked on the wrong disk.** The check ran against the home partition while the server files go to Docker's data root; both are checked separately now.
- **Container names are global, not project-scoped.** A second install colliding on `ac-worldserver` is now refused *before* the build, naming the folder that owns the name - read from `com.docker.compose.project.working_dir`. On the reuse path it runs only after `up` has actually failed, as a diagnosis rather than a gate, because an unconditional check there would refuse a *moved* install folder while naming a path that no longer exists.
- **`python -m yulon` did not exist**, and the frozen build now excludes that redirect so `main.py` cannot be pulled into the bundle twice.
- **The CLI could not answer a sudo prompt.** The terminal prompter now tells sudo's prompt from the two y/n consent questions by a random per-install marker, so the password is hidden and the consent questions stay visible.

## Test suite

**30-45 minutes to 89 seconds** for the live-Docker integration suite. The fixtures spent `STOP_GRACE_SECONDS = 300` in full against busybox stand-ins that never handle SIGTERM; they now trap it. Same measurement independently on three boxes.

## Verification

| Gate | Result |
| --- | --- |
| Fast suite (yulon-ubuntu) | 1015 passed, 2 skipped |
| Integration, live Docker | 11 passed, 5 skipped in 89 s |
| ruff / black / mypy | clean |
| gdb segfault gate | 25/25 no crash |

Reviewed in six lenses in-house, then adversarially refuted, then critiqued - the critique found three defects in the fixes themselves, and two of its own recommendations were refuted and deliberately not applied. A fourth, independent review from a different model family then found the two blockers in the last commit here (the byte-wise banner scan and the partial-image set), and cleared the QThread ownership model, the post-failure container diagnosis and the status timeout as sound.
