### PR TITLE
Yulon does not build: the #136 merge left two copies of one test

### DIFF
--- a/pylauncher/tests/test_composegen.py
+++ b/pylauncher/tests/test_composegen.py
@@ -446,13 +446,6 @@ def test_the_generated_stack_configures_the_bot_population(tmp_path: Path) -> No
     plan = render(tmp_path / "wow")
     assert f'AC_AI_PLAYERBOT_MIN_RANDOM_BOTS: "{BOT_POPULATION}"' in plan.override
     assert f'AC_AI_PLAYERBOT_MAX_RANDOM_BOTS: "{BOT_POPULATION}"' in plan.override
-    machine's population is not a default for every machine — a preflight-passing
-    laptop can install successfully and then be unusable. Making them data is
-    what lets a capacity-aware default, or a user setting, exist later.
-    """
-    plan = render(tmp_path / "wow")
-    assert 'AC_AI_PLAYERBOT_MIN_RANDOM_BOTS: "500"' in plan.override
-    assert 'AC_AI_PLAYERBOT_MAX_RANDOM_BOTS: "500"' in plan.override
 
     # Data, not code — and the structural flags stay behind in the constant.
     assert "AC_AI_PLAYERBOT_MIN_RANDOM_BOTS" not in composegen.DEFAULT_WORLD_ENV


### PR DESCRIPTION
`Yulon` does not currently build. Neither does any PR against it — the failure is on the base, so every branch inherits it.

### One file, four red jobs

`tests/test_composegen.py` does not parse:

```
invalid-syntax: missing closing quote in string literal
   --> tests/test_composegen.py:449:12
```

Because it cannot be collected, `ruff` fails, both `lint-type-test` matrix legs fail, and the `integration (live Docker)` job fails too. That reads as four problems and is one.

### What happened

`test_the_generated_stack_configures_the_bot_population` existed in two versions: the current one, which reads the number from the `BOT_POPULATION` constant, and an older one that spelled `"500"` directly in the assertion. Merging #136 kept **both tails**. What survived of the superseded copy is the last four lines of its docstring — now sitting in the function body with no string around them — followed by a second `plan = render(...)` and its two literal assertions.

Neither side of the merge was wrong. Both branches were green on their own, and this is only broken where they meet, which is why nothing caught it before the merge commit itself.

### The fix

The orphaned tail is deleted. The surviving test is the current version; the assertions that pin the population to `catalog.json` rather than to a constant in this package are untouched, and no other file is changed.

### Checks, on this branch

```
pytest -m "not integration"   1034 passed, 69 skipped, 16 deselected
ruff check .                  All checks passed!
black --check .               79 files would be left unchanged
mypy yulon main.py            Success: no issues found in 39 source files
```
